### PR TITLE
start versioning Docker releases and show version numbers in the site footer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,6 +82,7 @@ modules/oirmfo
 siteapp/staticfiles
 vendor
 .kitchen
+VERSION
 
 # Emacs
 *~

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,7 @@ RUN ./fetch-vendor-resources.sh
 #
 # NOTE: Do *not* include the "local" directory in this step, since
 # that often has local development files.
+COPY VERSION ./VERSION
 COPY discussion ./discussion
 COPY guidedmodules ./guidedmodules
 COPY modules ./modules

--- a/deployment/docker/README.md
+++ b/deployment/docker/README.md
@@ -196,7 +196,7 @@ For example:
 
 You may build the Docker image locally from the current source code rather than obtaining it from the Docker Hub. In the root directory of this repository, build the Docker image:
 
-	docker image build --tag govready/govready-q .
+	deployment/docker/docker_image_build.sh
 
 If you are a GovReady team member, you can then push the image to hub.docker.com:
 

--- a/deployment/docker/docker_container_run.sh
+++ b/deployment/docker/docker_container_run.sh
@@ -239,6 +239,6 @@ sleep 1
 echo "GovReady-Q has been started!"
 echo -n "URL: http"
 if [ "$HTTPS" == true ]; then echo -n s; fi
-echo -n "://$ADDRESS"
+echo -n "://$HOST"
 if [ "$PORT" != 80 ]; then echo -n ":$PORT"; fi
 echo

--- a/deployment/docker/docker_container_run.sh
+++ b/deployment/docker/docker_container_run.sh
@@ -222,13 +222,18 @@ if [ ! -z "$NAME" ]; then
   echo "Container Name: $NAME"
 fi
 echo "Container ID: $CONTAINER_ID"
-echo "Listening on: $BIND"
+
+# Show the version.
+echo -n "Version: "
+docker container exec ${CONTAINER_ID} cat VERSION | tr '\n' ' ';
+
+echo
 
 # Check that the database is ready. The docker exec command
 # writes out a 'ready' file once migrations are finished,
 # and then it's probably another second before the Django
 # server is listening.
-while ! docker container exec $NAME test -f ready; do
+while ! docker container exec ${CONTAINER_ID} test -f ready; do
   echo "Waiting for GovReady-Q to come online..."
   sleep 3
 done
@@ -237,6 +242,7 @@ sleep 1
 # Form and show the public address that Q is expected to be
 # accessed at.
 echo "GovReady-Q has been started!"
+echo "Listening on: $BIND"
 echo -n "URL: http"
 if [ "$HTTPS" == true ]; then echo -n s; fi
 echo -n "://$HOST"

--- a/deployment/docker/docker_image_build.sh
+++ b/deployment/docker/docker_image_build.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+set -euf -o pipefail # abort script on error
+
+WARNINGS=0
+
+if [ ! -f Dockerfile ]; then
+	echo "This should be run from the root of the GovReady-Q repository."
+	exit 1
+fi
+
+# Check that there are no uncommitted changes.
+if ! git diff-index --quiet HEAD --; then
+    echo "There are uncommitted changes. Commit first."
+    exit 1
+fi
+
+# Check that the HEAD commit is pushed.
+if ! git branch -r --contains | grep "^\s*origin/master$" > /dev/null; then
+	echo "WARNING: Your branch is ahead of origin/master. Push first?"
+	echo
+	WARNINGS=1
+fi
+
+# Construct version information.
+VERSION_TAG_PATTERN="v*"
+if ! VERSION=$(git describe --tags --exact-match --match $VERSION_TAG_PATTERN 2> /dev/null); then
+	echo "WARNING: The HEAD commit is not tagged."
+	echo
+	WARNINGS=1
+
+	# Fall back to a recent tag or, if there are no tags (which should
+	# never occur after right now) the current commit number.
+	if ! VERSION=$(git describe --long --tags --match $VERSION_TAG_PATTERN --always); then
+		echo "WARNING: Could not get a version string."
+		exit 1
+	fi
+fi
+
+# Append the current commit hash as the second line of the VERSION file.
+COMMIT=$(git rev-parse HEAD)
+
+cat > VERSION << EOF;
+$VERSION
+$COMMIT
+EOF
+
+echo "Building version:"
+cat VERSION
+echo
+
+# Build the image.
+docker image build --tag govready/govready-q:${TAG-latest} .
+rm -f VERSION # it's for Docker only
+
+# Show warning again.
+if [ $WARNINGS -gt 0 ]; then
+	echo
+	echo "WARNING: There were warnings --- see above."
+	exit 1
+fi

