### PR TITLE
add a Content-Security-Policy-Header to prevent loading third-party resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 GovReady-Q Release Notes
 ========================
 
+In Development
+--------------
+
+Deployment changes:
+
+* The HTTP Content-Security-Policy header is now set to prevent the loading of third-party assets.
+
 v0.8.2-rc3 (May 18, 2018)
 -------------------------
 

--- a/siteapp/middleware.py
+++ b/siteapp/middleware.py
@@ -10,6 +10,15 @@ from .models import Organization
 allowed_paths = None
 account_login_url = None
 
+class ContentSecurityPolicyMiddleware:
+    # Set the CSP header on all responses.
+    def __init__(self, next_middleware):
+        self.next_middleware = next_middleware
+    def __call__(self, request):
+        response = self.next_middleware(request)
+        response['Content-Security-Policy'] = "default-src 'self' data:; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'"
+        return response
+
 class OrganizationSubdomainMiddleware:
     def __init__(self, next_middleware):
         self.next_middleware = next_middleware

--- a/siteapp/settings_application.py
+++ b/siteapp/settings_application.py
@@ -17,6 +17,7 @@ INSTALLED_APPS += [
 
 MIDDLEWARE += [
     #'debug_toolbar.middleware.DebugToolbarMiddleware',
+    'siteapp.middleware.ContentSecurityPolicyMiddleware',
     'siteapp.middleware.OrganizationSubdomainMiddleware',
     'guidedmodules.middleware.InstrumentQuestionPageLoadTimes',
 ]


### PR DESCRIPTION
The Content-Security-Policy HTTP header is a security precaution when a site might be serving untrusted content out of its control. The policy can be used to restrict the browser from loading scripts, CSS, images, etc. from domains (origins) besides the one the page was loaded from.

We weren't able to enable this before because our emojis were being loaded directly from an EmojiOne CDN. But we've recently fixed that so all of the site's assets are served statically from our own server.

This PR enables a CSP policy via the HTTP header to prevent accidental loading of any remote resources.

It still allows loading data: URL resources because we use this heavily throughout the site. This isn't an ideal CSP policy because if we're serving untrusted content, then that untrusted content could include third-party potentially malicious scripts etc. using data: URLs. However, we have other content sanitization in place to prevent this. And, in fact, we allow this by design in compliance app output document templates on the assumption that compliance apps are only made available in the catalog if they are trusted.