### PR TITLE
remove the external-function question type and calling Python functions defined in compliance app .py files from module templates

### DIFF
--- a/docs/Apps.md
+++ b/docs/Apps.md
@@ -243,13 +243,11 @@ Apps can contain executable content (some of which is disabled by default):
 
 * JavaScript executed by the client browser served as a static asset and referenced by a `<script>` tag.
 
-* Python scripts executed by the GovReady-Q server for `external-function` questions.
+Both sources of Javascript execute within the context of pages on the domain that the Q site itself runs on, which means the scripts have access to the page DOM, cookies, localStorage, etc. These scripts must only be enabled if they are trusted for these environments.
 
-Both sources of Javascript execute within the context of pages on the domain that the Q site itself runs on, which means the scripts have access to the page DOM, cookies, localStorage, etc. Server-side Python executes as the local Unix user within the Q Django process. These scripts must only be enabled if they are trusted for these environments.
+Javascript static assets  (**but not Javascript in module templates** - this is a TODO) are therefore disabled by default. (Javascript static assets are disabled by serving them with an incorrect MIME type.)
 
-Javascript static assets and Python scripts (**but not Javascript in module templates** - this is a TODO) are therefore disabled by default. (Javascript static assets are disabled by serving them with an incorrect MIME type. Python assets are not loaded if disabled.)
-
-To enable these scripts, the `Trust javascript assets` flag must be true on the AppSource that provides the app. This flag must only be true if any Apps provided by the AppSource, including Apps already loaded into Q, are trusted to have executable content that may have as much client or server-side access as the Q instance does itself.
+To enable these scripts, the `Trust assets` flag must be true on the AppSource that provides the app. This flag must only be true if any Apps provided by the AppSource, including Apps already loaded into Q, are trusted to have executable content that may have as much client or server-side access as the Q instance does itself.
 
 
 ### Updating modules

--- a/docs/Schema.md
+++ b/docs/Schema.md
@@ -177,23 +177,6 @@ In addition to the `output` documents described above, a project module may also
 	  template: |
 	    Project {{name}}
 
-### Accessing External Python Code
-
-External Python functions can be made available in the template context when rendering documents. Define a Python file with the same file name as the YAML module specification file, except with a `.py` extension instead of `.yaml`. Any functions, classes, and variables defined at the top (global) level of the Python module are exposed as variables in the template context.
-
-For example, define in `mymodule.py`:
-
-	def your_function_name(arg1, arg2):
-		return str(arg1) + str(arg2)
-
-In `mymodule.yaml`, you can call this function from templates as:
-
-	{{ your_function_name(arg1, arg2) }}
-
-The arguments can refer to any other template context variables, such as question variables.
-
-The function is also available in impute conditions and impute expression values, but then without the outermost braces.
-
 
 Module Assets
 -------------
@@ -443,19 +426,6 @@ As with all questions, it is necessary to add the `id` of the interstitial to th
 
 In document templates and impute conditions, the value of `interstitial` questions is always a null value.
 
-#### `external-function`
-
-An `external-function` question is not really a question at all but instead runs some Python code when the user clicks the Submit button and stores the result as the value of the question. The `prompt` is displayed to the user as normal. The function is run when the user clicks the Submit button.
-
-The function is specified as
-
-    type: external-function
-    function: {function-name}
-
-where `{function-name}` identifies the Python function to be executed in an accompanying Python module. See Accessing External Python Code above for how Python functions are located (but the arguments provided to the function are different, see next paragraph).
-
-The arguments provide information about the module and the question being answered as well as all of the answers to the module that have been provided so far. `question` is a dict containing the question's specification (i.e. a dict containing keys `id`, `type`, and `function`, and whatever else might be in this part of the the YAML file). `answers` is a dict mapping question IDs to answer values. `**kwargs` ensures forwards-compatibility with future versions of Q.
-
 #### `raw`
 
 This type is meant for questions that are always imputed (i.e. that are never presented to the user) and where the answer value can be any JSON-serializable Python data structure, as given by the impute value (see Imputing Answers below).
@@ -501,7 +471,6 @@ In both conditions and `expression`-type values, as well as in documents, the va
 * `project`, which gives the project name
 * `project.question_id`, `project.question_id.subquestion_id`, etc. to access questions within the project
 * `organization`, which gives the organization name
