### PR TITLE
Run docker containers using a non-root user and where possible with a read-only root filesystem

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,7 @@ COPY manage.py .
 # Flatten static files. Create a local/environment.json file that
 # has the static directory set and only setting necessary for collectstatic
 # to work. It matches what's set in dockerfile_exec.sh.
-RUN mkdir -p local && echo '{ "static": "/tmp/static_root", "debug": false, "host": "_", "https": false }' > local/environment.json
+RUN mkdir -p local && echo '{ "static": "static_root", "debug": false, "host": "_", "https": false }' > local/environment.json
 RUN python3.6 manage.py collectstatic --noinput
 
 # Add container startup scripts.
@@ -71,12 +71,18 @@ RUN mkdir -p /mnt/apps
 # Create a non-root user and group for the application to run as to guard against
 # run-time modification of the system and application.
 RUN groupadd application && \
-    useradd -g application -d /tmp/home -s /sbin/nologin -c "application process" application && \
-    chown -R application:application /tmp/home
+    useradd -g application -d /home/application -s /sbin/nologin -c "application process" application && \
+    chown -R application:application /home/application
 
 # Give the non-root user access to scratch space.
 RUN mkdir -p local
 RUN chown -R application:application local
+
+# Move the environment.json to /tmp because in some environments the main
+# filesystem is read-only and we won't be able to update local/environment.json
+# once the container starts. In those cases, /tmp must be a tmpfs. We use
+# /tmp for other purposes at run-time as well.
+RUN ln -sf /tmp/environment.json local/environment.json
 
 # Run the container's process zero as this user.
 USER application

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,8 +52,21 @@ COPY siteapp ./siteapp
 COPY templates ./templates
 COPY fixtures ./fixtures
 COPY manage.py .
-COPY deployment/docker/first_run.sh .
+
+# Flatten static files. Create a local/environment.json file that
+# has the static directory set and only setting necessary for collectstatic
+# to work. It matches what's set in dockerfile_exec.sh.
+RUN mkdir -p local && echo '{ "static": "/tmp/static_root", "debug": false, "host": "_", "https": false }' > local/environment.json
+RUN python3.6 manage.py collectstatic --noinput
+
+# Add container startup scripts.
 COPY deployment/docker/dockerfile_exec.sh .
+COPY deployment/docker/first_run.sh .
+
+# This directory must be present for the AppSource created by our
+# first_run script. The directory only has something in it if
+# the container is launched with --mount.
+RUN mkdir -p /mnt/apps
 
 # Set the startup script.
 CMD [ "bash", "dockerfile_exec.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -68,5 +68,18 @@ COPY deployment/docker/first_run.sh .
 # the container is launched with --mount.
 RUN mkdir -p /mnt/apps
 
+# Create a non-root user and group for the application to run as to guard against
+# run-time modification of the system and application.
+RUN groupadd application && \
+    useradd -g application -d /tmp/home -s /sbin/nologin -c "application process" application && \
+    chown -R application:application /tmp/home
+
+# Give the non-root user access to scratch space.
+RUN mkdir -p local
+RUN chown -R application:application local
+
+# Run the container's process zero as this user.
+USER application
+
 # Set the startup script.
 CMD [ "bash", "dockerfile_exec.sh" ]

--- a/deployment/docker/docker_container_run.sh
+++ b/deployment/docker/docker_container_run.sh
@@ -14,8 +14,11 @@ fi
 ##########
 
 # The image on hub.docker.com to use. Set with
-# --image IMAGENAME. The default is:
+# --image IMAGENAME. The default is govready/govready-q.
+# If --image is given, then it is up to the user to
+# run `docker image pull`.
 IMAGE="govready/govready-q"
+PULLIMAGE=1
 
 # The name for the newly run container. Set with
 # --name NAME. If set to the empty string, no name
@@ -80,6 +83,7 @@ while [ $# -gt 0 ]; do
   case "$1" in
     --image)
       IMAGE="$2"
+      PULLIMAGE=0
       shift 2 ;;
     --name)
       NAME="$2"
@@ -172,8 +176,9 @@ if [ ! -z "$NAME" ]; then
 fi
 
 # Check for an updated image.
-
-docker image pull $IMAGE
+if [ $PULLIMAGE -eq 1 ]; then
+  docker image pull $IMAGE
+fi
 
 # Construct the arguments to "docker container run".
 

--- a/deployment/docker/docker_container_run.sh
+++ b/deployment/docker/docker_container_run.sh
@@ -289,3 +289,4 @@ if [ "$HTTPS" == true ]; then echo -n s; fi
 echo -n "://$HOST"
 if [ "$PORT" != 80 ]; then echo -n ":$PORT"; fi
 echo
