### PR TITLE
cached_state must be cleared if any Task in the same project is modified

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,8 @@ jobs:
     #    name: Running X virtual framebuffer
     #    command: Xvfb :99 -screen 0 1280x1024x24
     #    background: true
+
+    # Install packages necesary for requirements_txt_checker.sh.
     - run: sudo pip3 install -U pip-tools liccheck safety
 
     # Run tests.

--- a/requirements.txt
+++ b/requirements.txt
@@ -114,9 +114,9 @@ mondrianish==0.5.3 \
 oauthlib==2.0.6 \
     --hash=sha256:ce57b501e906ff4f614e71c36a3ab9eacbb96d35c24d1970d2539bbc3ec70ce1 \
     # via requests-oauthlib
-packaging==16.8 \
-    --hash=sha256:5d50835fdf0a7edf0b55e311b7c887786504efea1177abd7e69329a8e5ea619e \
-    --hash=sha256:99276dc6e3a7851f32027a68f1095cd3f77c148091b092ea867a351811cfe388 \
+packaging==17.0 \
+    --hash=sha256:e9f654a6854321ac39d2e6745b820773ba9efa394e71dea1b387cc717d439f93 \
+    --hash=sha256:fd6933093a5462f61eec7e2d7f9bb042c28ee597ff6a93d27fb73bdc43f2684d \
     # via dparse, safety
 pillow==5.0.0 \
     --hash=sha256:0013f590a8f260df60bcfd65db19d18efc04e7f046c3c82a40e2e2b3292a937c \

--- a/requirements_txt_checker.sh
+++ b/requirements_txt_checker.sh
@@ -6,8 +6,8 @@
 
 set -euf -o pipefail # abort script on error
 
-# Install the latest pip-tools and pyup.io's safety tool.
-pip3 install -U pip-tools liccheck safety > /dev/null
+# You will need the latest pip-tools and pyup.io's safety tool:
+# pip3 install -U pip-tools liccheck safety
 
 # Flatten out all of the dependencies of our dependencies to
 # a temporary file.


### PR DESCRIPTION
This fixes a bug in how Task data is cached, including e.g. the rendered output documents.

Some Tasks have templates that reference `{{project}}` and can see all data throughout the project, so whenever anything in a project changes, those Task's cached_state must be cleared. But we weren't doing that. This has long been a bug but until 66e306c38b2cc0da7132637cbd8917cae932c354 the only information that was cached was whether a Task was finished and how far along it is, so we did not notice the bug. Now that we're caching output document content, it was readily apparent that the cache was not being cleared when answers were changing.

The downside is that more cached information is being cleared more often, and if it's too often it defeats the purpose of the cache. If a Task doesn't actually peek up to `{{project}}`, there's no need to clear its cache in this case but we don't know if that's the case so we have to clear it for all.