### PR TITLE
ensure locale.setlocale works in Docker by installing the locale

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,10 @@ EXPOSE 8000
 # Put the Python source code here.
 WORKDIR /usr/src/app
 
+# Install the U.S. locale, which we reference explicitly in Q for
+# formatting and parsing numbers.
+RUN apt-get update && apt-get install locales && apt-get clean && sed -i "s/^[# ]*en_US.UTF-8/en_US.UTF-8/" /etc/locale.gen && /usr/sbin/locale-gen
+
 # Install required system packages.
 # jq: we use it to assemble the local/environment.json file
 RUN apt-get update && apt-get install -y graphviz unzip pandoc wkhtmltopdf jq && apt-get clean

--- a/guidedmodules/answer_validation.py
+++ b/guidedmodules/answer_validation.py
@@ -78,9 +78,9 @@ class question_input_parser:
     def parse_real(question, value):
         try:
             # Use a locale to parse human input since it may have
-            # e.g. thousands-commas.
+            # e.g. thousands-commas. The locale is set on app
+            # startup using locale.setlocale in settings.py.
             import locale
-            locale.setlocale(locale.LC_ALL, 'en_US.UTF-8') 
             return locale.atof(value)
         except ValueError:
             # make a nicer error message

--- a/guidedmodules/module_logic.py
+++ b/guidedmodules/module_logic.py
@@ -1201,8 +1201,8 @@ class RenderedAnswer:
                 value = ", ".join(get_question_choice(self.question, c)["text"] for c in self.answer)
         elif self.question_type in ("integer", "real"):
             # Use a locale to generate nice human-readable numbers.
+            # The locale is set on app startup using locale.setlocale in settings.py.
             import locale
-            locale.setlocale(locale.LC_ALL, 'en_US.UTF-8')
             value = locale.format(
                 "%d" if self.question_type == "integer" else "%g",
                 self.answer,

--- a/siteapp/settings.py
+++ b/siteapp/settings.py
@@ -258,6 +258,12 @@ LANGUAGE_CODE = 'en-us'
 USE_I18N = False
 USE_L10N = True
 
+# This might be redundant, but if we're using locale directly we
+# need to set this on startup.
+
+import locale
+locale.setlocale(locale.LC_ALL, 'en_US.UTF-8')
+
 # Dump outbound emails to the console by default for debugging.
 # If the "email" environment setting is present, it is a dictionary
 # providing an SMTP server to send outbound emails to. TLS is


### PR DESCRIPTION
@peterkaminski got errors running tests within docker --- which we had not been doing --- because our docker base image does not contain the en_US.UTF-8 locale data, which we use for parsing/rendering numbers in user input. locale.setlocale was also being called in the wrong place --- it should be called on app start so it fails early. This moves the call and installs the required data file in our Docker build.