### PR TITLE
show date of file attachment for file-type questions in documents

### DIFF
--- a/guidedmodules/module_logic.py
+++ b/guidedmodules/module_logic.py
@@ -637,12 +637,17 @@ class HtmlAnswerRenderer:
                    i = 0
                return "%s %s" % (s, size_name[i])
 
+            label = "attached {format} file ({size}; {date})".format(
+                format=value.file_data["type_display"],
+                size=convert_size(value.file_data['size']),
+                date=answerobj.created.strftime("%x") if answerobj else "",
+            )
+
             if not img_url:
                 # no thumbnail
-                value = """<p><a href="%s">attached %s file (%s)</a></p>""" % (
+                value = """<p><a href="%s">%s</a></p>""" % (
                     html.escape(value.file_data['url']),
-                    value.file_data["type_display"],
-                    convert_size(value.file_data['size'])
+                    label,
                 )
             else:
                 # has a thumbnail
@@ -651,13 +656,12 @@ class HtmlAnswerRenderer:
                 <p>
                   <a href="%s" class="user-media">
                     <img src="%s" class="img-responsive" style=" border: 1px solid #333; margin-bottom: .25em;">
-                    <div style='font-size: 90%%;'>attached %s file (%s)</a></div>
+                    <div style='font-size: 90%%;'>%s</a></div>
                   </a>
                 </p>""" % (
                     html.escape(value.file_data['url']),
                     html.escape(img_url or ""),
-                    value.file_data["type_display"],
-                    convert_size(value.file_data['size'])
+                    label,
                 )
 
             wrappertag = "div"

--- a/guidedmodules/tests.py
+++ b/guidedmodules/tests.py
@@ -502,7 +502,7 @@ class RenderTests(TestCaseWithFixtureData):
             "type": "text/plain",
             "type_display": "plain text",
         }
-        test("q_file", file_metadata, '<a href="some-url-here">attached plain text file (1 KB)</a>', file_metadata)
+        test("q_file", file_metadata, '<a href="some-url-here">attached plain text file (1 KB; )</a>', file_metadata)
         test("q_file.url", file_metadata, "some-url-here")
         test("q_file.text", file_metadata, escape("<uploaded file: %s>" % file_metadata["url"]))
         test("q_file", None, escape("<file>"), None) # is actually the question's title, not its type, and {{...}} differently than in an impute condition


### PR DESCRIPTION
Add the date that the question was answered into how file-type questions are rendered:

![image](https://user-images.githubusercontent.com/445875/33811195-cf5e3dcc-dddd-11e7-989a-2aec3e4cb9fc.png)

Don't show the time because the value is in UTC in the database and we don't know what timezone the user is in.