### PR TITLE
bump python package dependency version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -202,8 +202,8 @@ pillow==5.0.0 \
 pycparser==2.18 \
     --hash=sha256:99a8ca03e29851d96616ad0404b4aad7d9ee16f25c9f9708a11faf2810f7b226 \
     # via cffi
-pygithub==1.35 \
-    --hash=sha256:fea1c5adedb0b2c641422efa7d22ad1af1b538a499faf25da14c0bb57e2cfefe
+pygithub==1.36 \
+    --hash=sha256:b6c1c0c1305b879b6c40b2ba957914b8ad26cd4549ac7a5e21339a0af0307b43
 pygments==2.2.0 \
     --hash=sha256:78f3f434bcc5d6ee09020f92ba487f95ba50f1e3ef83ae96b9d5ffa1bab25c5d \
     --hash=sha256:dbae1046def0efb574852fab9e90209b23f556367b5a320c0bcb871c77c3e8cc

--- a/requirements_txt_checker_ignoreupdates.txt
+++ b/requirements_txt_checker_ignoreupdates.txt
@@ -1,2 +1,3 @@
 Django==2.0.2
 django-allauth==0.35.0
+unittest-xml-reporting==2.1.1


### PR DESCRIPTION
pygithub has a new minor version. Should fix tests.

On CircleCI, tests are failing also because there's a newer version of unittest-xml-reporting. But we don't install that package. It must be CircleCI. So until CircleCI updates their base image, we need to ignore the new version of unittest-xml-reporting by adding it to `requirements_txt_checker_ignoreupdates.txt` so our tests pass.