### PR TITLE
rhel deployment: enable notification email process

### DIFF
--- a/deployment/rhel/supervisor.ini
+++ b/deployment/rhel/supervisor.ini
@@ -1,9 +1,9 @@
-[program:app-uwsgi]
+[program:govready-q-uwsgi]
 command = /home/govready-q/.local/bin/uwsgi --wsgi-file siteapp/wsgi.py --http-socket :3031
 directory = /home/govready-q/govready-q
 user = govready-q
 
-#[program:app-notificationemails]
-#command = python3.4 manage.py send_notification_emails forever
-#directory = /home/govready-q/govready-q
-#user = govready-q
+[program:govready-q-notificationemails]
+command = python3.4 manage.py send_notification_emails forever
+directory = /home/govready-q/govready-q
+user = govready-q

--- a/requirements.in
+++ b/requirements.in
@@ -22,7 +22,7 @@ django-allauth # MIT License
 django-bootstrap3 # Apache License 2.0
 django-notifications-hq==1.3 # MIT License -- see requirements_txt_updater.sh that has a patch to use a Github release
 jsonfield # MIT License
-dj_database_url==0.4.2 # BSD License
+dj_database_url # BSD License
 whitenoise # MIT License
 
 # Python Packages Developed by GovReady and/or Josh

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,9 +36,9 @@ defusedxml==0.5.0 \
     --hash=sha256:24d7f2f94f7f3cb6061acb215685e5125fbcdc40a857eff9de22518820b0a4f4 \
     --hash=sha256:702a91ade2968a82beb0db1e0766a6a273f33d4616a6ce8cde475d8e09853b20 \
     # via python3-openid
-dj_database_url==0.4.2 \
-    --hash=sha256:a6832d8445ee9d788c5baa48aef8130bf61fdc442f7d9a548424d25cd85c9f08 \
-    --hash=sha256:e16d94c382ea0564c48038fa7fe8d9c890ef1ab1a8ec4cb48e732c124b9482fd
+dj-database-url==0.5.0 \
+    --hash=sha256:4aeaeb1f573c74835b0686a2b46b85990571159ffc21aa57ecd4d1e1cb334163 \
+    --hash=sha256:851785365761ebe4994a921b433062309eb882fedd318e1b0fcecc607ed02da9
 django-allauth==0.35.0 \
     --hash=sha256:7b31526cccd1c46f9f09acf0703068e8a9669337d29eb065f7e8143c2d897339
 django-bootstrap3==9.1.0 \
@@ -172,14 +172,14 @@ psycopg2==2.7.4 \
     --hash=sha256:d74cf9234ba76426add5e123449be08993a9b13ff434c6efa3a07caa305a619f \
     --hash=sha256:f3d3a88128f0c219bdc5b2d9ccd496517199660cea021c560a3252116df91cbd \
     --hash=sha256:fe6a7f87356116f5ea840c65b032af17deef0e1a5c34013a2962dd6f99b860dd
-pygithub==1.36 \
-    --hash=sha256:b6c1c0c1305b879b6c40b2ba957914b8ad26cd4549ac7a5e21339a0af0307b43
+pygithub==1.37 \
+    --hash=sha256:2e3e116a6f7f9986cecc9770be66451ed60015988151186fe97646df7f5e93cb
 pygments==2.2.0 \
     --hash=sha256:78f3f434bcc5d6ee09020f92ba487f95ba50f1e3ef83ae96b9d5ffa1bab25c5d \
     --hash=sha256:dbae1046def0efb574852fab9e90209b23f556367b5a320c0bcb871c77c3e8cc
-pyjwt==1.5.3 \
-    --hash=sha256:500be75b17a63f70072416843dc80c8821109030be824f4d14758f114978bae7 \
-    --hash=sha256:a4e5f1441e3ca7b382fd0c0b416777ced1f97c64ef0c33bfa39daf38505cfd2f \
+pyjwt==1.6.0 \
+    --hash=sha256:9c3016e4a292151c5396e25cc0c28c4e1cdf13fa19118eb84f500f9670e3f628 \
+    --hash=sha256:b752500cafd4df9f0dc6efe9063603e36a4e1a5c24fee48234d2949b6606aa59 \
     # via pygithub
 pynliner==0.8.0 \
     --hash=sha256:32da16ed8ba1fec775909e39f0ffa8e6e02a674b889286c9a2370c3c03f617a5 \
@@ -226,9 +226,9 @@ rtyaml==0.0.4 \
 safety==1.7.0 \
     --hash=sha256:9fb74211a0a0ab09541fe894293d66a558b6138a9fe8ebabc8cf56670e8a009c \
     --hash=sha256:ff0c4b76ad791d33825e36c41671ea45330d438921e5395903c0e87e576a377a
-selenium==3.9.0 \
-    --hash=sha256:a34a833d89bcfb463bfba5e5515a9276bb94221787b409f0ad28d2f91903e31d \
-    --hash=sha256:b0a06afa31a80d7dcb627eafb62776488b20bdaffcd807ac4158fadbc11061f4
+selenium==3.10.0 \
+    --hash=sha256:60b45c045e9e658ac033ccdafb36000f39088b94336e078c89e8df18d0ef080e \
+    --hash=sha256:6a76deef7d5ea9749e3348b6c1f39df26dbffb9f0ce19ae37bcef02ce9032e41
 six==1.11.0 \
     --hash=sha256:70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9 \
     --hash=sha256:832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb \


### PR DESCRIPTION
When we build the RHEL deployment notes, we commented out the supervisor config line to start the background process that sends notification emails. I'm not sure why. This PR enables it.

On our production instance, I ran the following in the manage.py shell first to mark the backlog of notifications as already sent so that we didn't flood all of our users with emails for notifications from a long time ago:

```
for u in User.objects.all():
  m = u.notifications.aggregate(max=Max('id'))["max"]
  if m:
   u.notifemails_last_notif_id = m
   u.save(update_fields=["notifemails_last_notif_id"])
```