### PR TITLE
clear Task.cached_state faster and after upgrading apps

### DIFF
--- a/guidedmodules/views.py
+++ b/guidedmodules/views.py
@@ -846,6 +846,10 @@ def upgrade_app(request):
     from .module_logic import clear_module_question_cache
     clear_module_question_cache()
 
+    # Since impute conditions, output documents, and other generated
+    # data may have changed, clear all cached Task state.
+    Task.clear_state(Task.objects.filter(module__app=appinst))
+
     from django.contrib import messages
     messages.add_message(request, messages.INFO, 'App upgraded.')
 

--- a/requirements_txt_checker_ignoreupdates.txt
+++ b/requirements_txt_checker_ignoreupdates.txt
@@ -1,3 +1,3 @@
 pipenv==11.10.4
 setuptools==39.1.0
-wheel==0.31.0
+wheel==0.31.1


### PR DESCRIPTION
* Upgrading apps must clear the cached_state of all Tasks for that app, since the cached_state includes generated output documents whose templates may be different in the upgraded app.
* Since this requires clearing the cached_state of many Tasks, I rewrote the clear function to be optimized for clearing the state of many tasks at once. This also improved the other calls, such as after answering questions, because it makes far fewer database queries.