### PR TITLE
remove build error for newer upstream python packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,9 +35,16 @@ jobs:
     # Run tests.
 
     # Install packages necesary for requirements_txt_checker.sh,
-    # and then run it.
-    - run: pip3 install --user -U pip-tools safety
-    - run: ./requirements_txt_checker.sh
+    # and then run it and store output as an artifact.
+    - run: pip3 install --user -U pip-tools
+    - run: ./requirements_txt_checker.sh > requirements.txt.status.txt
+    - store_artifacts:
+        path: requirements.txt.status.txt
+
+    # Install packages necesary for to check packages for known
+    # vulnerabilities using pyup.io, and run the check.
+    - run: pip3 install --user -U safety
+    - run: safety check --bare -r requirements.txt
 
     # Run static code analysis using 'bandit'.
     # Disable warning-like tests:

--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,6 @@
-# This is our master file of requirements. Use update_packages.sh
-# to generate the requirements.txt file that is used in production.
+# This is our master file of requirements. Use ./requirements_txt_updater.sh
+# to generate the requirements.txt file that is used in deployments to install
+# Python libraries.
 
 # Common Python Packages
 python-dateutil # Simplified BSD License

--- a/requirements_txt_checker.sh
+++ b/requirements_txt_checker.sh
@@ -26,19 +26,13 @@ cat requirements.txt \
 # Compare the requirements.txt in the repository to the one found by
 # generating it from requirements.in.
 if ! diff -B -u $FN $FN2; then
-	rm $FN $FN2
 	echo
-	echo "requirements.txt is not in sync. Run requirements_txt_updater.sh."
-	exit 1
+	echo "requirements.txt is not in sync with requirements.in. Some packages may have updates available. Run requirements_txt_updater.sh."
+else
+	echo "requirements.txt is in sync with requirements.in."
 fi
-rm $FN $FN2
-echo "requirements.txt is in sync with requirements.in."
-echo
 
-# Check packages for known vulnerabilities using pyup.io.
-# Script exits on error.
-safety check --bare -r requirements.txt
-echo "No known vulnerabilities in Python dependencies."
+rm $FN $FN2
 echo
 
 # Check installed packages for anything outdated. Unfortunately
@@ -63,14 +57,10 @@ if [ -f requirements_txt_checker_ignoreupdates.txt ]; then
 fi
 
 if [ $(cat $FN | wc -l) -gt 2 ]; then
-	echo
 	echo "Some packages are out of date:"
 	echo
 	cat $FN
-	rm $FN
-	exit 1
 else
-	echo
 	echo "All packages are up to date with latest upstream versions."
 fi
 rm $FN


### PR DESCRIPTION
This PR removes build errors when there are new upstream Python packages because there is always something new and our build keeps breaking even though we may want to remain on our pinned versions of packages for a while. We do this to force us to check upstream packages for security updates etc. But doing it on every pull request is too much.

Instead, store the output of the checks as a CircleCI artifact for review later.

Right now we're waiting for a GitHub outage to end that is preventing from CircleCI checking this PR.

@gregelin suggests that we set up a secondary build or use another service that forces us to check upstream package updates regularly, maybe weekly, but not in a way that blocks pull requests. Maybe it would automatically open an issue for each new upstream package that is changed. @peterkaminski Do you know of a service that would help us do that? Basically a cron job that starts a container and installs packages -> runs our upstream package update checker script -> takes action based on output.