### PR TITLE
f1b31668 broke the API Docs button - it stopped acting like a link

### DIFF
--- a/templates/project.html
+++ b/templates/project.html
@@ -174,7 +174,7 @@ h3.question-group-title {
     {% if can_upgrade_app %}
       <a id="upgrade-app" class="btn btn-sm" href="{{project.get_absolute_url}}/upgrade">
         <i class="glyphicon glyphicon-download"></i>
-        Update App
+        Upgrade App
       </a>
     {% endif %}
 

--- a/templates/project.html
+++ b/templates/project.html
@@ -166,7 +166,7 @@ h3.question-group-title {
       </button>
     {% endif %}
 
-    <button class="btn btn-sm btn-default" href="{{project.get_absolute_url}}/api">
+    <button class="btn btn-sm btn-default" onclick="window.location = '{{project.get_absolute_url|escapejs}}/api';">
       <i class="glyphicon glyphicon-sort"></i>
       API Docs
     </button>

--- a/templates/project.html
+++ b/templates/project.html
@@ -141,7 +141,7 @@ h3.question-group-title {
 {% endblock %}
 
 {% block action_buttons %}
-  <div class="btn-group-vertical" role="group" aria-label="action buttons group">
+  <div class="btn-group" role="group" aria-label="action buttons group">
     {% if not project.is_account_project or project.is_deletable %}
       <button class="btn btn-sm btn-default" onclick="$('#project_settings').modal();">
         <i class="glyphicon glyphicon-cog"></i> Settings</a>
@@ -172,23 +172,24 @@ h3.question-group-title {
     </button>
 
     {% if can_upgrade_app %}
-      <a id="upgrade-app" class="btn btn-sm" href="{{project.get_absolute_url}}/upgrade">
+      <button class="btn btn-sm btn-default" onclick="window.location = '{{project.get_absolute_url|escapejs}}/upgrade';">
         <i class="glyphicon glyphicon-download"></i>
         Upgrade App
-      </a>
+      </button>
     {% endif %}
 
     {% if authoring_tool_enabled %}
-      <a id="open-authoring-tools" class="btn btn-sm" href="#" onclick="$('.authoring-tool-hidden').fadeIn(); $(this).remove(); return false;">
+      <button id="open-authoring-tools" class="btn btn-sm btn-default" onclick="$('.authoring-tool-hidden').toggle();">
         <i class="glyphicon glyphicon-pencil"></i>
         Authoring Tool
-      </a>
+      </button>
     {% endif %}
   </div>
 
     {# action buttons #}
     {% if action_buttons %}
       {% for q in action_buttons %}
+        <div style="margin-top: 1em">
           {% if can_start_task and q.can_start_new_task %}
             <form id="question-{{q.question.key}}" class="start-task" method="post" action="/tasks/start" style="display:inline;">
               {% csrf_token %}
@@ -207,6 +208,7 @@ h3.question-group-title {
             {{q.question.spec.title}} &raquo; {# use a stable title - dont make it depend on the task #}
           </a>
           {% endif %}
+        </div>
       {% endfor %}
     {% endif %}
 {% endblock %}


### PR DESCRIPTION
This PR fixes a functionality breakage - the API Docs button wasn't actually opening the API Docs page - and some UI improvements:

from:

![screenshot from 2018-05-21 15-19-29](https://user-images.githubusercontent.com/445875/40325648-9bae26ca-5d0a-11e8-946e-f5affb36277f.png)
![screenshot from 2018-05-21 15-19-36](https://user-images.githubusercontent.com/445875/40325649-9bba0fbc-5d0a-11e8-9673-96d41d4b4751.png)

to

![screenshot from 2018-05-21 15-18-44](https://user-images.githubusercontent.com/445875/40325647-9ba144e6-5d0a-11e8-8ce5-17daf142be28.png)
![screenshot from 2018-05-21 15-23-26](https://user-images.githubusercontent.com/445875/40325760-ef39efc2-5d0a-11e8-9d98-2cfa0d5cfe1f.png)
