### PR TITLE
Fix typo in Developer_guide.md

### DIFF
--- a/docs/Developer_guide.md
+++ b/docs/Developer_guide.md
@@ -1,4 +1,4 @@
-Deveoper Guide
+Developer Guide
 ================================
 
 Documentation for developers of GovReady-Q Compliance Server.


### PR DESCRIPTION
The word "Developer" in the title of page was misspelled.