-* The name of an external Python function (see Accessing External Python Code)
 
 We also have a funtion to retreive the URL of a module's static assets, e.g.:
 

--- a/fixtures/modules/other/simple_project/question_types_media.py
+++ b/fixtures/modules/other/simple_project/question_types_media.py
@@ -1,2 +1,0 @@
-def sample_external_function(question, answers, **kwargs):
-    return 'Successfully ran an external function'

--- a/fixtures/modules/other/simple_project/question_types_media.yaml
+++ b/fixtures/modules/other/simple_project/question_types_media.yaml
@@ -16,16 +16,9 @@ questions:
     prompt: This is an interstitial.
     type: interstitial
 
-  - id: q_external_function
-    title: external-function
-    prompt: I'm going to run a Python function.
-    type: external-function
-    function: sample_external_function
-
 output:
   - title: Your Answers
     format: markdown
     template: |
       {{q_file}}
       {{q_interstitial}}
-      {{q_external_function}}

--- a/guidedmodules/answer_validation.py
+++ b/guidedmodules/answer_validation.py
@@ -116,11 +116,6 @@ class question_input_parser:
             raise ValueError("Invalid input.")
         return None
 
-    def parse_external_function(question, value):
-        # the user doesn't answer these directly
-        if value != "":
-            raise ValueError("Invalid input.")
-        return None # doesn't matter
 
 class validator:
     # Validate that an answer is of the right data type and meets the
@@ -317,6 +312,3 @@ class validator:
             raise ValueError("Invalid data type (%s)." % type(value))
         return value
 
-    def validate_external_function(question, value):
-        # Any data structure is OK.
-        return value

--- a/guidedmodules/models.py
+++ b/guidedmodules/models.py
@@ -11,8 +11,6 @@ from .module_logic import ModuleAnswers, render_content
 from .answer_validation import validator
 from siteapp.models import User, Organization, Project, ProjectMembership
 
-ModulePythonCode = { }
-
 class AppSource(models.Model):
     is_system_source = models.BooleanField(default=False, help_text="This field is set to True for a single AppSource that holds the system modules such as user profiles.")
     slug = models.CharField(max_length=200, unique=True, help_text="A unique URL-safe string that names this AppSource.")
@@ -117,18 +115,6 @@ class Module(models.Model):
     def get_questions(self):
         # Return the ModuleQuestions in definition order.
         return list(self.questions.order_by('definition_order'))
-
-    def python_functions(self):
-        # Run exec() on the Python source code stored in the spec, and cache the
-        # globally defined functions, classes, and variables.
-        global ModulePythonCode
-        if self.id not in ModulePythonCode:
-            exec(
-                self.spec.get("python-module", ""),
-                None, # default globals - TODO: Make this safe?
-                ModulePythonCode.setdefault(self.id, {}) # put locals, i.e. global definitions, here
-            )
-        return ModulePythonCode[self.id]
 
     def export_json(self, serializer):
         # Exports this Module's metadata to a JSON-serializable Python data structure.

--- a/guidedmodules/module_logic.py
+++ b/guidedmodules/module_logic.py
@@ -1028,19 +1028,6 @@ class TemplateContext(Mapping):
     def getitem(self, item):
         self._execute_lazy_module_answers()
 
-        # If 'item' matches an external function name (in the root template context only), return it.
-        # Un-wrap RenderedAnswer instances so the external function gets the value and not the
-        # RenderedAnswer instance.
-        if self.root and self.module_answers and item in self.module_answers.module.python_functions():
-            func = self.module_answers.module.python_functions()[item]
-            def arg_filter(arg):
-                if isinstance(arg, RenderedAnswer):
-                    return arg.answer
-                return arg
-            def wrapper(*args, **kwargs):
-                return func(*map(arg_filter, args), **kwargs)
-            return wrapper
-
         # If 'item' matches a question ID, wrap the internal Pythonic/JSON-able value
         # with a RenderedAnswer instance which take care of converting raw data values
         # into how they are rendered in templates (escaping, iteration, property accessors)
@@ -1103,12 +1090,6 @@ class TemplateContext(Mapping):
         self._execute_lazy_module_answers()
 
         seen_keys = set()
