### PR TITLE
various Docker improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Deployment changes:
 * The HTTP Content-Security-Policy header is now set to prevent the loading of third-party assets.
 * A CentOS 7-based Vagrantfile has been added to the source distribution for those looking to deploy using a VM.
 * Added some outputs to Docker launches to see the Q version and the container user during build and at the very start of container startup.
+* We're now publishing version tags to Docker Hub so that past versions of GovReady-Q remain available when we publish a new release.
 
 Developer changes:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ GovReady-Q Release Notes
 In Development
 --------------
 
+Application changes:
+
+* Javascript and CSS static assets of compliance apps may have had the wrong MIME type set.
+
 Deployment changes:
 
 * The HTTP Content-Security-Policy header is now set to prevent the loading of third-party assets.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Deployment changes:
 
 * The HTTP Content-Security-Policy header is now set to prevent the loading of third-party assets.
 * A CentOS 7-based Vagrantfile has been added to the source distribution for those looking to deploy using a VM.
+* Added some outputs to Docker launches to see the Q version and the container user during build and at the very start of container startup.
 
 Developer changes:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Deployment changes:
 * A CentOS 7-based Vagrantfile has been added to the source distribution for those looking to deploy using a VM.
 * Added some outputs to Docker launches to see the Q version and the container user during build and at the very start of container startup.
 * We're now publishing version tags to Docker Hub so that past versions of GovReady-Q remain available when we publish a new release.
+* With Docker, email environment variable settings were ignored since the last (-rc3) release.
 
 Developer changes:
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -95,6 +95,7 @@ RUN mkdir -p /mnt/apps
 RUN groupadd application && \
     useradd -g application -d /home/application -s /sbin/nologin -c "application process" application && \
     chown -R application:application /home/application
+RUN echo -n "the non-root user is: " && grep ^application /etc/passwd
 
 # Give the non-root user access to scratch space.
 RUN mkdir -p local

--- a/deployment/docker/docker_image_build.sh
+++ b/deployment/docker/docker_image_build.sh
@@ -90,8 +90,14 @@ cat VERSION
 echo
 
 # Build the image.
-docker image build --tag govready/govready-q:${TAG-latest} .
+docker image build --tag govready/govready-q:$VERSION .
 rm -f VERSION # it's for Docker only
+
+# Show push commands.
+echo
+echo "To publish, run:"
+echo "docker image push govready/govready-q:$VERSION"
+echo "docker image tag govready/govready-q:$VERSION govready/govready-q:latest && docker image push govready/govready-q:latest"
 
 # Show warning again.
 if [ $WARNINGS -gt 0 ]; then

--- a/deployment/docker/dockerfile_exec.sh
+++ b/deployment/docker/dockerfile_exec.sh
@@ -8,6 +8,14 @@ set -euf -o pipefail # abort script on error
 echo "This is GovReady-Q."
 cat VERSION
 
+# Show filesystem information because the root filesystem might be
+# read-only and other paths might be mounted with tmpfs and that's
+# helpful to know for debugging.
+echo
+echo Filesystem information:
+cat /proc/mounts | egrep -v "^proc|^cgroup| /proc| /dev| /sys"
+echo
+
 # Check that we're running as the 'application' user. Our Dockerfile
 # specifies to run containers as that user. But cluster environments
 # can override the start user and might do so to enforce running as

--- a/deployment/docker/dockerfile_exec.sh
+++ b/deployment/docker/dockerfile_exec.sh
@@ -3,6 +3,24 @@
 
 set -euf -o pipefail # abort script on error
 
+# Show the version immediately, which might help diagnose problems
+# from console output.
+echo "This is GovReady-Q."
+cat VERSION
+
+# Check that we're running as the 'application' user. Our Dockerfile
+# specifies to run containers as that user. But cluster environments
+# can override the start user and might do so to enforce running as
+# a non-root user, so this process might have started up as the wrong
+# user.
+if [ "$(whoami)" != "application" ]; then
+	echo "The container is running as the wrong UNIX user."
+	id
+	echo "Should be:"
+	id application
+	echo
+fi
+
 # What's the address (and port, if not 80) that end users
 # will access the site at? If the HOST and PORT environment
 # variables are set (and PORT is not 80), take the values