--- a/siteapp/middleware.py
+++ b/siteapp/middleware.py
@@ -169,3 +169,9 @@ class OrganizationSubdomainMiddleware:
         if request.path not in (account_login_url, settings.LOGIN_REDIRECT_URL):
             qs = "?" + urlencode({ "next": request.path })
         return HttpResponseRedirect(account_login_url + qs)
+
+def QTemplateContextProcessor(request):
+    return {
+        "APP_VERSION_STRING": settings.APP_VERSION_STRING,
+        "APP_VERSION_COMMIT": settings.APP_VERSION_COMMIT,
+    }

--- a/siteapp/settings_application.py
+++ b/siteapp/settings_application.py
@@ -21,6 +21,10 @@ MIDDLEWARE += [
     'guidedmodules.middleware.InstrumentQuestionPageLoadTimes',
 ]
 
+TEMPLATES[0]['OPTIONS']['context_processors'] += [
+    'siteapp.middleware.QTemplateContextProcessor',
+]
+
 AUTHENTICATION_BACKENDS += ['siteapp.models.DirectLoginBackend']
 
 INTERNAL_IPS = ['127.0.0.1'] # for django_debug_toolbar
@@ -46,3 +50,19 @@ NOTIFICATIONS_USE_JSONFIELD = True # allows us to store extra data on Notificati
 
 GOVREADY_CMS_API_AUTH = environment.get('govready_cms_api_auth')
 MAILGUN_API_KEY = environment.get('mailgun_api_key', '') # for the incoming mail route
+
+# Get the version of this software.
+import os.path
+if os.path.exists("VERSION"):
+    # Get the version from the VERSION file which has two lines.
+    # The first line is a version string for display. The second
+    # line is the git commit hash that the build was based on.
+    with open("VERSION") as f:
+        APP_VERSION_STRING = f.readline().strip()
+        APP_VERSION_COMMIT = f.readline().strip()
+else:
+    # If there is no VERSION file, query the git working directory.
+    import subprocess
+    APP_VERSION_STRING = subprocess.check_output("git describe --tags --always", shell=True).strip().decode("ascii")
+    APP_VERSION_COMMIT = subprocess.check_output("git rev-parse HEAD", shell=True).strip().decode("ascii")
+

--- a/templates/base.html
+++ b/templates/base.html
@@ -274,7 +274,7 @@
               <div class="row">
                 <div class="col-sm-4"><p class="pull-left">&copy; GovReady {% now "Y" %}</p></div>
                 <div class="col-sm-4"><img alt="GovReady Q logo" src="{% static "img/brand/govready_logo_transparent.png" %}" width="110px;"></div>
-                <div class="col-sm-4"><p class="pull-right">&nbsp;</p></div>
+                <div class="col-sm-4"><p class="pull-right">ver {{APP_VERSION_STRING}}</p></div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
There's a new script to build docker images. The script generates a version number by checking if the current commit has been tagged with a tag that starts with "v". It puts the version and the HEAD commit hash into a `VERSION` file in the docker image.

If the HEAD commit doesn't correspond with a tag, it shows a warning and generates a version number suitable for development purposes using `git describe`, which combines a recent tag with how many commits have been added to it and the current commit hash.

The version number is added to the site footer on the right hand side.

This PR also corrects a harmless bug in docker_container_start.sh.