### PR TITLE
Polish column and "card" UI styling

### DIFF
--- a/templates/app-store.html
+++ b/templates/app-store.html
@@ -32,9 +32,12 @@ h2 {
     white-space: nowrap;
   }
 
-.app-category-nav a {
-  margin-left:20px;
-}
+  .app-category-nav *[data-category] {
+    margin-left: 20px;
+  }
+    .app-category-nav *[data-category].first {
+      margin-left: 0;
+    }
 
 .app {
   border-radius: 10px;
@@ -95,17 +98,19 @@ h2 {
 </style>
 {% endblock %}
 
-{% block contextbar %}
-    <div id="context-bar">
-    <div class="container-fluid">
+{% block contextbar %} 
+  {# kill breadcrumbs but add some space below site header #}
+  <div id="contextbar">
+    &nbsp;
+  </div>
+{% endblock %}
 
+{% block body %}
       <div>
-      {% block breadcrumbs %}
         <a href="/" style="color: black;">
           <span class="glyphicon glyphicon-home" style="margin-right: .25em"></span>
         </a>
         / Compliance Apps
-      {% endblock %}
 
       <div class="pull-right" style="margin-bottom: 1em">
         <form class="form-inline" onsubmit="return false;">
@@ -119,11 +124,6 @@ h2 {
         </form>
       </div>
 
-    </div><!-- container -->
-    </div><!-- div wrapper -->
-{% endblock %}
-
-{% block body %}
 
 {% if filter_description %}
 <p style="margin-bottom: 30px">These apps can help you with <i>{{filter_description}}</i>.</p>

--- a/templates/app-store.html
+++ b/templates/app-store.html
@@ -7,6 +7,12 @@ Compliance Apps
 
 {% block head %}
 <style>
+body {
+  padding-left: 20px;
+  padding-right: 20px;
+  background-color: rgb(247,247,247);
+}
+
 h1 {
   margin-bottom: 30px;
 }
@@ -25,19 +31,16 @@ h2 {
     color: #66C;
     white-space: nowrap;
   }
-    .app-category-nav > *[data-category]:before {
-      content: " · ";
-    }
-    .app-category-nav > *[data-category].first:before {
-      display: none;
-    }
+
+.app-category-nav a {
+  margin-left:20px;
+}
 
 .app {
-  border: 1px solid #D0D0D0;
-  /*border-top: 4px solid #88A;*/
-  box-shadow: 0 0 0 1px rgba(128, 128, 128, .1), 0 2px 3px rgba(128, 128, 128, .4);
+  border-radius: 10px;
+  border-bottom: 1px solid rgb(204, 204, 204);
   padding: 12px;
-  background-color: #FBFBFB;
+  background-color: white;
   margin-bottom: 24px;
   cursor: default;
   overflow: hidden;
@@ -55,7 +58,7 @@ h2 {
       }
     }
   .app .app-icon {
-    width: 30%;
+    width: 20%;
     max-width: 128px;
   }
     @media screen and (max-width: 768px) {
@@ -92,35 +95,42 @@ h2 {
 </style>
 {% endblock %}
 
-{% block breadcrumbs %}
-<li class="active">Compliance Apps</li>
+{% block contextbar %}
+    <div id="context-bar">
+    <div class="container-fluid">
+
+      <div>
+      {% block breadcrumbs %}
+        <a href="/" style="color: black;">
+          <span class="glyphicon glyphicon-home" style="margin-right: .25em"></span>
+        </a>
+        / Compliance Apps
+      {% endblock %}
+
+      <div class="pull-right" style="margin-bottom: 1em">
+        <form class="form-inline" onsubmit="return false;">
+          <div class="form-group">
+            <label class="sr-only" for="app-search">search apps for</label>
+            <div class="input-group">
+              <div class="input-group-addon">search</div>
+              <input type="text" class="form-control" id="app-search" placeholder="search apps">
+            </div>
+          </div>
+        </form>
+      </div>
+
+    </div><!-- container -->
+    </div><!-- div wrapper -->
 {% endblock %}
 
 {% block body %}
-<h1>
-  <img alt="GovReady Q logo" src="{% static "img/brand/govready_logo_transparent.png" %}" width="190px" style="margin-top:-18.5px;">
-  Compliance Apps
-</h1>
 
 {% if filter_description %}
 <p style="margin-bottom: 30px">These apps can help you with <i>{{filter_description}}</i>.</p>
 {% endif %}
 
-<div class="pull-right" style="margin-bottom: 1em">
-  <form class="form-inline" onsubmit="return false;">
-    <div class="form-group">
-      <label class="sr-only" for="app-search">search apps for</label>
-      <div class="input-group">
-        <div class="input-group-addon">search</div>
-        <input type="text" class="form-control" id="app-search" placeholder="search apps">
-      </div>
-    </div>
-  </form>
-</div>
-
 {# since the category links disappear in response to search queries, this should come after the search box so the search box's position doesn't jump around if this element changes size or disappears #}
-<div class="pull-left app-category-nav" style="margin-bottom: 1em">
-  <span style="color: #666">Jump to...</span>
+<div class="pull-left app-category-nav" style="margin-bottom: 1em; width:96%; margin:0 20px 0 20px;">
   {% for app_category in apps %}
     <span data-category="{{app_category.title}}" {% if forloop.first %}class="first"{% endif %}>
       <a href="#" onclick="smooth_scroll_to($('.app-category').filter(function() { return this.getAttribute('data-category') == '{{app_category.title|escapejs}}' })); return false;">{{app_category.title}}</a>
@@ -147,46 +157,41 @@ h2 {
         <table>
         <tr valign="top">
 
-          {% if app.app_icon_dataurl %}
-            <td class="app-icon" style="padding-top: 1px; padding-right: 12px;">
-              <img src="{{app.app_icon_dataurl}}" class="img-responsive"">
-            </td>
-          {% endif %}
-
         <td>
+          <h3>{{app.title}}</h3>
 
-        <h3>
-          {% if app.vendor %}
-          <small>{{app.vendor}}</small><br/>
+          <div class="body">
+          {{app.description.short|safe|truncatewords_html:18}}
+          </div>
+
+          {% if app.authz != "none" %}
+          <div class="app-metadata">
+            Admin approval required</div>
+          </div>
           {% endif %}
-          {{app.title}}
-        </h3>
 
-        <div class="body">
-        {{app.description.short|safe|truncatewords_html:18}}
-        </div>
+          <div style="margin-top: .5em">
+          <form action="/store/{{app.key|urlencode}}{{forward_qsargs}}" method="get" style="display: inline-block;">
+            <button type="submit" class="btn btn-info btn-sm view-app">
+              <span class="glyphicon glyphicon-info-sign"> </span>
+              Info
+            </button>
+          </form>
+          <form action="/store/{{app.key|urlencode}}{{forward_qsargs}}" method="post" style="display: inline-block;">
+            {% csrf_token %}
+            <button type="submit" class="btn btn-success btn-sm start-app">
+              Add ►
+            </button>
+          </form>
+          </div>
+        </td>
 
-        {% if app.authz != "none" %}
-        <div class="app-metadata">
-          Admin approval required</div>
-        </div>
+        {% if app.app_icon_dataurl %}
+        <td class="app-icon" style="padding-top: 1px; padding-right: 12px;">
+          <img src="{{app.app_icon_dataurl}}" class="img-responsive"">
+        </td>
         {% endif %}
 
-        <div style="margin-top: .5em">
-        <form action="/store/{{app.key|urlencode}}{{forward_qsargs}}" method="get" style="display: inline-block;">
-          <button type="submit" class="btn btn-info btn-sm view-app">
-            <span class="glyphicon glyphicon-info-sign"> </span>
-            Info
-          </button>
-        </form>
-        <form action="/store/{{app.key|urlencode}}{{forward_qsargs}}" method="post" style="display: inline-block;">
-          {% csrf_token %}
-          <button type="submit" class="btn btn-success btn-sm start-app">
-            Add ►
-          </button>
-        </form>
-        </div>
-        </td>
         </tr>
         </table>
       </div>

--- a/templates/base-landing.html
+++ b/templates/base-landing.html
@@ -57,7 +57,7 @@
 
     {% block body-wide %}
     <div class="container-fluid">
-      <div class="container" style="min-height: 80%; margin-top: 2em;">
+      <div class="container" style="min-height: 80%; margin-top: 1em;">
       {% block body %}
       {% endblock %}
       </div>

--- a/templates/base.html
+++ b/templates/base.html
@@ -35,16 +35,15 @@
             }
 
             #context-bar {
-               background-color: rgb(242,242,242);
+               background-color: rgb(247,247,247);
                padding: 14px 0 10px 0;
-               border: 1px solid rgb(207,207,207);
             }
               #context-bar .breadcrumb {
                 margin: 0; padding: 0; background: none;
                 cursor: default;
               }
               #context-bar .breadcrumb a {
-                color: #777;
+                color: black;
               }
             .glyphicon-globe { color: #888; }
             h1, h2 {
@@ -255,7 +254,7 @@
     {% endif %}
 
     {% block body-wide %}
-    <div class="container-fluid" style="min-height: 400px; margin-top: 2em;">
+    <div class="container-fluid" style="min-height: 70vh;">
       {% block body %}
       {% endblock %}
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -23,6 +23,8 @@
         <style>
             body {
                 padding-top: 50px !important; /* the !important is to fix a bug with the dashboard integration, remove it eventually */
+                padding-left: 20px;
+                padding-right: 20px;
                 padding-bottom: 20px;
                 overflow-y: scroll;
                 font-family: 'Hind', sans-serif;

--- a/templates/focus-area-styles.css
+++ b/templates/focus-area-styles.css
@@ -1,9 +1,6 @@
 body {
     background-color: rgb(247,247,247);
-    padding-left: 20px;
-    padding-right: 20px;
 }
-
 
 #focus-area-wrapper {
   border-radius: 10px;

--- a/templates/focus-area-styles.css
+++ b/templates/focus-area-styles.css
@@ -1,12 +1,17 @@
 body {
-    background-color: rgb(246,247,249);
+    background-color: rgb(247,247,247);
+    padding-left: 20px;
+    padding-right: 20px;
 }
 
 
 #focus-area-wrapper {
-  border: 1px solid #D0D0D0;
-  border-top: 4px solid rgb(74,164,74);
-  box-shadow: 0 0 0 1px rgba(0, 0, 0, .1), 0 2px 3px rgba(0, 0, 0, .2);
-  padding: 1.5em;
+  /*border: 1px solid #D0D0D0;*/
+  /*border-top: 4px solid rgb(74,164,74);*/
+  /*box-shadow: 0 0 0 1px rgba(0, 0, 0, .1), 0 2px 3px rgba(0, 0, 0, .2);*/
+  border-radius: 10px;
+  border-bottom: 1px solid rgb(204, 204, 204);
+  padding: 2em;
+  padding-bottom: 3em;
   background-color: white;
 }

--- a/templates/focus-area-styles.css
+++ b/templates/focus-area-styles.css
@@ -6,9 +6,6 @@ body {
 
 
 #focus-area-wrapper {
-  /*border: 1px solid #D0D0D0;*/
-  /*border-top: 4px solid rgb(74,164,74);*/
-  /*box-shadow: 0 0 0 1px rgba(0, 0, 0, .1), 0 2px 3px rgba(0, 0, 0, .2);*/
   border-radius: 10px;
   border-bottom: 1px solid rgb(204, 204, 204);
   padding: 2em;

--- a/templates/project.html
+++ b/templates/project.html
@@ -71,13 +71,10 @@ h3.question-group-title {
   margin: 0;
 }
 
-.question-row-container {
-  border-radius: 5px;
+.question {
+  background-color: white;
   border-bottom: 1px solid rgb(204, 204, 204);
   margin-bottom: 15px;
-}
-
-.question {
   padding-top: .75em;
   padding-bottom: .75em;
   {% if layout_mode == "grid" %}
@@ -85,9 +82,10 @@ h3.question-group-title {
     margin-top: 10px;
   {% endif %}
   border-radius: 15px; /* good for highlighting */
+
 }
   .question:hover {
-    background-color: rgb(248,248,248);
+    background-color: rgb(246,250,249);
   }
   .question .question-icon {
     margin: 0 auto;
@@ -113,6 +111,9 @@ h3.question-group-title {
       font-weight: bold;
     }
 
+  .question-title > .btn {
+    margin: 8px 0 0 0;
+  }
   .question .invitation {
     font-size: 14px;
     line-height: 128%;
@@ -268,12 +269,10 @@ h3.question-group-title {
                     {# The layout of the project page is either a grid of components or a vertical list of components. #}
                     {% if layout_mode == "grid" %}col-sm-3 col-lg-2{% else %}col-xs-12{% endif %}
                     question
-                    question-row-container
 
                     {# Add CSS classes for whether this question is finished or if it's the next item for the user to do. #}
                     {% if q.is_finished %}task_finished{% endif %}
                     {% if q.first_start %}first_start{% endif %}"
-                    style="background-color: white;"
                     >
 
                     {# The user may not have permission to actually start a Task, however. If not, show the same UI but without the form element that actually makes the request to start the Task. #}
@@ -374,13 +373,10 @@ h3.question-group-title {
                             </div>
                             {% if layout_mode == "rows" %}
                             {% if task.is_finished %}
-                            <div class="btn btn-sm btn-default" style="color: rgb(57, 139, 37); margin-top: 8px;">Finished</div>
+                            <div class="btn btn-sm btn-default" style="color: rgb(57, 139, 37);">Finished</div>
                             {% elif task.is_started %}
                             <div class="btn btn-sm btn-default">In progress</div>
                             {% else %}
-                            <div class="progress" style="width:80%; height: 5px;margin: 8px 0 0 0;">
-                              <div class="progress-bar progress-bar-success" role="progressbar" style="width: {{q.progress_percent}}%" aria-valuenow="{{q.progress_percent}}" aria-valuemin="0" aria-valuemax="100"></div>
-                            </div>
                             <div class="btn btn-sm btn-default">Start section</div>
                             {% endif %}
                             {% endif %}

--- a/templates/project.html
+++ b/templates/project.html
@@ -9,13 +9,20 @@
 {% block head %}
 {{block.super}}
 <style>
-{% if layout_mode == "columns" %}
 .question-column {
   margin: 0 -10px;
   padding: 10px;
-  background-color: #F3F3F3;
+  background-color: rgb(247,247,247);
   border-radius: 5px;
+  max-width:66vw;
+  box-shadow: 0 0 0 1px rgba(0, 0, 0, .1), 0 2px 3px rgba(0, 0, 0, .2);
 }
+{% if layout_mode == "rows" %}
+  .question-column {
+    padding: 0px 30px 0px 30px;
+}
+{% endif %}
+{% if layout_mode == "columns" %}
   .question-column h2 {
     color: black;
     margin: 5px 0 10px 0;
@@ -40,6 +47,7 @@
   margin-bottom: 15px;
   border-radius: 3px;
   border-bottom: 1px solid rgb(204, 204, 204);
+  /*border: 1px solid #D0D0D0;*/
 }
 
 .question-icon {
@@ -50,16 +58,23 @@
 
 {% else %}
 .question-group {
-  margin: 30px 0 20px 0;
+  margin: 10px 0 20px 0;
 }
 
 h2.question-column-title {
 }
 
 h3.question-group-title {
-  color: #777;
+  color: black;
+  font-weight: bold;
   padding: 16px 18px;
   margin: 0;
+}
+
+.question-row-container {
+  border-radius: 5px;
+  border-bottom: 1px solid rgb(204, 204, 204);
+  margin-bottom: 15px;
 }
 
 .question {
@@ -218,9 +233,9 @@ h3.question-group-title {
 
 {% block body_content %}
     {% if project.root_task.module.spec.introduction %}
-      <center style="margin: 30px 0;">
+      <p style="margin: 1em 0;">
       {{project.root_task.render_introduction|safe}}
-      </center>
+      </p>
     {% endif %}
 
     {% if project.root_task.module.spec.is_app_stub %}
@@ -253,10 +268,12 @@ h3.question-group-title {
                     {# The layout of the project page is either a grid of components or a vertical list of components. #}
                     {% if layout_mode == "grid" %}col-sm-3 col-lg-2{% else %}col-xs-12{% endif %}
                     question
+                    question-row-container
 
                     {# Add CSS classes for whether this question is finished or if it's the next item for the user to do. #}
                     {% if q.is_finished %}task_finished{% endif %}
                     {% if q.first_start %}first_start{% endif %}"
+                    style="background-color: white;"
                     >
 
                     {# The user may not have permission to actually start a Task, however. If not, show the same UI but without the form element that actually makes the request to start the Task. #}
@@ -353,14 +370,17 @@ h3.question-group-title {
                         {% if layout_mode != "grid" and not q.can_start_new_task %}
                           {% with task=q.tasks.0 %}
                             <div class="progress" style="width:80%; height: 5px;margin: 8px 0 0 0;">
-                              <div class="progress-bar progress-bar-success" role="progressbar" style="width: {{q.progress_percent}}%" aria-valuenow="{{q.progress_percent}}" aria-valuemin="0" aria-valuemax="100"></div>   
+                              <div class="progress-bar progress-bar-success" role="progressbar" style="width: {{q.progress_percent}}%" aria-valuenow="{{q.progress_percent}}" aria-valuemin="0" aria-valuemax="100"></div>
                             </div>
-                            {% if layout_mode == "row" %}
+                            {% if layout_mode == "rows" %}
                             {% if task.is_finished %}
-                            <div class="btn btn-sm btn-default" style="color: rgb(57, 139, 37); ">Finished</div>
+                            <div class="btn btn-sm btn-default" style="color: rgb(57, 139, 37); margin-top: 8px;">Finished</div>
                             {% elif task.is_started %}
-                            <span class="btn btn-sm btn-default">In progress</span>
+                            <div class="btn btn-sm btn-default">In progress</div>
                             {% else %}
+                            <div class="progress" style="width:80%; height: 5px;margin: 8px 0 0 0;">
+                              <div class="progress-bar progress-bar-success" role="progressbar" style="width: {{q.progress_percent}}%" aria-valuenow="{{q.progress_percent}}" aria-valuemin="0" aria-valuemax="100"></div>
+                            </div>
                             <div class="btn btn-sm btn-default">Start section</div>
                             {% endif %}
                             {% endif %}

--- a/templates/projects.html
+++ b/templates/projects.html
@@ -56,6 +56,15 @@ Your Compliance Projects
       margin: 0;
       font-weight: bold;
     }
+
+  h1.mini {
+    font-size: 16px;
+    font-family: Hind, sands-serif;
+    line-height: 22px;
+    color: rgba(51, 51, 51);
+    padding: 0px 0px 0px 0px;
+    margin: 0px 0px 0px 0px;
+  }
 </style>
 {% endblock %}
 
@@ -80,7 +89,7 @@ Your Compliance Projects
   {% endif %}
 </div>
 
-<div><span class="glyphicon glyphicon-home" style="margin-right: .25em"></span> Assessments</div>
+<h1 class="mini"><span class="glyphicon glyphicon-home" style="margin-right: .25em"></span> Assessments</h1>
 </div>
 
 {% for lifecycle in lifecycles %}

--- a/templates/projects.html
+++ b/templates/projects.html
@@ -61,38 +61,32 @@ body {
       margin: 0;
       font-weight: bold;
     }
-
-  #context-bar {
-    background-color: white !important;
-  }
 </style>
 {% endblock %}
 
 <!-- Remove contextbar from top of page -->
-{% block contextbar %}
-    <div id="context-bar">
-    <div class="container-fluid">
-
-      <div style="float: right; margin: 0 0.5em 0em 5em;">
-        <a id="new-system" href="/store?protocol=govready.com/apps/compliance/2018/information-technology-system" class="btn btn-success"><i class="glyphicon glyphicon-plus"></i> Add system </a>
-        <a id="new-project" href="/store" class="btn btn-success"><i class="glyphicon glyphicon-plus"></i> Add other app </a>
-        {% if is_lonely_admin %}
-        <a href="#" onclick="show_invite_to_org(); return false;" class="btn btn-success"><i class="glyphicon glyphicon-send"></i> Invite colleague </a>
-        {% endif %}
-      </div>
-
-      <div><span class="glyphicon glyphicon-home" style="margin-right: .25em"></span> Assessments</div>
-    </div><!-- container -->
-    </div><!-- div wrapper -->
-{% endblock %}
+{% block contextbar %}{% endblock %}
 
 {% block body %}
+
 {% comment %}
 {% if request.user.can_see_org_settings and not request.organization.get_organization_project.root_task.is_finished %}
   <h2>Complete your organization profile</h2>
   <p>Fill out your <a href="{{request.organization.get_organization_project.get_absolute_url}}">your organization&rsquo;s profile</a>.</p>
 {% endif %}
 {% endcomment %}
+
+<div style="margin-top: 15px">
+<div style="float: right; margin: 0 0.5em 0em 5em;">
+  <a id="new-system" href="/store?protocol=govready.com/apps/compliance/2018/information-technology-system" class="btn btn-success"><i class="glyphicon glyphicon-plus"></i> Add system </a>
+  <a id="new-project" href="/store" class="btn btn-success"><i class="glyphicon glyphicon-plus"></i> Add other app </a>
+  {% if is_lonely_admin %}
+  <a href="#" onclick="show_invite_to_org(); return false;" class="btn btn-success"><i class="glyphicon glyphicon-send"></i> Invite colleague </a>
+  {% endif %}
+</div>
+
+<div><span class="glyphicon glyphicon-home" style="margin-right: .25em"></span> Assessments</div>
+</div>
 
 {% for lifecycle in lifecycles %}
   <div class="clearfix"></div>

--- a/templates/projects.html
+++ b/templates/projects.html
@@ -11,11 +11,6 @@ Your Compliance Projects
 
 {% block head %}
 <style>
-body {
-  padding-left: 20px;
-  padding-right: 20px;
-}
-
 .btn .glyphicon { margin-right: 6px; }
 .btn.btn-success .glyphicon { color: #FFF; }
 

--- a/templates/projects.html
+++ b/templates/projects.html
@@ -11,13 +11,13 @@ Your Compliance Projects
 
 {% block head %}
 <style>
-h1 {
-  margin: 15px 0 30px 0;
+body {
+  padding-left: 20px;
+  padding-right: 20px;
 }
 
 .btn .glyphicon { margin-right: 6px; }
 .btn.btn-success .glyphicon { color: #FFF; }
-
 
 .lifecycle {
   margin-bottom: 30px;
@@ -28,9 +28,10 @@ h1 {
 .lifecycle .stage {
   margin: 0 -10px;
   padding: 10px;
-  background-color: #F3F3F3;
+  background-color: rgb(247,247,247);
   border-radius: 5px;
   max-width: 530px; /* so individual cards don't stretch across whole page */
+  box-shadow: 0 0 0 1px rgba(0, 0, 0, .1), 0 2px 3px rgba(0, 0, 0, .2);
 }
   .lifecycle .stage h3 {
     color: black;
@@ -60,11 +61,30 @@ h1 {
       margin: 0;
       font-weight: bold;
     }
+
+  #context-bar {
+    background-color: white !important;
+  }
 </style>
 {% endblock %}
 
 <!-- Remove contextbar from top of page -->
-{% block contextbar %}{% endblock %}
+{% block contextbar %}
+    <div id="context-bar">
+    <div class="container-fluid">
+
+      <div style="float: right; margin: 0 0.5em 0em 5em;">
+        <a id="new-system" href="/store?protocol=govready.com/apps/compliance/2018/information-technology-system" class="btn btn-success"><i class="glyphicon glyphicon-plus"></i> Add system </a>
+        <a id="new-project" href="/store" class="btn btn-success"><i class="glyphicon glyphicon-plus"></i> Add other app </a>
+        {% if is_lonely_admin %}
+        <a href="#" onclick="show_invite_to_org(); return false;" class="btn btn-success"><i class="glyphicon glyphicon-send"></i> Invite colleague </a>
+        {% endif %}
+      </div>
+
+      <div><span class="glyphicon glyphicon-home" style="margin-right: .25em"></span> Assessments</div>
+    </div><!-- container -->
+    </div><!-- div wrapper -->
+{% endblock %}
 
 {% block body %}
 {% comment %}
@@ -73,16 +93,6 @@ h1 {
   <p>Fill out your <a href="{{request.organization.get_organization_project.get_absolute_url}}">your organization&rsquo;s profile</a>.</p>
 {% endif %}
 {% endcomment %}
-
-<div style="float: right; margin: 0 0 1em 5em;">
-  <a id="new-system" href="/store?protocol=govready.com/apps/compliance/2018/information-technology-system" class="btn btn-success"><i class="glyphicon glyphicon-plus"></i> Add system </a>
-  <a id="new-project" href="/store" class="btn btn-success"><i class="glyphicon glyphicon-plus"></i> Add other app </a>
-  {% if is_lonely_admin %}
-  <a href="#" onclick="show_invite_to_org(); return false;" class="btn btn-success"><i class="glyphicon glyphicon-send"></i> Invite colleague </a>
-  {% endif %}
-</div>
-
-<h1>Your Compliance Projects</h1>
 
 {% for lifecycle in lifecycles %}
   <div class="clearfix"></div>


### PR DESCRIPTION
Make the column and "card" styling consistent across main pages.
Add box styling to columns for more visual delination.

Re-style context-bar to match focus-area background and
put context-bar on main pages.
Darken color of breadcrumbs text.

Move projects action buttons into context-bar.
Shrink page title on projects and add home icon.
Rename "Your Compliance Projects" title to "Assessments" as experiment.
Shrink width of module area displays on projects rows layout.
Add column styling to rows layout on project page for consistency.
Add back in "Finished" button, unable to display "In Progress" and "Start" buttons still.

Apply "card" styling to app-store.
Re-style app blocks in app-store to match "card" styling,
shift app-icon to right side of app block.
Remove vendor name from app block.
Re-style app-store top of page category links.
Move app-store search box to into context-bar.
Add home icon to app-store breadcrumbs.