@@ -62,7 +80,7 @@ if [ ! -z "${BRANDING-}" ]; then
 fi
 
 # Write out the settings that indicate where we think the site is running at.
-echo "Starting GovReady-Q at ${ADDRESS} with HTTPS ${HTTPS-false}."
+echo "Starting at ${ADDRESS} with HTTPS ${HTTPS-false}."
 
 # Run checks.
 python3.6 manage.py check --deploy

--- a/docs/source/deploy_docker.md
+++ b/docs/source/deploy_docker.md
@@ -207,9 +207,13 @@ The container's console, which can be accessed with
 
 	docker container logs govready-q
 
-shows the output of container's start-up commands including database migrations and process startup. Additional log files are stored in /var/log (in particular, /var/log/supervisor) within the container. A special management command can be used to follow the log files:
+shows the output of container's start-up commands including database migrations and process startup.
 
-	docker container exec govready-q tail_logs -f
+Additional log files are stored in /var/log within the container. These files contain access logs and other program output, including logs for unhandled error messages that appear as 500 Internal Server Error pages to end users. A special management command can be used to see the log files:
+
+	docker container exec govready-q tail_logs
+
+`tail_logs` takes the same arguments as Unix `tail`. For instance, add `-n 1000` to see the most recent 1,000 log lines, or add `-f` to continue to output the logs as the log files grow.
 
 The log files can also be accessed by mounting `/var/log` with a Docker bind-mount or as a volume (and that's the only way to see the logs if `docker container exec` cannot be used in your environment).
 

--- a/guidedmodules/module_sources.py
+++ b/guidedmodules/module_sources.py
@@ -991,4 +991,15 @@ def load_module_assets_into_database(app):
         # Add to the pack.
         pack.assets.add(asset)
 
+        mime_types = {
+            "css": "text/css",
+            "js": "text/javascript",
+        }
+        mime_type = mime_types.get(file_path.rsplit(".", 1)[-1])
+        if mime_type:
+            from dbstorage.models import StoredFile
+            StoredFile.objects\
+                .filter(path=asset.file.name)\
+                .update(mime_type=mime_type)
+
     return pack

--- a/guidedmodules/validate_module_specification.py
+++ b/guidedmodules/validate_module_specification.py
@@ -15,6 +15,11 @@ class ValidationError(ValueError):
         return self.context + ": " + self.message
 
 def validate_module(spec, is_authoring_tool=False):
+    # The module must have a title.
+    for field in ("title",):
+        if field not in spec:
+            raise ValidationError("module specification", "Missing '%s' field." % field)
+
     # Validate that the introduction and output documents are renderable.
     if "introduction" in spec:
         if not isinstance(spec["introduction"], dict):

--- a/siteapp/views.py
+++ b/siteapp/views.py
@@ -366,7 +366,6 @@ def apps_catalog_item(request, source_slug, app_name):
         # Show the "app" page.
 
         return render(request, "app-store-item.html", {
-            "first": not ProjectMembership.objects.filter(user=request.user, project__organization=request.organization).exists(),
             "app": app_catalog_info,
         })
     

--- a/templates/app-store-item.html
+++ b/templates/app-store-item.html
@@ -39,6 +39,11 @@
 <div class="row">
   <div class="col-sm-9 col-sm-push-3">
     <h1><small>{{app.vendor}}</small><br/>{{app.title}}</h1>
+
+    {% if error %}
+      <p class="text-danger">{{error}}</p>
+    {% endif %}
+
     <div class="body">
       {{app.description.long|safe}}
     </div>


### PR DESCRIPTION
This PR contains:
* Added some debug outputs to Docker builds and container startups to see the Q release version number, the user the container is running as, filesystem information (i.e. what mount points are read-only)
* When building Docker images, tag with the Q release version number rather than using `latest` so that we publish multiple images by version and so we don't necessarily always clobber `latest`.
* Documentation for seeing Docker log files.
* A fix for MIME types of compliance app static assets.
* Validation that modules have tiles.
* Additional error handling when starting apps.
