### PR TITLE
refactor module_sources.py splitting it into two new files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Developer changes:
 
 * The AppInstance table now has created and updated datetime columns, version_number and version_name columns extracted from the catalog metadata, and a new catalog_metadata field that holds the original YAML 'catalog' information (but in JSON in the database; this information was previously in the 'app' Module's spec field).
 * The ModuleAssetPack table is dropped and its columns have been moved to the AppInstance table.
+* Code refactoring: split module_sources.py into two modules.
 * Upgraded some dependencies.
 
 v0.8.2-rc3 (May 18, 2018)

--- a/guidedmodules/admin.py
+++ b/guidedmodules/admin.py
@@ -173,7 +173,7 @@ class ApprovedAppsList(forms.Widget):
 
 		# Get all of the apps to list from the AppSource instance, if this
 		# form is associated with an existing AppSource instance.
-		from .module_sources import AppSourceConnectionError
+		from .app_source_connections import AppSourceConnectionError
 		applist = []
 		seen_apps = set()
 		if self.appsource:

--- a/guidedmodules/app_loading.py
+++ b/guidedmodules/app_loading.py
@@ -188,7 +188,7 @@ def create_module(app, appinst, spec):
     m.source = app.store.source
     m.app = appinst
     m.module_name = spec['id']
-    print("Creating", m.app, m.module_name, file=sys.stderr)
+    #print("Creating", m.app, m.module_name, file=sys.stderr)
     update_module(m, spec, False)
     return m
 
@@ -221,7 +221,8 @@ def update_module(m, spec, log_status):
     # not yet in use).
     for q in m.questions.all():
         if q not in qs:
-            print("Deleting", repr(q), file=sys.stderr)
+            if log_status:
+                print("Deleting", repr(q), file=sys.stderr)
             try:
                 q.delete()
             except ProtectedError:

--- a/guidedmodules/app_loading.py
+++ b/guidedmodules/app_loading.py
@@ -1,0 +1,431 @@
+###########################################################
+# Import Apps into the AppInstance, Module, ModuleQuestion,
+# and ModuleAsset Django ORM models.
+###########################################################
+
+import enum
+import json
+import sys
+from collections import OrderedDict
+
+from django.db import transaction
+from django.db.models.deletion import ProtectedError
+
+from .models import AppSource, AppInstance, ModuleAsset, \
+                    Module, ModuleQuestion, Task, \
+                    extract_catalog_metadata
+
+from .validate_module_specification import \
+    validate_module, \
+    ValidationError as ModuleValidationError
+
+class AppImportUpdateMode(enum.Enum):
+    CreateInstance = 1
+    ForceUpdate = 2
+    CompatibleUpdate = 3
+
+class ModuleDefinitionError(Exception):
+    pass
+
+class ValidationError(ModuleDefinitionError):
+    def __init__(self, file_name, scope, message):
+        super().__init__("There was an error in %s (%s): %s" % (file_name, scope, message))
+
+class CyclicDependency(ModuleDefinitionError):
+    def __init__(self, path):
+        super().__init__("Cyclic dependency between modules: " + " -> ".join(path + [path[0]]))
+
+class DependencyError(ModuleDefinitionError):
+    def __init__(self, from_module, to_module):
+        super().__init__("Invalid module ID '%s' in module '%s'." % (to_module, from_module))
+
+class IncompatibleUpdate(Exception):
+    pass
+
+
+@transaction.atomic # there can be an error mid-way through
+def load_app_into_database(app, update_mode=AppImportUpdateMode.CreateInstance, update_appinst=None):
+    # Pull in all of the modules. We need to know them all because they'll
+    # be processed recursively.
+    available_modules = dict(app.get_modules())
+
+    # Create an AppInstance to add new Modules into, unless update_appinst is given.
+    if update_appinst is None:
+        appinst = AppInstance.objects.create(
+            source=app.store.source,
+            appname=app.name,
+            catalog_metadata={},
+            asset_paths={},
+        )
+    else:
+        # Update Modules in this one.
+        appinst = update_appinst
+
+    # Load them all into the database. Each will trigger load_module_into_database
+    # for any modules it depends on.
+    processed_modules = { }
+    for module_id in available_modules.keys():
+        load_module_into_database(
+            app,
+            appinst,
+            module_id,
+            available_modules, processed_modules,
+            [], update_mode)
+
+    # Load assets.
+    load_module_assets_into_database(app, appinst)
+
+    # If there's an 'app' module, move the app catalog information
+    # to the AppInstance.
+    if 'app' in processed_modules:
+        extract_catalog_metadata(processed_modules['app'])
+        appinst.save()
+        processed_modules['app'].save()
+
+    return appinst
+
+
+def load_module_into_database(app, appinst, module_id, available_modules, processed_modules, dependency_path, update_mode):
+    # Prevent cyclic dependencies between modules.
+    if module_id in dependency_path:
+        raise CyclicDependency(dependency_path)
+
+    # Because of dependencies between modules, we may have already
+    # been here. Do this after the cyclic dependency check or else
+    # we would never see a cyclic dependency.
+    if module_id in processed_modules:
+        return processed_modules[module_id]
+
+    # Load the module's YAML file.
+    if module_id not in available_modules:
+        raise DependencyError((dependency_path[-1] if len(dependency_path) > 0 else None), module_id)
+
+    spec = available_modules[module_id]
+
+    # Sanity check that the 'id' in the YAML file matches just the last
+    # part of the path of the module_id. This allows the IDs to be 
+    # relative to the path in which the module is found.
+    if spec.get("id") != module_id.split('/')[-1]:
+        raise ValidationError(module_id, "module", "Module 'id' field (%s) doesn't match source file path (\"%s\")." % (repr(spec.get("id")), module_id))
+
+    # Replace spec["id"] (just the last part of the path) with the full module_id
+    # (a full path, minus .yaml) relative to the root of the app. The id is used
+    # in validate_module to resolve references to other modules.
+    spec["id"] = module_id
+
+    # Validate and normalize the module specification.
+
+    try:
+        spec = validate_module(spec)
+    except ModuleValidationError as e:
+        raise ValidationError(spec['id'], e.context, e.message)
+
+    # Recursively update any modules this module references.
+    dependencies = { }
+    for m1 in get_module_spec_dependencies(spec):
+        mdb = load_module_into_database(app, appinst, m1, available_modules, processed_modules, dependency_path + [spec["id"]], update_mode)
+        dependencies[m1] = mdb
+
+    # Now that dependent modules are loaded, replace module string IDs with database numeric IDs.
+    for q in spec.get("questions", []):
+        if q.get("type") not in ("module", "module-set"): continue
+        if "module-id" not in q: continue
+        mdb = dependencies[q["module-id"]]
+        q["module-id"] = mdb.id
+
+    # Look for an existing Module to update.
+
+    m = None
+    if update_mode != AppImportUpdateMode.CreateInstance:
+        try:
+            m = Module.objects.get(app=appinst, module_name=spec['id'])
+        except Module.DoesNotExist:
+            # If it doesn't exist yet in the previous app, we'll just create it.
+            pass
+    if m:
+        # What is the difference between the app's module and the module in the database?
+        change = is_module_changed(m, app.store.source, spec)
+    
+        if change is None:
+            # There is no difference, so we can go on immediately.
+            pass
+
+        elif (change is False and update_mode == AppImportUpdateMode.CompatibleUpdate) \
+            or update_mode == AppImportUpdateMode.ForceUpdate:
+            # There are no incompatible changes and we're allowed to update modules,
+            # or we're forcing an update and it doesn't matter whether or not there
+            # are changes --- update this one in place.
+            update_module(m, spec, True)
+
+        else:
+            # Block an incompatible update --- don't create a new module.
+            raise IncompatibleUpdate("Module {} cannot be updated because changes are incompatible with the existing data model: {}".format(module_id, change))
+
+    if not m:
+        # No Module in the database matched what we need, or an existing
+        # one cannot be updated. Create one.
+        m = create_module(app, appinst, spec)
+
+    processed_modules[module_id] = m
+    return m
+
+
+def get_module_spec_dependencies(spec):
+    # Scans a module YAML specification for any dependencies and
+    # returns a generator that yields the module IDs of the
+    # dependencies.
+    questions = spec.get("questions")
+    if not isinstance(questions, list): questions = []
+    for question in questions:
+        if question.get("type") in ("module", "module-set"):
+            if "module-id" in question:
+                yield question["module-id"]
+
+
+def create_module(app, appinst, spec):
+    # Create a new Module instance.
+    m = Module()
+    m.source = app.store.source
+    m.app = appinst
+    m.module_name = spec['id']
+    print("Creating", m.app, m.module_name, file=sys.stderr)
+    update_module(m, spec, False)
+    return m
+
+
+def remove_questions(spec):
+    spec = OrderedDict(spec) # clone
+    if "questions" in spec:
+        del spec["questions"]
+    return spec
+
+
+def update_module(m, spec, log_status):
+    # Update a module instance according to the specification data.
+    # See is_module_changed.
+    if log_status:
+        print("Updating", repr(m), file=sys.stderr)
+
+    # Remove the questions from the module spec because they'll be
+    # stored with the ModuleQuestion instances.
+    m.visible = True
+    m.spec = remove_questions(spec)
+    m.save()
+
+    # Update its questions.
+    qs = set()
+    for i, question in enumerate(spec.get("questions", [])):
+        qs.add(update_question(m, i, question, log_status))
+
+    # Delete removed questions (only happens if the Module is
+    # not yet in use).
+    for q in m.questions.all():
+        if q not in qs:
+            print("Deleting", repr(q), file=sys.stderr)
+            try:
+                q.delete()
+            except ProtectedError:
+                raise IncompatibleUpdate("Module {} cannot be updated because question {}, which has been removed, has already been answered.".format(m.module_name, q.key))
+
+    # If we're updating a Module in-place, clear out any cached state on its Tasks.
+    for t in Task.objects.filter(module=m):
+        t.on_answer_changed()
+
+
+def update_question(m, definition_order, spec, log_status):
+    # Adds or updates a ModuleQuestion within Module m given its
+    # YAML specification data in 'question'.
+
+    # Create/update database record.
+    field_values = {
+        "definition_order": definition_order,
+        "spec": spec,
+        "answer_type_module": Module.objects.get(id=spec["module-id"]) if spec.get("module-id") else None,
+    }
+    q, isnew = ModuleQuestion.objects.get_or_create(
+        module=m,
+        key=spec["id"],
+        defaults=field_values)
+
+    if isnew:
+        pass # print("Added", repr(q))
+    else:            
+        # Don't need to update the database (and we can avoid
+        # bumping the .updated date) if the question's specification
+        # is identifical to what's already stored.
+        if is_question_changed(q, definition_order, spec) is not None:
+            if log_status: print("Updated", repr(q), file=sys.stderr)
+            for k, v in field_values.items():
+                setattr(q, k, v)
+            q.save(update_fields=field_values.keys())
+
+    return q
+
+
+def is_module_changed(m, source, spec):
+    # Returns whether a module specification has changed since
+    # it was loaded into a Module object (and its questions).
+    # Returns:
+    #   None => No change.
+    #   False => Change, but is compatible with the database record
+    #           and the database record can be updated in-place.
+    #   any string => Incompatible change - a new database record is needed.
+
+    # If all other metadata is the same, then there are no changes.
+    if \
+            json.dumps(m.spec, sort_keys=True) == json.dumps(remove_questions(spec), sort_keys=True) \
+        and json.dumps([q.spec for q in m.get_questions()], sort_keys=True) \
+            == json.dumps([q for q in spec.get("questions", [])], sort_keys=True):
+        return None
+
+    # Now we're just checking if the change is compatible or not with
+    # the existing database record.
+
+    if m.spec.get("version") != spec.get("version"):
+        # The module writer can force a bump by changing the version
+        # field.
+        return "The module version number changed, forcing a reload."
+
+    # If there are no Tasks started for this Module, then the change is
+    # compatible because there is no data consistency to worry about.
+    if not Task.objects.filter(module=m).exists():
+        return False
+
+    # An incompatible change is the removal of a question, the change
+    # of a question type, or the removal of choices from a choice
+    # question --- anything that would cause a TaskQuestion/TaskAnswer
+    # to have invalid data. If a question has never been answered, then
+    # this does not apply because there is no data that would become
+    # corrupted.
+    qs = set()
+    for definition_order, q in enumerate(spec.get("questions", [])):
+        mq = ModuleQuestion.objects.filter(module=m, key=q["id"]).first()
+        if not mq:
+            # This is a new question. That's a compatible change.
+            continue
+
+        # Is there an incompatible change in the question? (If there
+        # is a change that is compatible, we will return that the
+        # module is changed anyway at the end of this method.)
+        qchg = is_question_changed(mq, definition_order, q)
+        if isinstance(qchg, str):
+            return "In question %s: %s" % (q["id"], qchg)
+
+        # Remember that we saw this question.
+        qs.add(mq)
+
+    # Were any questions removed?
+    for mq in m.questions.all():
+        if mq in qs:
+            continue
+
+        # If this question has never been answered, then anything is fine.
+        if mq.taskanswer_set.count() == 0:
+            return False
+
+        # The removal of this question is an incompatible change.
+        return "Question %s was removed." % mq.key
+
+    # The changes will not create any data inconsistency.
+    return False
+
+def is_question_changed(mq, definition_order, spec):
+    # Returns whether a question specification has changed since
+    # it was loaded into a ModuleQuestion object.
+    # Returns:
+    #   None => No change.
+    #   False => Change, but is compatible with the database record
+    #           and the database record can be updated in-place.
+    #   str => Incompatible change - a new database record is needed.
+    #          The string holds an explanation of what changed.
+
+    # Check if the specifications are identical. We are passed a
+    # trasnformed question spec already.
+    if mq.definition_order == definition_order \
+        and json.dumps(mq.spec, sort_keys=True) == json.dumps(spec, sort_keys=True):
+        return None
+
+    # If this question has never been answered, then anything is fine.
+    if mq.taskanswer_set.count() == 0:
+        return False
+
+    # Change in question type -- that's incompatible.
+    if mq.spec["type"] != spec["type"]:
+        return "The question type changed from %s to %s." % (
+            repr(mq.spec["type"]), repr(spec["type"])
+            )
+
+    # Removal of a choice.
+    if mq.spec["type"] in ("choice", "multiple-choice"):
+        def get_choice_keys(choices): return { c.get("key") for c in choices }
+        rm_choices = get_choice_keys(mq.spec["choices"]) - get_choice_keys(spec["choices"])
+        if rm_choices:
+            return "One or more choices was removed: " + ", ".join(rm_choices) + "."
+
+    # Constriction of valid number of choices to a multiple-choice
+    # (min is increased or max is newly set or decreased).
+    if mq.spec["type"] == "multiple-choice":
+        if "min" not in mq.spec or "max" not in mq.spec:
+            return "min/max was missing."
+        if spec['min'] > mq.spec['min']:
+            return "min went up."
+        if mq.spec["max"] is None and spec["max"] is not None:
+            return "max was added."
+        if mq.spec["max"] is not None and spec["max"] is not None and spec["max"] < mq.spec["max"]:
+            return "max went down."
+
+    # Change in the module type if a module-type question, including
+    # if the references module has been updated. spec has already
+    # been transformed so that it stores an integer module database ID
+    # rather than the string module ID in the YAML files.
+    if mq.spec["type"] in ("module", "module-set"):
+        if mq.spec.get("module-id") != spec.get("module-id"):
+            return "The answer type module changed from %s to %s." %(
+                repr(mq.spec.get("module-id")), repr(spec.get("module-id"))
+            )
+        if set(mq.spec.get("protocol", [])) != set(spec.get("protocol", [])):
+            return "The answer type protocol changed (%s to %s)." % (
+                set(mq.spec.get("protocol")),
+                set(spec.get("protocol"))
+            )
+
+    # The changes to this question do not create a data inconsistency.
+    return False
+
+def load_module_assets_into_database(app, appinst):
+    # Load all of the static assets from the source into the database.
+    # If a ModuleAsset already exists for an asset, use that.
+
+    source = app.store.source
+
+    # Add the assets.
+    appinst.trust_assets = source.trust_assets # remember setting at time of app load
+    appinst.asset_paths = { }
+    for file_path, file_hash, content_loader in app.get_assets():
+        # Get or create the ModuleAsset --- it might already exist in an earlier app.
+        asset, is_new = ModuleAsset.objects.get_or_create(
+            source=source,
+            content_hash=file_hash,
+        )
+        if is_new:
+            # Set the new file content.
+            from django.core.files.base import ContentFile
+            asset.file.save(file_path, ContentFile(content_loader()))
+            asset.save()
+
+        mime_types = {
+            "css": "text/css",
+            "js": "text/javascript",
+        }
+        mime_type = mime_types.get(file_path.rsplit(".", 1)[-1])
+        if mime_type:
+            from dbstorage.models import StoredFile
+            StoredFile.objects\
+                .filter(path=asset.file.name)\
+                .update(mime_type=mime_type)
+
+        # Add to the app.
+        appinst.asset_files.add(asset)
+        appinst.asset_paths[file_path] = file_hash
+
+    appinst.save()

--- a/guidedmodules/app_source_connections.py
+++ b/guidedmodules/app_source_connections.py
@@ -1,25 +1,46 @@
-from django.db import transaction
-from django.db.models.deletion import ProtectedError
+###########################################################
+# App Source Connections
+#
+# This module defines the abstract AppSourceConnection
+# class and its subclasses which fetch app definitions from
+# local directories and remote locations like git
+# repositories.
+#
+# The main implementation is the PyFsAppSourceConnection,
+# which reads apps from directories in a PyFilesystem2
+# directory. We then use fs.osfs and our own fs classes
+# that implement filesystems around the the PyGithub and
+# GitPython packages.
+#
+# The AppSourceConnection has two methods, one to fetch all
+# apps and one to get an app by name, both returning
+# instances of App, an abstract class defined here as well.
+# There is one implementation, PyFsApp, which returns app
+# data by reading a PyFilesystem2 directory, which allows
+# us to nicely pull app data from any local/remote location
+# as long as we can access it with PyFilesystem2.
+#
+# Each AppSourceConnection implementation is configured by
+# passing it an AppSource instance. The AppSource's "spec"
+# property holds a dict holding key/value data, such as the
+# local directory path or a git repository and credentials.
+# AppSourceConnection.create(source) creates an AppSourceConnection
+# instance by reading source.spec["type"] to determine which
+# class to instantiate and then passing the source to the
+# appropriate implementation. See comments below for details
+# about what should be in source.spec.
+#
+# AppSourceConnections should be used in with ...: blocks
+# so that resources opened by the connection are automatically
+# closed.
+###########################################################
 
-from collections import OrderedDict
-import enum
-import json
 import re
-import sys
 
 import fs, fs.errors
 from fs.base import FS as fsFS
 
-from .models import AppSource, AppInstance, Module, ModuleQuestion, ModuleAsset, Task, extract_catalog_metadata
-from .validate_module_specification import validate_module, ValidationError as ModuleValidationError
-
-class AppImportUpdateMode(enum.Enum):
-    CreateInstance = 1
-    ForceUpdate = 2
-    CompatibleUpdate = 3
-
-class ModuleDefinitionError(Exception):
-    pass
+from .app_loading import ModuleDefinitionError
 
 class AppSourceConnectionError(Exception):
     pass
@@ -29,6 +50,7 @@ class AppSourceConnection(object):
 
     @staticmethod
     def create(source):
+        """Returns a new AppSourceConnection instance given an AppSource."""
         if source.spec.get("type") in AppSourceConnectionTypes:
             return AppSourceConnectionTypes[source.spec["type"]](source)
         raise ValueError("Invalid AppSourceConnection type: %s" % repr(source.spec.get("type")))
@@ -56,50 +78,14 @@ class App(object):
     def get_assets(self):
         raise Exception("Not implemented!")
 
-    @transaction.atomic # there can be an error mid-way through updating a Module
-    def import_into_database(self, update_mode=AppImportUpdateMode.CreateInstance, update_appinst=None):
-        # Pull in all of the modules. We need to know them all because they'll
-        # be processed recursively.
-        available_modules = dict(self.get_modules())
-
-        # Create an AppInstance to add new Modules into, unless update_appinst is given.
-        if update_appinst is None:
-            appinst = AppInstance.objects.create(
-                source=self.store.source,
-                appname=self.name,
-                catalog_metadata={},
-                asset_paths={},
-            )
-        else:
-            # Update Modules in this one.
-            appinst = update_appinst
-
-        # Load them all into the database. Each will trigger load_module_into_database
-        # for any modules it depends on.
-        processed_modules = { }
-        for module_id in available_modules.keys():
-            load_module_into_database(
-                self,
-                appinst,
-                module_id,
-                available_modules, processed_modules,
-                [], update_mode)
-
-        # Load assets.
-        load_module_assets_into_database(self, appinst)
-
-        # If there's an 'app' module, move the app catalog information
-        # to the AppInstance.
-        if 'app' in processed_modules:
-            extract_catalog_metadata(processed_modules['app'])
-            appinst.save()
-            processed_modules['app'].save()
-
-        return appinst
-
 
 ### IMPLEMENTATIONS ###
 
+# This class implements AppSourceConnection for an empty
+# set of apps. source.spec should look like:
+# {
+#  "type": "null"
+# }
 class NullAppSourceConnection(AppSourceConnection):
     """The NullAppSourceConnection contains no apps."""
     def __init__(self, source):
@@ -113,8 +99,7 @@ class NullAppSourceConnection(AppSourceConnection):
 
 
 class MultiplexedAppSourceConnection(AppSourceConnection):
-    """A subclass of ModuleLoader that wraps other ModuleLoader classes
-       at given mount-points in the module naming space."""
+    """A subclass of AppSourceConnection that wraps other AppSourceConnection instances."""
 
     def __init__(self, sources):
         self.loaders = []
@@ -124,7 +109,8 @@ class MultiplexedAppSourceConnection(AppSourceConnection):
             except ValueError as e:
                 raise ValueError('There was an error creating the AppSource "{}": {}'.format(ms.slug, e))
 
-    # Override "with ...:" semantics
+    # Override "with ...:" semantics to enter and exit all of the
+    # connections this connection wraps.
     def __enter__(self):
         for loader in self.loaders:
             loader.__enter__()
@@ -149,7 +135,7 @@ class MultiplexedAppSourceConnection(AppSourceConnection):
                 yield app
 
 class PyFsAppSourceConnection(AppSourceConnection):
-    """Creates an app store from a Pyfilesystem2 filesystem, like
+    """Creates a connection from a Pyfilesystem2 filesystem, like
     a local directory containing directories for apps."""
 
     def __init__(self, source, fsfunc):
@@ -374,6 +360,12 @@ class PyFsApp(App):
                 yield (fn, content_hash, make_content_loader(fn))
 
 
+# This class implements AppSourceConnection for a local path using fs.osfs.OSFS.
+# source.spec should look like:
+# {
+#  "type": "local",
+#  "path": "path/to/apps",
+# }
 class LocalDirectoryAppSourceConnection(PyFsAppSourceConnection):
     """An App Store provided by a local directory."""
     def __init__(self, source):
@@ -439,8 +431,16 @@ class GithubApiFilesystem(SimplifiedReadonlyFilesystem):
         return io.BytesIO(content)
 
 
+# This class implements AppSourceConnection using the GitHub API,
+# using the GithubApiFilesystem class above to wrap the GitHub API
+# in a PyFilesystem2 filesystem. source.spec should look like:
+# {
+#	"type": "github",
+#   "repo": "organization/repository",
+#   "path": "apps", # optional
+#   "auth": { "user": "username", "pw": "password" } # optional
+# }
 class GithubApiAppSourceConnection(PyFsAppSourceConnection):
-    """An App Store provided by a local directory."""
     def __init__(self, source):
         # the spec is incomplete
         if not isinstance(source.spec.get("repo"), str): raise ValueError("The AppSource is misconfigured: missing or invalid 'repo'.")
@@ -453,14 +453,6 @@ class GithubApiAppSourceConnection(PyFsAppSourceConnection):
 
 
 class GitRepositoryFilesystem(SimplifiedReadonlyFilesystem):
-    """
-        "url": "git@github.com:GovReady/myrepository",
-        "branch": "master", # optional - remote's default branch is used by default
-        "path": "/subpath", # this is optional, if specified it's the directory in the repo to look at
-        "ssh_key": "-----BEGIN RSA PRIVATE KEY-----\nkey data\n-----END RSA PRIVATE KEY-----"
-            # ^ for private repos only
-    """
-
     def __init__(self, url, branch, path, ssh_key=None):
         self.url = url
         self.branch = branch or None
@@ -588,6 +580,17 @@ class GitRepositoryFilesystem(SimplifiedReadonlyFilesystem):
         return io.BytesIO(tree.data_stream.read())
 
 
+# This class implements AppSourceConnection for a git repository,
+# using the GitRepositoryFilesystem class above to wrap the git client
+# in a PyFilesystem2 filesystem. source.spec should look like:
+# {
+#  "type": "git",
+#  "url": "git@github.com:GovReady/myrepository",
+#  "branch": "master", # optional - remote's default branch is used by default
+#  "path": "/subpath", # this is optional, if specified it's the directory in the repo to look at
+#  "ssh_key": "-----BEGIN RSA PRIVATE KEY-----\nkey data\n-----END RSA PRIVATE KEY-----"
+#             ^ for private repos only
+# }
 class GitRepositoryAppSourceConnection(PyFsAppSourceConnection):
     """An App Store provided by a local directory."""
     def __init__(self, source):
@@ -615,367 +618,3 @@ AppSourceConnectionTypes = {
     "github": GithubApiAppSourceConnection,
     "git": GitRepositoryAppSourceConnection,
 }
-
-
-## LOAD MODULES ##
-
-
-class ValidationError(ModuleDefinitionError):
-    def __init__(self, file_name, scope, message):
-        super().__init__("There was an error in %s (%s): %s" % (file_name, scope, message))
-
-class CyclicDependency(ModuleDefinitionError):
-    def __init__(self, path):
-        super().__init__("Cyclic dependency between modules: " + " -> ".join(path + [path[0]]))
-
-class DependencyError(ModuleDefinitionError):
-    def __init__(self, from_module, to_module):
-        super().__init__("Invalid module ID '%s' in module '%s'." % (to_module, from_module))
-
-class IncompatibleUpdate(Exception):
-    pass
-
-def load_module_into_database(app, appinst, module_id, available_modules, processed_modules, dependency_path, update_mode):
-    # Prevent cyclic dependencies between modules.
-    if module_id in dependency_path:
-        raise CyclicDependency(dependency_path)
-
-    # Because of dependencies between modules, we may have already
-    # been here. Do this after the cyclic dependency check or else
-    # we would never see a cyclic dependency.
-    if module_id in processed_modules:
-        return processed_modules[module_id]
-
-    # Load the module's YAML file.
-    if module_id not in available_modules:
-        raise DependencyError((dependency_path[-1] if len(dependency_path) > 0 else None), module_id)
-
-    spec = available_modules[module_id]
-
-    # Sanity check that the 'id' in the YAML file matches just the last
-    # part of the path of the module_id. This allows the IDs to be 
-    # relative to the path in which the module is found.
-    if spec.get("id") != module_id.split('/')[-1]:
-        raise ValidationError(module_id, "module", "Module 'id' field (%s) doesn't match source file path (\"%s\")." % (repr(spec.get("id")), module_id))
-
-    # Replace spec["id"] (just the last part of the path) with the full module_id
-    # (a full path, minus .yaml) relative to the root of the app. The id is used
-    # in validate_module to resolve references to other modules.
-    spec["id"] = module_id
-
-    # Validate and normalize the module specification.
-
-    try:
-        spec = validate_module(spec)
-    except ModuleValidationError as e:
-        raise ValidationError(spec['id'], e.context, e.message)
-
-    # Recursively update any modules this module references.
-    dependencies = { }
-    for m1 in get_module_spec_dependencies(spec):
-        mdb = load_module_into_database(app, appinst, m1, available_modules, processed_modules, dependency_path + [spec["id"]], update_mode)
-        dependencies[m1] = mdb
-
-    # Now that dependent modules are loaded, replace module string IDs with database numeric IDs.
-    for q in spec.get("questions", []):
-        if q.get("type") not in ("module", "module-set"): continue
-        if "module-id" not in q: continue
-        mdb = dependencies[q["module-id"]]
-        q["module-id"] = mdb.id
-
-    # Look for an existing Module to update.
-
-    m = None
-    if update_mode != AppImportUpdateMode.CreateInstance:
-        try:
-            m = Module.objects.get(app=appinst, module_name=spec['id'])
-        except Module.DoesNotExist:
-            # If it doesn't exist yet in the previous app, we'll just create it.
-            pass
-    if m:
-        # What is the difference between the app's module and the module in the database?
-        change = is_module_changed(m, app.store.source, spec)
-    
-        if change is None:
-            # There is no difference, so we can go on immediately.
-            pass
-
-        elif (change is False and update_mode == AppImportUpdateMode.CompatibleUpdate) \
-            or update_mode == AppImportUpdateMode.ForceUpdate:
-            # There are no incompatible changes and we're allowed to update modules,
-            # or we're forcing an update and it doesn't matter whether or not there
-            # are changes --- update this one in place.
-            update_module(m, spec, True)
-
-        else:
-            # Block an incompatible update --- don't create a new module.
-            raise IncompatibleUpdate("Module {} cannot be updated because changes are incompatible with the existing data model: {}".format(module_id, change))
-
-    if not m:
-        # No Module in the database matched what we need, or an existing
-        # one cannot be updated. Create one.
-        m = create_module(app, appinst, spec)
-
-    processed_modules[module_id] = m
-    return m
-
-
-def get_module_spec_dependencies(spec):
-    # Scans a module YAML specification for any dependencies and
-    # returns a generator that yields the module IDs of the
-    # dependencies.
-    questions = spec.get("questions")
-    if not isinstance(questions, list): questions = []
-    for question in questions:
-        if question.get("type") in ("module", "module-set"):
-            if "module-id" in question:
-                yield question["module-id"]
-
-
-def create_module(app, appinst, spec):
-    # Create a new Module instance.
-    m = Module()
-    m.source = app.store.source
-    m.app = appinst
-    m.module_name = spec['id']
-    print("Creating", m.app, m.module_name, file=sys.stderr)
-    update_module(m, spec, False)
-    return m
-
-
-def remove_questions(spec):
-    spec = OrderedDict(spec) # clone
-    if "questions" in spec:
-        del spec["questions"]
-    return spec
-
-
-def update_module(m, spec, log_status):
-    # Update a module instance according to the specification data.
-    # See is_module_changed.
-    if log_status:
-        print("Updating", repr(m), file=sys.stderr)
-
-    # Remove the questions from the module spec because they'll be
-    # stored with the ModuleQuestion instances.
-    m.visible = True
-    m.spec = remove_questions(spec)
-    m.save()
-
-    # Update its questions.
-    qs = set()
-    for i, question in enumerate(spec.get("questions", [])):
-        qs.add(update_question(m, i, question, log_status))
-
-    # Delete removed questions (only happens if the Module is
-    # not yet in use).
-    for q in m.questions.all():
-        if q not in qs:
-            print("Deleting", repr(q), file=sys.stderr)
-            try:
-                q.delete()
-            except ProtectedError:
-                raise IncompatibleUpdate("Module {} cannot be updated because question {}, which has been removed, has already been answered.".format(m.module_name, q.key))
-
-    # If we're updating a Module in-place, clear out any cached state on its Tasks.
-    for t in Task.objects.filter(module=m):
-        t.on_answer_changed()
-
-
-def update_question(m, definition_order, spec, log_status):
-    # Adds or updates a ModuleQuestion within Module m given its
-    # YAML specification data in 'question'.
-
-    # Create/update database record.
-    field_values = {
-        "definition_order": definition_order,
-        "spec": spec,
-        "answer_type_module": Module.objects.get(id=spec["module-id"]) if spec.get("module-id") else None,
-    }
-    q, isnew = ModuleQuestion.objects.get_or_create(
-        module=m,
-        key=spec["id"],
-        defaults=field_values)
-
-    if isnew:
-        pass # print("Added", repr(q))
-    else:            
-        # Don't need to update the database (and we can avoid
-        # bumping the .updated date) if the question's specification
-        # is identifical to what's already stored.
-        if is_question_changed(q, definition_order, spec) is not None:
-            if log_status: print("Updated", repr(q), file=sys.stderr)
-            for k, v in field_values.items():
-                setattr(q, k, v)
-            q.save(update_fields=field_values.keys())
-
-    return q
-
-
-def is_module_changed(m, source, spec):
-    # Returns whether a module specification has changed since
-    # it was loaded into a Module object (and its questions).
-    # Returns:
-    #   None => No change.
-    #   False => Change, but is compatible with the database record
-    #           and the database record can be updated in-place.
-    #   any string => Incompatible change - a new database record is needed.
-
-    # If all other metadata is the same, then there are no changes.
-    if \
-            json.dumps(m.spec, sort_keys=True) == json.dumps(remove_questions(spec), sort_keys=True) \
-        and json.dumps([q.spec for q in m.get_questions()], sort_keys=True) \
-            == json.dumps([q for q in spec.get("questions", [])], sort_keys=True):
-        return None
-
-    # Now we're just checking if the change is compatible or not with
-    # the existing database record.
-
-    if m.spec.get("version") != spec.get("version"):
-        # The module writer can force a bump by changing the version
-        # field.
-        return "The module version number changed, forcing a reload."
-
-    # If there are no Tasks started for this Module, then the change is
-    # compatible because there is no data consistency to worry about.
-    if not Task.objects.filter(module=m).exists():
-        return False
-
-    # An incompatible change is the removal of a question, the change
-    # of a question type, or the removal of choices from a choice
-    # question --- anything that would cause a TaskQuestion/TaskAnswer
-    # to have invalid data. If a question has never been answered, then
-    # this does not apply because there is no data that would become
-    # corrupted.
-    qs = set()
-    for definition_order, q in enumerate(spec.get("questions", [])):
-        mq = ModuleQuestion.objects.filter(module=m, key=q["id"]).first()
-        if not mq:
-            # This is a new question. That's a compatible change.
-            continue
-
-        # Is there an incompatible change in the question? (If there
-        # is a change that is compatible, we will return that the
-        # module is changed anyway at the end of this method.)
-        qchg = is_question_changed(mq, definition_order, q)
-        if isinstance(qchg, str):
-            return "In question %s: %s" % (q["id"], qchg)
-
-        # Remember that we saw this question.
-        qs.add(mq)
-
-    # Were any questions removed?
-    for mq in m.questions.all():
-        if mq in qs:
-            continue
-
-        # If this question has never been answered, then anything is fine.
-        if mq.taskanswer_set.count() == 0:
-            return False
-
-        # The removal of this question is an incompatible change.
-        return "Question %s was removed." % mq.key
-
-    # The changes will not create any data inconsistency.
-    return False
-
-def is_question_changed(mq, definition_order, spec):
-    # Returns whether a question specification has changed since
-    # it was loaded into a ModuleQuestion object.
-    # Returns:
-    #   None => No change.
-    #   False => Change, but is compatible with the database record
-    #           and the database record can be updated in-place.
-    #   str => Incompatible change - a new database record is needed.
-    #          The string holds an explanation of what changed.
-
-    # Check if the specifications are identical. We are passed a
-    # trasnformed question spec already.
-    if mq.definition_order == definition_order \
-        and json.dumps(mq.spec, sort_keys=True) == json.dumps(spec, sort_keys=True):
-        return None
-
-    # If this question has never been answered, then anything is fine.
-    if mq.taskanswer_set.count() == 0:
-        return False
-
-    # Change in question type -- that's incompatible.
-    if mq.spec["type"] != spec["type"]:
-        return "The question type changed from %s to %s." % (
-            repr(mq.spec["type"]), repr(spec["type"])
-            )
-
-    # Removal of a choice.
-    if mq.spec["type"] in ("choice", "multiple-choice"):
-        def get_choice_keys(choices): return { c.get("key") for c in choices }
-        rm_choices = get_choice_keys(mq.spec["choices"]) - get_choice_keys(spec["choices"])
-        if rm_choices:
-            return "One or more choices was removed: " + ", ".join(rm_choices) + "."
-
-    # Constriction of valid number of choices to a multiple-choice
-    # (min is increased or max is newly set or decreased).
-    if mq.spec["type"] == "multiple-choice":
-        if "min" not in mq.spec or "max" not in mq.spec:
-            return "min/max was missing."
-        if spec['min'] > mq.spec['min']:
-            return "min went up."
-        if mq.spec["max"] is None and spec["max"] is not None:
-            return "max was added."
-        if mq.spec["max"] is not None and spec["max"] is not None and spec["max"] < mq.spec["max"]:
-            return "max went down."
-
-    # Change in the module type if a module-type question, including
-    # if the references module has been updated. spec has already
-    # been transformed so that it stores an integer module database ID
-    # rather than the string module ID in the YAML files.
-    if mq.spec["type"] in ("module", "module-set"):
-        if mq.spec.get("module-id") != spec.get("module-id"):
-            return "The answer type module changed from %s to %s." %(
-                repr(mq.spec.get("module-id")), repr(spec.get("module-id"))
-            )
-        if set(mq.spec.get("protocol", [])) != set(spec.get("protocol", [])):
-            return "The answer type protocol changed (%s to %s)." % (
-                set(mq.spec.get("protocol")),
-                set(spec.get("protocol"))
-            )
-
-    # The changes to this question do not create a data inconsistency.
-    return False
-
-def load_module_assets_into_database(app, appinst):
-    # Load all of the static assets from the source into the database.
-    # If a ModuleAsset already exists for an asset, use that.
-
-    source = app.store.source
-
-    # Add the assets.
-    appinst.trust_assets = source.trust_assets # remember setting at time of app load
-    appinst.asset_paths = { }
-    for file_path, file_hash, content_loader in app.get_assets():
-        # Get or create the ModuleAsset --- it might already exist in an earlier app.
-        asset, is_new = ModuleAsset.objects.get_or_create(
-            source=source,
-            content_hash=file_hash,
-        )
-        if is_new:
-            # Set the new file content.
-            from django.core.files.base import ContentFile
-            asset.file.save(file_path, ContentFile(content_loader()))
-            asset.save()
-
-        # Add to the app.
-        appinst.asset_files.add(asset)
-        appinst.asset_paths[file_path] = file_hash
-
-        mime_types = {
-            "css": "text/css",
-            "js": "text/javascript",
-        }
-        mime_type = mime_types.get(file_path.rsplit(".", 1)[-1])
-        if mime_type:
-            from dbstorage.models import StoredFile
-            StoredFile.objects\
-                .filter(path=asset.file.name)\
-                .update(mime_type=mime_type)
-
-    appinst.save()

--- a/guidedmodules/app_source_connections.py
+++ b/guidedmodules/app_source_connections.py
@@ -39,8 +39,6 @@ import re
 import fs, fs.errors
 from fs.base import FS as fsFS
 
-from .app_loading import ModuleDefinitionError
-
 class AppSourceConnectionError(Exception):
     pass
 
@@ -241,12 +239,8 @@ class PyFsApp(App):
             err_str = "%s/app.yaml" % self.fs.desc('')
             try:
                 yaml = read_yaml_file(f)
-            except ModuleDefinitionError as e:
-                raise ModuleDefinitionError("There was an error loading the module at %s: %s" % (
-                    err_str,
-                    str(e)))
-            except Exception as e:
-                raise ModuleDefinitionError("There was an unhandled error loading the module at %s." % (
+            except AppSourceConnectionError as e:
+                raise AppSourceConnectionError("There was an error loading the module at %s: %s" % (
                     err_str,
                     str(e)))
 
@@ -607,7 +601,7 @@ def read_yaml_file(f):
     try:
         return rtyaml.load(f)
     except (yaml.scanner.ScannerError, yaml.parser.ParserError, yaml.constructor.ConstructorError) as e:
-        raise ModuleDefinitionError("There was an error parsing the YAML file: " + str(e))
+        raise AppSourceConnectionError("There was an error parsing the YAML file: " + str(e))
 
 AppSourceConnectionTypes = {
     "null": NullAppSourceConnection,

--- a/guidedmodules/management/commands/apps_catalog.py
+++ b/guidedmodules/management/commands/apps_catalog.py
@@ -2,7 +2,7 @@ from django.core.management.base import BaseCommand, CommandError
 from django.conf import settings
 
 from guidedmodules.models import AppSource
-from guidedmodules.module_sources import MultiplexedAppSourceConnection
+from guidedmodules.app_source_connections import MultiplexedAppSourceConnection
 
 class Command(BaseCommand):
     help = 'Prints a list of all apps in the configured app stores.'

--- a/guidedmodules/management/commands/load_modules.py
+++ b/guidedmodules/management/commands/load_modules.py
@@ -2,7 +2,7 @@ from django.core.management.base import BaseCommand, CommandError
 from django.conf import settings
 
 from guidedmodules.models import AppSource, AppInstance
-from guidedmodules.module_sources import AppImportUpdateMode, IncompatibleUpdate
+from guidedmodules.app_loading import AppImportUpdateMode, IncompatibleUpdate, load_app_into_database
 
 class Command(BaseCommand):
     help = 'Updates the system modules from the YAML specifications in AppSources.'
@@ -19,7 +19,8 @@ class Command(BaseCommand):
 
                 # Try to update the existing app.
                 try:
-                    appinst = app.import_into_database(
+                    appinst = load_app_into_database(
+                        app,
                         update_appinst=oldappinst,
                         update_mode=AppImportUpdateMode.CompatibleUpdate if oldappinst else AppImportUpdateMode.CreateInstance)
                 except IncompatibleUpdate as e:
@@ -27,7 +28,7 @@ class Command(BaseCommand):
                     # a new AppInstance and mark the old one as no longer the system_app.
                     # Only one can be the system_app.
                     print(app, e)
-                    appinst = app.import_into_database()
+                    appinst = load_app_into_database(app)
                     oldappinst.system_app = None # the correct value here is None, not False, to avoid unique constraint violation
                     oldappinst.save()
 

--- a/guidedmodules/models.py
+++ b/guidedmodules/models.py
@@ -68,7 +68,7 @@ class AppSource(models.Model):
     def open(self):
         # Return an AppSourceConnection instance for this source.
         from .app_source_connections import AppSourceConnection
-        return AppSourceConnection.create(self)
+        return AppSourceConnection.create(self, self.spec)
 
 class AppInstance(models.Model):
     source = models.ForeignKey(AppSource, related_name="appinstances", on_delete=models.CASCADE, help_text="The source of this AppInstance.")

--- a/guidedmodules/models.py
+++ b/guidedmodules/models.py
@@ -67,7 +67,7 @@ class AppSource(models.Model):
 
     def open(self):
         # Return an AppSourceConnection instance for this source.
-        from .module_sources import AppSourceConnection
+        from .app_source_connections import AppSourceConnection
         return AppSourceConnection.create(self)
 
 class AppInstance(models.Model):

--- a/guidedmodules/tests.py
+++ b/guidedmodules/tests.py
@@ -4,6 +4,7 @@ from django.conf import settings
 from siteapp.models import Organization, Project, User
 from .models import Module, Task, TaskAnswer
 from .module_logic import *
+from .app_loading import load_app_into_database
 
 class TestCaseWithFixtureData(TestCase):
     @classmethod
@@ -15,9 +16,9 @@ class TestCaseWithFixtureData(TestCase):
         settings.VALIDATE_EMAIL_DELIVERABILITY = False
 
         # Load modules from the fixtures directory.
-        from guidedmodules.models import AppSource, AppInstance
-        from guidedmodules.management.commands.load_modules import Command as load_modules
-        from guidedmodules.module_sources import MultiplexedAppSourceConnection
+        from .models import AppSource, AppInstance
+        from .management.commands.load_modules import Command as load_modules
+        from .app_source_connections import MultiplexedAppSourceConnection
         src = AppSource.objects.create(
             slug="fixture",
             spec={
@@ -27,7 +28,7 @@ class TestCaseWithFixtureData(TestCase):
         )
         with MultiplexedAppSourceConnection(ms for ms in AppSource.objects.all()) as store:
             for app in store.list_apps():
-                app.import_into_database()
+                load_app_into_database(app)
         self.fixture_app = AppInstance.objects.get(source=src, appname="simple_project")
 
         # Create a dummy organization, project, and user.

--- a/guidedmodules/views.py
+++ b/guidedmodules/views.py
@@ -818,8 +818,7 @@ def upgrade_app(request):
     if not appinst.has_upgrade_priv(request.user):
         return HttpResponseForbidden()
 
-    from .module_sources import AppImportUpdateMode, ValidationError, IncompatibleUpdate
-    from .module_sources import ModuleDefinitionError
+    from .app_loading import load_app_into_database, AppImportUpdateMode, ModuleDefinitionError, IncompatibleUpdate
     with appinst.source.open() as store:
             # Load app.
             try:
@@ -837,8 +836,8 @@ def upgrade_app(request):
 
             # Import.
             try:
-                app.import_into_database(mode, appinst)
-            except (ModuleDefinitionError, ValidationError, IncompatibleUpdate) as e:
+                load_app_into_database(app, mode, appinst)
+            except (ModuleDefinitionError, IncompatibleUpdate) as e:
                 return JsonResponse({ "status": "error", "message": str(e) })
 
     # Since ModuleQuestions may have changed...


### PR DESCRIPTION
The module was getting big. This splits it into two smaller modules, one that provides abstract classes for getting compliance apps from remote sources and one that loads the apps into the database.

This PR has commits from the other pending PR. I'll fix that when the other PR is merged.