### PR TITLE
docker log path simplification, privacy policy and TOS pages, mysql documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Application changes:
 
 Deployment changes:
 
-* Docker launch failed if `HTTPS` environment variable was not passed in.
+* Docker launch failed if `HTTPS` environment variable was not passed in and may have failed with a permission denied error.
 * Added a new `branding` environment setting for sites to override templates and provide new assets using a custom Django app.
 * Move mysqlclient dependency from Dockerfile to requirements.in --- pip-compile doesn't have a problem with it anymore.
 

--- a/deployment/docker/dockerfile_exec.sh
+++ b/deployment/docker/dockerfile_exec.sh
@@ -66,10 +66,6 @@ echo "done" > /tmp/govready-q-is-ready
 echo "GovReady-Q is starting."
 echo # usgi output follows
 
-# Start the server. Ensure some paths exist since
-# if the containing directories are mounted with
-# --tmpfs then they'll be empty but supervisord
-# expects its paths to be there. See the Dockerfile.
-mkdir -p /var/{run,log}/supervisor
+# Start the server.
 exec supervisord -n
 

--- a/deployment/docker/tail_logs.sh
+++ b/deployment/docker/tail_logs.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-exec tail $@ /var/log/supervisor/*.log
+exec tail $@ /var/log/*.log

--- a/deployment/rhel/README.md
+++ b/deployment/rhel/README.md
@@ -35,7 +35,7 @@ Deploy GovReady-Q source code:
     cd govready-q
 
     # Install required software. (You probably need to jump out of being the govready-q user for this line, then come back.)
-    sudo yum install graphviz postgresql pandoc xorg-x11-server-Xvfb wkhtmltopdf
+    sudo yum install graphviz postgresql mysql-devel pandoc xorg-x11-server-Xvfb wkhtmltopdf
     
     # Install pip packages
     pip3 install --user -r requirements.txt

--- a/siteapp/urls.py
+++ b/siteapp/urls.py
@@ -10,6 +10,9 @@ from .good_settings_helpers import signup_wrapper
 urlpatterns = [
     url(r"^$", views.homepage, name="homepage"),
 
+    # static pages that also exist on the landing domain
+    url(r"^(privacy|terms-of-service)$", views.shared_static_pages),
+
     # apps
     url(r"^tasks/", include("guidedmodules.urls")),
     url(r"^discussion/", include("discussion.urls")),

--- a/siteapp/urls_landing.py
+++ b/siteapp/urls_landing.py
@@ -4,6 +4,7 @@ from django.contrib import admin
 
 admin.autodiscover()
 
+import siteapp.views as views_orgsubdomain
 import siteapp.views_landing as views_landing
 import guidedmodules.views
 
@@ -12,6 +13,9 @@ urlpatterns = [
     url(r"^welcome/(?P<org_slug>.*)$", views_landing.org_welcome_page),
     url(r'^api/v1/organizations/(?P<org_slug>.*)/projects/(?P<project_id>\d+)/answers$', views_landing.project_api),
     url(r'^media/users/(\d+)/photo/(\w+)/(\w+)', views_landing.user_profile_photo),
+
+    # static pages that also exist on the organization domains
+    url(r"^(privacy|terms-of-service)$", views_orgsubdomain.shared_static_pages),
 
     # analytis, which are available here and on organization subdomains
     url(r'^tasks/analytics$', guidedmodules.views.analytics),

--- a/siteapp/views.py
+++ b/siteapp/views.py
@@ -1439,3 +1439,18 @@ def organization_settings_save(request):
         return JsonResponse({ "users": [user.render_context_dict(request.organization) for user in users] })
 
     return JsonResponse({ "status": "error", "message": str(request.POST) })
+
+def shared_static_pages(request, page):
+    from django.utils.module_loading import import_string
+    from django.contrib.humanize.templatetags.humanize import intcomma
+    password_hasher = import_string(settings.PASSWORD_HASHERS[0])()
+    password_hash_method = password_hasher.algorithm.upper().replace("_", " ") \
+        + " (" + intcomma(password_hasher.iterations) + " iterations)"
+
+    return render(request,
+        page + ".html", {
+        "base_template": "base-landing.html" if not hasattr(request, "organization")
+                         else "base.html",
+        "SITE_ROOT_URL": request.build_absolute_uri("/"),
+        "password_hash_method": password_hash_method,
+    })

--- a/templates/base-landing.html
+++ b/templates/base-landing.html
@@ -68,6 +68,7 @@
       <footer>
         <div class="container">
           <p>&copy; GovReady {% now "Y" %}</p>
+          <p><a href="/privacy">Privacy Policy</a> | <a href="/terms-of-service">Terms of Service</a></p>
         </div>
       </footer>
     </div> <!-- /container -->

--- a/templates/base.html
+++ b/templates/base.html
@@ -188,7 +188,13 @@
           <div class="row">
             <div class="col-sm-12">
               <div class="row">
-                <div class="col-sm-4"><p class="pull-left">&copy; GovReady {% now "Y" %}</p></div>
+                <div class="col-sm-4">
+                  <p class="pull-left">
+                    &copy; GovReady {% now "Y" %}.
+                    <a href="/privacy">Privacy Policy</a>.
+                    <a href="/terms-of-service">Terms of Service</a>.
+                  </p>
+                </div>
                 <div class="col-sm-4">&nbsp;</div>
                 <div class="col-sm-4"><p class="pull-right">ver {{APP_VERSION_STRING}}</p></div>
             </div>

--- a/templates/privacy.html
+++ b/templates/privacy.html
@@ -1,0 +1,22 @@
+{% extends base_template %}
+{% load static %}
+
+{% block title %}
+Privacy Policy
+{% endblock %}
+
+{% block head %}
+<style>
+	.body-text {
+		max-width: 70em;
+	}
+</style>
+{% endblock %}
+
+{% block body %}
+<div class="body-text">
+	<h1>Privacy policy</h1>
+	<p>The organization hosting this open source instance of GovReady-Q has not yet posted a privacy policy.</p>
+</div>
+{% endblock %}
+

--- a/templates/terms-of-service.html
+++ b/templates/terms-of-service.html
@@ -1,0 +1,23 @@
+{% extends base_template %}
+{% load static %}
+
+{% block title %}
+Terms of Service
+{% endblock %}
+
+{% block head %}
+<style>
+	.body-text {
+		max-width: 70em;
+	}
+</style>
+{% endblock %}
+
+{% block body %}
+<div class="body-text">
+	<h1>Terms of service</h1>
+
+	<p>The organization hosting this open source instance of GovReady-Q has not yet posted a terms of service agreement.</p>
+</p>
+{% endblock %}
+


### PR DESCRIPTION
* Add stock privacy policy and terms of service pages, which can be overridden using the new branding app. Fixes #228.
* Change where our Docker deployment stores supervisord's logs to get around a permission denied error that I encountered on my desktop and in AWS ECS but not on my laptop.
* Note in the RHEL README that mysql-devel must be installed.