### PR TITLE
prevent template rendering from dying on an invalid property access too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Application changes:
 
 App authoring changes:
 
-* Templates no longer die but instead show inline error messages when an undefined context variable is accessed.
+* Templates no longer die but instead show inline error messages when an undefined variable is accessed.
 
 Deployment changes:
 

--- a/requirements_txt_checker_ignoreupdates.txt
+++ b/requirements_txt_checker_ignoreupdates.txt
@@ -1,5 +1,5 @@
 unittest-xml-reporting==2.1.1
-pipenv==11.9.0
+pipenv==11.10.0
 pip==9.0.3
 virtualenv==15.2.0
 wheel==0.31.0


### PR DESCRIPTION
When a property access (e.g. {{project.something}}) tries to access an invalid property, substitute a similar error message as when an undefined top-level context variable is accessed.

Property accesses on questions (e.g. q1.something) are not error-handled this way yet, but these are less common.