### PR TITLE
Improve Deployment Guide table in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,12 +39,12 @@ If you have questions about if hosted version, email <a href="mailto:info@govrea
 
 ## Installing GovReady-Q
 
-| Deployment Guide                           | Where                                                                                         |
-|--------------------------------------------|-----------------------------------------------------------------------------------------------|
-| Installing on Workstations for Development | [deploy_local_dev](https://govready-q.readthedocs.io/en/latest/deploy_local_dev.html)         |
-| Deploying with Docker                      | [deploy_docker](https://govready-q.readthedocs.io/en/latest/deploy_docker.html)               |
-| Deploying on RHEL 7 / CentOS 7             | [deploy_rhel7_centos7](https://govready-q.readthedocs.io/en/latest/deploy_rhel7_centos7.html) |
-| Deploying on Ubuntu                        | [deploy_ubuntu](https://govready-q.readthedocs.io/en/latest/deploy_ubuntu.html)               |
+| Deployment Guide                                                                                                |
+|-----------------------------------------------------------------------------------------------------------------|
+| [Installing on Workstations for Development](https://govready-q.readthedocs.io/en/latest/deploy_local_dev.html) |
+| [Deploying with Docker](https://govready-q.readthedocs.io/en/latest/deploy_docker.html)                         |
+| [Deploying on RHEL 7 / CentOS 7](https://govready-q.readthedocs.io/en/latest/deploy_rhel7_centos7.html)         |
+| [Deploying on Ubuntu](https://govready-q.readthedocs.io/en/latest/deploy_ubuntu.html)                           |
 
 
 ## Support


### PR DESCRIPTION
Small tweak to Deployment Guide in README to just have a single column. 

<img width="779" alt="screen shot 2018-04-24 at 2 09 17 pm" src="https://user-images.githubusercontent.com/24979/39214445-535a6f6a-47c9-11e8-80e3-ab8a867be96e.png">