-
-        # external functions, in the root template context only
-        if self.root and self.module_answers and self.module_answers.module:
-            for fname in self.module_answers.module.python_functions():
-                seen_keys.add(fname)
-                yield fname
 
         # question names
         for q in self._module_questions.values():
@@ -1376,13 +1357,10 @@ class RenderedAnswer:
                 self.escapefunc, parent_context=self.parent_context)
                 for v in self.answer)
 
-        elif self.question_type == "external-function":
-            return iter(self.answer)
-
         raise TypeError("Answer of type %s is not iterable." % self.question_type)
 
     def __len__(self):
-        if self.question_type in ("multiple-choice", "module-set", "external-function"):
+        if self.question_type in ("multiple-choice", "module-set"):
             if self.answer is None: return 0
             return len(self.answer)
 
@@ -1416,10 +1394,11 @@ class RenderedAnswer:
                 tc = TemplateContext(ans, self.escapefunc, parent_context=self.parent_context)
             return tc[item]
 
-        # For external-function and "raw" question types, the answer value is any
-        # JSONable Python data structure. Forward the getattr request onto the value.
-        # Similarly for file questions.
-        elif self.question_type in ("external-function", "raw", "file"):
+        # For the "raw" question type, the answer value is any
+        # JSONable Python data structure. Forward the getattr
+        # request onto the value.
+        # Similarly for file questions which have their own structure.
+        elif self.question_type in ("raw", "file"):
             if self.answer is not None:
                 return self.answer[item]
             else:
@@ -1462,17 +1441,3 @@ class RenderedAnswer:
             # If one tries to compare a string to an integer, just
             # say false.
             return False
-
-def run_external_function(question, answers, **additional_args):
-    # Find and run the method.
-    import copy # don't give the function referneces to ORM values
-    function_name = question.spec.get("function", question.key)
-    funcs = question.module.python_functions()
-    if function_name not in funcs:
-        raise Exception("Invalid function name %s in %s question %s. Available functions are %s." % (
-        function_name, question.module, question.key,
-        ",".join(name for name in funcs if callable(funcs[name]))
-          if funcs else "[no functions defined]"
-        )) # not trapped / not user-visible error
-    method = funcs[function_name]
-    return method(module=copy.deepcopy(question.module.spec), question=copy.deepcopy(question.spec), answers=answers.as_dict(), **additional_args)

--- a/guidedmodules/module_sources.py
+++ b/guidedmodules/module_sources.py
@@ -262,18 +262,6 @@ class PyFsApp(App):
                     with self.fs.open(entry.name) as f:
                         module_spec = read_yaml_file(f)
 
-                    # Load any associated Python code.
-                    if (fn_name + ".py") in path_entries and self.store.source.trust_assets:
-                        # Read the file.
-                        with self.fs.open(fn_name + ".py") as f:
-                            code = f.read()
-
-                        # Validate that it compiles.
-                        compile(code, module_id, "exec")
-
-                        # Store it in source form in the module specification.
-                        module_spec["python-module"] = code
-
                     yield (module_id, module_spec)
 
             elif entry.name in ("assets", "private-assets"):

--- a/guidedmodules/tests.py
+++ b/guidedmodules/tests.py
@@ -150,12 +150,6 @@ class ImputeConditionTests(TestCaseWithFixtureData):
         # Interstitial questions never have value.
         test("q_interstitial", None, "q_interstitial", False)
 
-        # We're not calling the external function here - just using it
-        # given some return value.
-        test("q_external_function", False, "q_external_function", True) # answered is truthy, even if False
-        test("q_external_function", "VALUE", "q_external_function", True) # should be Pythonic truthy
-        test("q_external_function", None, "q_external_function", False) # but skipped/None are falsey
-
     def test_impute_using_module_questions(self):
         test = lambda *args : self._test_condition_helper("question_types_module", *args)
 
@@ -514,13 +508,6 @@ class RenderTests(TestCaseWithFixtureData):
         test("q_interstitial", None, escape("<interstitial>"), None) # is actually the question's title, not its type, and {{...}} differently than in an impute condition
         test("q_interstitial.text", None, escape("<not answered>"))
 
