### PR TITLE
update some dependencies that aren't pinned

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -59,9 +59,9 @@ click==6.7 \
     --hash=sha256:29f99fc6125fbc931b758dc053b3114e55c77a6e4c6c3a2674a2dc986016381d \
     --hash=sha256:f15516df478d5a56180fbf80e68f206010e6d160fc39fa508b65e035fd75130b \
     # via safety
-colour==0.1.4 \
-    --hash=sha256:1357f37ddfd0d7c0e770f0772901635b3a38025a2480a44280510faca30fb509 \
-    --hash=sha256:574836508fbbf989cf34da438fb8cbb6301f14737d5ff04283f72ad4a77c4a37 \
+colour==0.1.5 \
+    --hash=sha256:33f6db9d564fadc16e59921a56999b79571160ce09916303d35346dddc17978c \
+    --hash=sha256:af20120fefd2afede8b001fbef2ea9da70ad7d49fafdb6489025dae8745c3aee \
     # via mondrianish
 commonmark==0.7.4 \
     --hash=sha256:24678b72094398df96312fb927e274ccaf5148f25e47aca9f7fc062693ae7577 \
@@ -138,9 +138,9 @@ exclusiveprocess==0.9.4 \
 filemagic==1.6 \
     --hash=sha256:e684359ef40820fe406f0ebc5bf8a78f89717bdb7fed688af68082d991d6dbf3 \
     # via django-database-storage-backend
-fs==2.0.16 \
-    --hash=sha256:005a496854ebc28648a3197ec04426c50608c5a1413a9ce8ce2197b6d4c23c99 \
-    --hash=sha256:0360e137772c28750dbc42608d93f3f0d16949b24795ec33c9aeb39a216d71ba
+fs==2.0.17 \
+    --hash=sha256:020685e946eebb3819d5e1c01b78a66015dd5a0c37bdb2d173c43cdfb3a90d63 \
+    --hash=sha256:3da21d7a0439f9dcd5cee06964816f53cac850fc8f108473a6ffccb1149aa182
 future==0.16.0 \
     --hash=sha256:e39ced1ab767b5936646cedba8bcce582398233d6a627067d4c6a454c90cfedb \
     # via commonmark
@@ -259,9 +259,9 @@ requests==2.18.4 \
     --hash=sha256:6a1b267aa90cac58ac3a765d067950e7dbbf75b1da07e895d1f594193a40a38b \
     --hash=sha256:9c443e7324ba5b85070c4a818ade28bfabedf16ea10206da1132edaa6dda237e \
     # via django-allauth, requests-oauthlib, safety
-rfc5424-logging-handler==1.0.3 \
-    --hash=sha256:1dc2cecfd1f5b0a07e21bae6950c483abd7d6eb4beee866f76f753113ccc7a17 \
-    --hash=sha256:51c1272b93740479cc4ca66ec32ef09dc94fd1bd2ffe4de5092a0123a29427d3
+rfc5424-logging-handler==1.1.0 \
+    --hash=sha256:34800268ac4a09580b89a3352afc6f3221302b95f5e74a300b14f3d355b28844 \
+    --hash=sha256:f9ac979772e7f417b89dae560d9de8741eb97dc31e71068dafa297ea38ea09f2
 rtyaml==0.0.4 \
     --hash=sha256:a49c65d65944560a6ae9c746e53d6ce68206d390bf5fa53d0a2510f34cd0d2f1
 safety==1.6.1 \


### PR DESCRIPTION
Some of our dependencies have upstream new versions, which is causing our builds to fail. These dependencies aren't pinned according to requirements.in, so requirements_txt_checker.sh is failing because it appears that requirements.in is out of sync with requirements.txt.

I simply ran requirements_txt_updater.sh to re-flatten our dependencies.

Hopefully fixes build.