### PR TITLE
question pages crashed if the question had been answered and the help squad had been invited

### DIFF
--- a/guidedmodules/models.py
+++ b/guidedmodules/models.py
@@ -1277,10 +1277,11 @@ class TaskAnswer(models.Model):
             })
 
         # The invitation of the help squad.
+        from django.utils.dateparse import parse_datetime
         if (self.extra or {}).get("invited-help-squad"):
             history.append({
                 "type": "event",
-                "date": self.extra["invited-help-squad"],
+                "date": parse_datetime(self.extra["invited-help-squad"]),
                 "html": html.escape("Help squad invited to this discussion."),
                 "notification_text": "Help squad invited to this discussion.",
             })
@@ -1289,9 +1290,7 @@ class TaskAnswer(models.Model):
         history.sort(key = lambda item : item["date"])
 
         # render events for easier client-side processing
-        from django.utils.dateparse import parse_datetime
         for item in history:
-            if isinstance(item["date"], str): item["date"] = parse_datetime(item["date"])
             item["date_relative"] = reldate(item["date"], timezone.now()) + " ago"
             item["date_posix"] = item["date"].timestamp()
             del item["date"] # not JSON serializable


### PR DESCRIPTION
A call to sort() crashed with 'unorderable types: str() < datetime.datetime()' just when a
question has had activity (i.e. was answered), which used a datetime, and when the help squad
had been invited, whose activity entry used a string. If a question didn't have both, the
datatypes were consistent and sortable. Only when both were present was there a problem.

The help squad invite date had to be parsed earlier, before sort().

caused by 4073d8c35e23c184aa2f07d9a40762d486ebfbae