### PR TITLE
guests of dangling discussions would get a server error on project pages

### DIFF
--- a/guidedmodules/tests.py
+++ b/guidedmodules/tests.py
@@ -655,7 +655,6 @@ class ImportExportTests(TestCaseWithFixtureData):
             self.included_metadata = included_metadata
             self.answer_method = "web"
             def logger(message):
-                print(message)
                 self.log_capture.append(message)
             self.log = logger
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -89,9 +89,9 @@ django-model-utils==3.1.1 \
 https://github.com/phamk/django-notifications/archive/django-2-compatibility.zip \
     --hash=sha256:4da98487dda2ffcdc108f5d30db4552055056cecedb7e08edab616de763927ed
     # see https://github.com/phamk/django-notifications/commit/652222d2b8b0ad9c23e61cf4880f85dc40d699d0
-django==2.0.2 \
-    --hash=sha256:7c8ff92285406fb349e765e9ade685eec7271d6f5c3f918e495a74768b765c99 \
-    --hash=sha256:dc3b61d054f1bced64628c62025d480f655303aea9f408e5996c339a543b45f0
+django==2.0.3 \
+    --hash=sha256:3d9916515599f757043c690ae2b5ea28666afa09779636351da505396cbb2f19 \
+    --hash=sha256:769f212ffd5762f72c764fa648fca3b7f7dd4ec27407198b68e7c4abf4609fd0
 dnspython==1.15.0 \
     --hash=sha256:40f563e1f7a7b80dc5a4e76ad75c23da53d62f1e15e6e517293b04e1f84ead7c \
     --hash=sha256:861e6e58faa730f9845aaaa9c6c832851fbf89382ac52915a51f89c71accdd31 \

--- a/siteapp/models.py
+++ b/siteapp/models.py
@@ -583,7 +583,7 @@ class Project(models.Model):
         # see has_read_priv, get_all_participants
         from discussion.models import Discussion
         for d in Discussion.objects.filter(guests=user):
-            if d.attached_to.task.project == self:
+            if d.attached_to is not None and d.attached_to.task.project == self:
                 if not d.attached_to.task.deleted_at:
                     yield d
     


### PR DESCRIPTION
A Discussion becomes dangling if the TaskAnswer it is attached to is
deleted, such as when a Project is deleted (which cascades to the root
Task, and then to all inner TaskAnswers). These Discussions remain in
the database but are no longer attached to anything except an Organization.

This happens because Discussion uses a GenericForeignKey which does not
support delete cascading, so when the TaskAnswer is deleted, it is not
blocked by the fake foreign key from Discussion and the Discussion is
not deleted in the cascade.

We were missing checks for dangling Discussions. When visiting a Project
page, the view would look for any Discussions the user is a guest of
inside that Project. That search had a bug if one of the Discussions
was dangling.
