### PR TITLE
fix IAM proxy login reload issue

### DIFF
--- a/siteapp/settings_application.py
+++ b/siteapp/settings_application.py
@@ -15,6 +15,24 @@ INSTALLED_APPS += [
     'discussion',
 ]
 
+
+if environment.get("trust-user-authentication-headers"):
+    # When this is set, the 'username' and 'email' keys hold HTTP header
+    # names which control user authentication. Standard authentication
+    # is disabled. Instead, user login is handled by a proxy server running
+    # in front of Q. These headers are always expected to be set and trusted
+    # when this setting is enabled. Per the Django Documentation (https://docs.djangoproject.com/en/dev/howto/auth-remote-user/),
+    # you must be sure that your front-end web server does not permit an
+    # end-user to submit a spoofed header value for these headers *as well
+    # as* other headers that normalize to the same key as seen by Django.
+    # Because regular authentication is disabled, before setting this setting
+    # you should ensure you'll be able to log in with the proxy using the
+    # username of an admin account that is already registered.
+    MIDDLEWARE.append('siteapp.middleware.ProxyHeaderUserAuthenticationMiddleware') # must be after AuthenticationMiddleware but before OrganizationSubdomainMiddleware
+    AUTHENTICATION_BACKENDS = ['siteapp.middleware.ProxyHeaderUserAuthenticationBackend'] # replace the standard login backends
+    PROXY_HEADER_AUTHENTICATION_HEADERS = environment["trust-user-authentication-headers"]
+    print("Trusting authentication headers:", PROXY_HEADER_AUTHENTICATION_HEADERS)
+ 
 MIDDLEWARE += [
     #'debug_toolbar.middleware.DebugToolbarMiddleware',
     'siteapp.middleware.ContentSecurityPolicyMiddleware',
@@ -63,24 +81,6 @@ MAILGUN_API_KEY = environment.get('mailgun_api_key', '') # for the incoming mail
 
 VALIDATE_EMAIL_DELIVERABILITY = True
 
-if environment.get("trust-user-authentication-headers"):
-    # When this is set, the 'username' and 'email' keys hold HTTP header
-    # names which control user authentication. Standard authentication
-    # is disabled. Instead, user login is handled by a proxy server running
-    # in front of Q. These headers are always expected to be set and trusted
-    # when this setting is enabled. Per the Django Documentation (https://docs.djangoproject.com/en/dev/howto/auth-remote-user/),
-    # you must be sure that your front-end web server does not permit an
-    # end-user to submit a spoofed header value for these headers *as well
-    # as* other headers that normalize to the same key as seen by Django.
-    # Because regular authentication is disabled, before setting this setting
-    # you should ensure you'll be able to log in with the proxy using the
-    # username of an admin account that is already registered.
-    MIDDLEWARE += ['siteapp.middleware.ProxyHeaderUserAuthenticationMiddleware'] # must be after AuthenticationMiddleware
-    AUTHENTICATION_BACKENDS = ['siteapp.middleware.ProxyHeaderUserAuthenticationBackend',
-                               'siteapp.models.DirectLoginBackend']
-    PROXY_HEADER_AUTHENTICATION_HEADERS = environment["trust-user-authentication-headers"]
-    print("Trusting authentication headers:", PROXY_HEADER_AUTHENTICATION_HEADERS)
- 
 # Get the version of this software from the VERSION file which has up to two lines.
 # The first line is a version string for display. The second line is the git commit
 # hash that the build was based on. If the second line isn't present, we use git to


### PR DESCRIPTION
When using an IAM proxy server, the middleware needs to be arranged so that the proxy headers are read and applied *before* we check if the user has permission to view the organization domain they are requesting. We were seeing that a browser reload was necessary after login to make it to the projects page because the `/` route is permitted regardless of authorization and the user makes it to that page, then the IAM headers were read and applied to the request user, which started a session, and on reload the session would be used and the user would be permitted to go to their projects page.

The middleware `ProxyHeaderUserAuthenticationMiddleware` and `OrganizationSubdomainMiddleware` are now reversed, so the user's session is created before the site checks if the user has permission to see organization projects.

This PR also makes a few other smaller changes:

* The Django admin page on single-organization deployments should not be behind our custom organization domain authorization logic because that could prevent admins from reaching the page.
* An error message was improved.