+echo "For additional information run: docker container logs $NAME"

--- a/deployment/docker/docker_container_run.sh
+++ b/deployment/docker/docker_container_run.sh
@@ -3,6 +3,8 @@
 # This script simplifies what users need to know in
 # order to launch our Docker container.
 
+set -euf -o pipefail # abort script on error
+
 # Check that docker is installed and a version late
 # enough to support the "docker container run" command.
 if ! docker container 2>&1 | grep -q "Manage containers"; then

--- a/deployment/docker/docker_container_run.sh
+++ b/deployment/docker/docker_container_run.sh
@@ -253,7 +253,7 @@ echo
 # writes out a 'ready' file once migrations are finished,
 # and then it's probably another second before the Django
 # server is listening.
-while ! docker container exec ${CONTAINER_ID} test -f ready; do
+while ! docker container exec ${CONTAINER_ID} test -f /tmp/govready-q-is-ready; do
   echo "Waiting for GovReady-Q to come online..."
   sleep 3
 done

--- a/deployment/docker/dockerfile_exec.sh
+++ b/deployment/docker/dockerfile_exec.sh
@@ -3,11 +3,6 @@
 
 set -euf -o pipefail # abort script on error
 
-# Generate a local/environment.json file. Use the jq
-# tool to ensure that we produce valid JSON from
-# the environment variables.
-mkdir -p local
-
 # What's the address (and port, if not 80) that end users
 # will access the site at? If the HOST and PORT environment
 # variables are set (and PORT is not 80), take the values
@@ -53,7 +48,7 @@ fi
 
 # Write a file that indicates to the host that Q
 # is now fully configured.
-echo "done" > ready
+echo "done" > /tmp/govready-q-is-ready
 echo "GovReady-Q is fully up and running."
 
 # Start the server. The port is fixed --- see docker_container_run.sh.

--- a/deployment/docker/dockerfile_exec.sh
+++ b/deployment/docker/dockerfile_exec.sh
@@ -18,7 +18,7 @@ cat > local/environment.json << EOF;
 	"host": $(echo ${ADDRESS} | jq -R .),
 	"https": ${HTTPS-false},
 	"single-organization": "main",
-	"static": "/tmp/static_root",
+	"static": "static_root",
 	"db": $(echo ${DBURL} | jq -R .)
 }
 EOF

--- a/deployment/docker/dockerfile_exec.sh
+++ b/deployment/docker/dockerfile_exec.sh
@@ -39,14 +39,6 @@ if [ ! -z "$EMAIL_HOST" ]; then
 	> local/environment.json
 fi
 
-# See first_run.sh. This directory must be created
-# every time the container starts if the AppSource
-# fixture has been loaded.
-mkdir -p /mnt/apps
-
-# Flatten static files.
-python3.6 manage.py collectstatic --noinput
-
 # Initialize the database.
 python3.6 manage.py migrate
 python3.6 manage.py load_modules

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ beautifulsoup4==4.6.0 \
 certifi==2018.1.18 \
     --hash=sha256:14131608ad2fd56836d33a71ee60fa1c82bc9d2c8d98b7bdbc631fe1b3cd1296 \
     --hash=sha256:edbc3f203427eef571f79a7692bb160a2b0f7ccaa31953e99bd17e307cf63f7d \
-    # via pipenv, requests
+    # via requests
 chardet==3.0.4 \
     --hash=sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae \
     --hash=sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691 \
@@ -96,9 +96,9 @@ dnspython==1.15.0 \
     --hash=sha256:40f563e1f7a7b80dc5a4e76ad75c23da53d62f1e15e6e517293b04e1f84ead7c \
     --hash=sha256:861e6e58faa730f9845aaaa9c6c832851fbf89382ac52915a51f89c71accdd31 \
     # via email-validator
-dparse==0.3.0 \
-    --hash=sha256:6f5706703d09ea5db102f6fdef1d0fe7cda64f65cd84ee3a284fea9cdad6706b \
-    --hash=sha256:88b9ef0d2b7406c420f1ace86ce9b0a605c089e03c83474d9f6fc36146aa8e85 \
+dparse==0.4.1 \
+    --hash=sha256:00a5fdfa900629e5159bf3600d44905b333f4059a3366f28e0dbd13eeab17b19 \
+    --hash=sha256:cef95156fa0adedaf042cd42f9990974bec76f25dfeca4dc01f381a243d5aa5b \
     # via safety
 email-validator==1.0.3 \
     --hash=sha256:ddc4b5b59fa699bb10127adcf7ad4de78fde4ec539a072b104b8bb16da666ae5
