### PR TITLE
fix doc headings in docker_deploy.md

### DIFF
--- a/docs/source/deploy_docker.md
+++ b/docs/source/deploy_docker.md
@@ -262,7 +262,7 @@ The following environment variables are used to configure the container when lau
 
 `PORT`: The port that GovReady-Q will be accessed at by end users, typically either 80 (no HTTPS) or 443 (HTTPS). (Default: `8080`)
 
-`HTTPS`: Set to `true` if GovReady-Q will be accessed by end users at an https: address.  This must be done through a proxy that accepts HTTPS connections and passes the requests using HTTP to the Docker container. The proxy must set the `X-Forwarded-Proto: https` header. It is also permissible for the proxy to forward HTTP requests, and those requests will be automatically redirected to the https: URL. (Default: `false`)
+`HTTPS` - Set to `true` if GovReady-Q will be accessed by end users at an https: address.  This must be done through a proxy that accepts HTTPS connections and passes the requests using HTTP to the Docker container. The proxy must set the `X-Forwarded-Proto: https` header. It is also permissible for the proxy to forward HTTP requests, and those requests will be automatically redirected to the https: URL. (Default: `false`)
 
 `DEBUG`: Set to `true` to run in Django debug mode. (Default: `false`)
 


### PR DESCRIPTION
Add some clarity to headings in `docker_deploy.md` and also replace the "`parameter`:" sequence sith "`parameter ` -` to get code rendering of the "parameter". 