-        # We're not calling the external function here - just rendering it
-        # given some return value. It's not really intended to be rendered
-        # since its value can be any Python data structure.
-        test("q_external_function", "VALUE", "VALUE")
-        test("q_external_function.text", "VALUE", "VALUE")
-        test("q_external_function", None, escape("<external-function>"), None) # is actually the question's title, not its type, and {{...}} differently than in an impute condition
-        test("q_external_function.text", None, escape("<not answered>"))
 
     def test_render_module_questions(self):
         def test(*args):
@@ -694,7 +681,6 @@ class ImportExportTests(TestCaseWithFixtureData):
             },
             "question_types_media": {
                 "interstitial": [None],
-                "external-function": [{ "arbitrary": ["data"] }],
             },
         }
 

--- a/guidedmodules/views.py
+++ b/guidedmodules/views.py
@@ -229,19 +229,6 @@ def save_answer(request, task, answered, context, __):
             # client side validation should have picked this up
             return JsonResponse({ "status": "error", "message": str(e) })
 
-        # run external functions
-        if q.spec['type'] == "external-function":
-            # Make a deepcopy of some things so that we don't allow the function
-            # to mess with our data.
-            try:
-                value = module_logic.run_external_function(
-                    q, answered,
-                    project_name=task.project.title,
-                    project_url=task.project.organization.get_url(task.project.get_absolute_url())
-                )
-            except ValueError as e:
-                return JsonResponse({ "status": "error", "message": str(e) })
-
         cleared = False
 
     elif request.POST.get("method") == "review":

--- a/siteapp/tests.py
+++ b/siteapp/tests.py
@@ -842,17 +842,7 @@ class QuestionsTests(OrganizationSiteFunctionalTests):
         self.click_element("#save-button")
         var_sleep(.5)
 
-        # external-function
-        # There is nothing to really test in terms of functionality here, but
-        # the template result should show the output of the sample_external_function
-        # method defined below.
-        self.assertRegex(self.browser.title, "Next Question: external-function")
-        self.click_element("#save-button")
-        var_sleep(.5)
-
         self.assertRegex(self.browser.title, "^Test The Media Question Types - ")
-        self.assertInNodeText("Successfully ran an external function",
-        	".output-document span[data-question='external-function']")
 
     def test_questions_module(self):
         # Log in and create a new project.

--- a/siteapp/tests.py
+++ b/siteapp/tests.py
@@ -843,6 +843,8 @@ class QuestionsTests(OrganizationSiteFunctionalTests):
         var_sleep(.5)
 
         self.assertRegex(self.browser.title, "^Test The Media Question Types - ")
+        self.assertInNodeText("Download attachment (image; 90.5 kB; ",
+               ".output-document div[data-question='file']")
 
     def test_questions_module(self):
         # Log in and create a new project.

--- a/templates/question.html
+++ b/templates/question.html
@@ -356,10 +356,6 @@ label:hover .onhover { display: inline; }
               {# no other content but an empty value #}
               <input type="hidden" name="value" value=""/>
 
-            {% elif q.spec.type == "external-function" %}
-              {# no other content but an empty value #}
-              <input type="hidden" name="value" value=""/>
-
             {% else %}
               <p class="text-danger">QUESTION TYPE NOT IMPLEMENTED: {{q.spec.type}}</p>
 
@@ -376,9 +372,6 @@ label:hover .onhover { display: inline; }
               onclick="$('#question > form input[name=method]').val('save')">
               {% if q.spec.type == "interstitial" %}
                 Got it
-              {% elif q.spec.type == "external-function" %}
-                {# function might be fetching external information or taking an action like submitting content to an existing system #}
-                Go
               {% elif not request.GET.q %}
                 {# user is proceeding through the questions in order #}
                 Next


### PR DESCRIPTION
Long ago we created two features related to executing Python code written by compliance app authors:

* The `external-function` question type which runs a Python function when the question is "answered", instead of the user providing an answer.
* Calling Python functions from within module templates, like `{{ my_function(arg1, arg2) }}`.

These features both executed Python code defined in a .py file shipped along side a module YAML file, i.e. they are written by compliance app authors and not by GovReady.

Since running such Python code in the same process as Q requires that the code be fully trusted, both features have been disabled by default unless the `trust_assets` field was explicitly set to true on the AppSource that the compliance app containing the Python file came from.

It isn't practical for most end users to enable these features. This PR removes the two features.