### PR TITLE
Fixing hashbang conflict

### DIFF
--- a/templates/project.html
+++ b/templates/project.html
@@ -391,11 +391,21 @@ function invite_user_to_start_module(module_title, question_id) {
 }
 
 function open_tab_from_url_fragment() {
-  var tabpath = parse_qs(window.location.hash.substring(1)).tab;
+  var tabpath = window.location.hash;
+  // The GovReady Dashboard React app appends a random code like `?_k=h9zm95` to the
+  // hashbang, so we need to strip that out.
+  tabpath = tabpath.substring(tabpath.indexOf('/') + 1).split('?');
+  tabpath = tabpath.shift();
+  tabpath = parse_qs(tabpath).tab;
   if (tabpath) {
     tabpath = tabpath.split('/');
     var tab = tabpath.shift();
-    if (tab) {
+    // If the GovReady Dashboard tab is clicked, we need to change the hashbang.
+    if (tab === 'document-1') {
+      window.location.hash = '#/site-list';
+    }
+    // Otherwise, show the appropriate tab.
+    else if (tab) {
       $('#project-tabs a[href="#' + tab + '"]').tab("show");
     }
   }


### PR DESCRIPTION
Issue: https://github.com/proudcity/GovReady-Agent-Client/issues/4

@JoshData Sorry, I accidentally pushed this to https://github.com/GovReady/govready-q first in commit
https://github.com/GovReady/govready-q/commit/53446e123f7ce010607bbb3c7592cd407ca683d2.  I reverted that commit with https://github.com/GovReady/govready-q/commit/500d0fe3d079f4dd75e62584d09a45331786de4f.  This PR has the updated logic.

I needed to do two things:
1. Exclude everything after the ? (ex: `?_k=4l5deg`) that gets added automatically after you have logged into the React app.
2. If the tab is "document-1" (the GovReady tab), overwrite the hashbang so that the React app will work (it also uses the hashbang to handle routing within the app).

@aschmoe thinks there might be a better fix in the future, which we will work on in https://github.com/GovReady/GovReady-Agent-Client/issues/15.