@@ -183,9 +183,6 @@ pillow==5.1.0 \
     --hash=sha256:f5f302db65e2e0ae96e26670818157640d3ca83a3054c290eff3631598dcf819 \
     --hash=sha256:f7634d534662bbb08976db801ba27a112aee23e597eeaf09267b4575341e45bf \
     --hash=sha256:fe6931db24716a0845bd8c8915bd096b77c2a7043e6fc59ae9ca364fe816f08b
-pipenv==11.9.0 \
-    --hash=sha256:7b3c52fb57e17ca61b6141b75c8f5ba61a95c713ca470754240f7f1dbd0a4968 \
-    # via dparse
 psycopg2==2.7.4 \
     --hash=sha256:027ae518d0e3b8fff41990e598bc7774c3d08a3a20e9ecc0b59fb2aaaf152f7f \
     --hash=sha256:092a80da1b052a181b6e6c765849c9b32d46c5dac3b81bf8c9b83e697f3cdbe8 \
@@ -265,9 +262,9 @@ rfc5424-logging-handler==1.1.2 \
     --hash=sha256:a78a0a42b19e44215cd8a5be4ab42bfd3593c0c30a9cbfde9478e398f502ea00
 rtyaml==0.0.4 \
     --hash=sha256:a49c65d65944560a6ae9c746e53d6ce68206d390bf5fa53d0a2510f34cd0d2f1
-safety==1.7.0 \
-    --hash=sha256:9fb74211a0a0ab09541fe894293d66a558b6138a9fe8ebabc8cf56670e8a009c \
-    --hash=sha256:ff0c4b76ad791d33825e36c41671ea45330d438921e5395903c0e87e576a377a
+safety==1.8.1 \
+    --hash=sha256:0bd2a26b872668767c6db8efecfc8869b547463bedff5e7cd7b52f037aa6f200 \
+    --hash=sha256:fc3fc55656f1c909d65311b49a38211c42c937f57a05393289fb3f17cadfa4a1
 selenium==3.11.0 \
     --hash=sha256:2b6f018e55f50e9c67a67caec2f73f806f72c162fb38cf3ea79e0a8f6506bf56 \
     --hash=sha256:5841fb30c3965866220c34d16de8e3d091e2833fcac385160a63db0c3522a297
@@ -294,14 +291,6 @@ urllib3==1.22 \
     --hash=sha256:06330f386d6e4b195fbfc736b297f58c5a892e4440e54d294d7004e3a9bbea1b \
     --hash=sha256:cc44da8e1145637334317feebd728bd869a35285b93cbb4cca2577da7e62db4f \
     # via requests
-virtualenv-clone==0.3.0 \
-    --hash=sha256:4507071d81013fd03ea9930ec26bc8648b997927a11fa80e8ee81198b57e0ac7 \
-    --hash=sha256:b5cfe535d14dc68dfc1d1bb4ac1209ea28235b91156e2bba8e250d291c3fb4f8 \
-    # via pipenv
-virtualenv==15.2.0 \
-    --hash=sha256:1d7e241b431e7afce47e77f8843a276f652699d1fa4f93b9d8ce0076fd7b0b54 \
-    --hash=sha256:e8e05d4714a1c51a2f5921e62f547fcb0f713ebbe959e0a7f585cc8bef71d11f \
-    # via pipenv
 webencodings==0.5.1 \
     --hash=sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78 \
     --hash=sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923 \


### PR DESCRIPTION
These commits address two concerns:

* It is preferable for containers to run their CMD process as something other than root. Our Dockerfile now creates a non-root user and has the container CMD process start as that user. This means that the container does not have write permission anymore to the application source directory, so some container start-up operations were moved into the Dockerfile, which is where they belonged.
* It is preferable for containers to run with --read-only, which makes the root filesystem read-only. Our `docker_container_run.sh` script will now activate the --read-only option if the database URL command-line argument is given, which means there's nothing persistent stored in the container and we can confine disk writes to a tmpfs at /tmp.

The primary challenge was that our `local/environment.json` file still needs to be written on container startup and a non-persistent testing database in `local/db.sqlite` (plus its journal file) needs read-write access. The Dockerfile now gives the non-root user write permission to the container's `local` directory, and to support read-only root filesystems `local/environment.json` is now stored in /tmp anyway. But because of the Sqlite journal file the testing database in `local/db.sqlite` cannot be used with a read-only root filesystem (see the commit for details).