### PR TITLE
Split out foundry reqs from devel requirements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-language: python
-python: [ 3.4 ]
-install:
-  - pip install -r requirements.txt
-script:
-  - python3 manage.py test siteapp
-  - python3 -m unittest discover tests

--- a/Makefile
+++ b/Makefile
@@ -41,9 +41,9 @@ requirements: $(VENDOR) $(STATIC)
 
 static: $(STATIC)
 
-$(VENDOR): requirements.txt
+$(VENDOR): requirements.txt cf_requirements.txt
 	mkdir -p vendor/
-	$(PIP) download --dest vendor -r $< --exists-action i
+	for f in $^; do $(PIP) download --dest vendor -r $$f --exists-action i; done
 	touch $@
 
 $(STATIC): ./deployment/fetch-vendor-resources.sh

--- a/cf_requirements.txt
+++ b/cf_requirements.txt
@@ -1,0 +1,3 @@
+gunicorn
+psycopg2
+whitenoise==1.0.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,3 @@ django-bootstrap-form
 django-notifications-hq
 
 selenium
-gunicorn
-psycopg2
-whitenoise==1.0.6

--- a/siteapp/wsgi.py
+++ b/siteapp/wsgi.py
@@ -1,8 +1,8 @@
-import os
+import os, sys
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "siteapp.settings")
 from django.core.wsgi import get_wsgi_application
-from whitenoise.django import DjangoWhiteNoise
 
 application = get_wsgi_application()
-application = DjangoWhiteNoise(application)
-
+if 'runserver' not in sys.argv:
+    from whitenoise.django import DjangoWhiteNoise
+    application = DjangoWhiteNoise(application)


### PR DESCRIPTION
This includes:
- removal of travls.yml (since we don't use it)
- removing from requirements.txt the modules not needed for local development
  - esp psycop, which won't build unless you have postgres installed, which we don't always expect
- Fixing wsgi.py so it runs regardless of whether whitenoise is installed or not
- And circle.ci still vendors all the requirements witih `make requirements` to include cf_requirements.
