### PR TITLE
Custom branding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,13 @@ Deployment changes:
 
 * GovReady-Q can now be deployed behind an enterprise reverse proxy authentication server that sends login information in HTTP headers.
 * Python 3.6+ is now required.
+* Documentation was added for creating a custom Docker image that adds organization branding to the site.
 
 Developer changes:
 
 * Add a new VERSION file to source code control that stores the current version of the software, plus a commit hash for public releases, so that nightly builds don't fail because of a missing VERSION file. Add build tests to ensure the VERSION file matches the top release in CHANGELOG.md and ends with "+devel" if and only if this is a development release.
 * The application was not working on macOS in version v0.8.4 because of a bug in commonmark 0.8.0.
+* Some of the templates were split out into multiple files to make it easier to override them for custom branding.
 * Upgraded some dependencies.
 
 v0.8.4 (October 23, 2018)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,20 @@ GovReady-Q Release Notes
 In Development
 --------------
 
+Application changes:
+
+* An undocumented feature called "unskippable questions" was removed. This feature inadvertently hid some questions, resulting in a module being indicated as finished but its progress bar showing questions are unfinished.
+
 Deployment changes:
 
 * GovReady-Q can now be deployed behind an enterprise reverse proxy authentication server that sends login information in HTTP headers.
+* Python 3.6+ is now required.
 
 Developer changes:
 
 * Add a new VERSION file to source code control that stores the current version of the software, plus a commit hash for public releases, so that nightly builds don't fail because of a missing VERSION file. Add build tests to ensure the VERSION file matches the top release in CHANGELOG.md and ends with "+devel" if and only if this is a development release.
+* The application was not working on macOS in version v0.8.4 because of a bug in commonmark 0.8.0.
+* Upgraded some dependencies.
 
 v0.8.4 (October 23, 2018)
 -------------------------

--- a/docs/source/CustomBranding.md
+++ b/docs/source/CustomBranding.md
@@ -1,0 +1,172 @@
+Applying Custom Organization Branding
+=====================================
+
+The look and feel of GovReady-Q can be customized a bit by overriding the Django templates that are used to construct the site's pages and by serving additional static assets.
+
+Custom branding can contain static assets (such as a logo image) and HTML template overrides. Branding is packaged into a directory with a particular directory layout and some Python boilerplate code that allows GovReady-Q to find the branding files. The directory is placed inside the main GovReady-Q directory, and an application setting is used to activate it.
+
+Before setting out to create custom branding, make sure you have GovReady-Q [set up for development on your workstation](deploy_local_dev.html). You'll need a working setup of GovReady-Q to create the branding directory and to test your changes.
+
+## Creating the branding directory
+
+Custom branding is packaged inside what Django confusingly calls an [application](https://docs.djangoproject.com/en/2.1/ref/applications/), but it is just a packaged sub-component of a website. To create a new branding package directory, change to the directory where you have GovReady-Q set up. Then run:
+
+```sh
+python3 manage.py startapp sample_branding
+```
+
+This command creates a new directory called `sample_branding` with Python boilerplate code to make it a valid Django "application."
+
+Make directories for storing the custom static assets and templates:
+
+```sh
+mkdir sample_branding/static
+mkdir sample_branding/templates
+```
+
+## Activate the branding package
+
+Next, let your development installation of GovReady-Q know that you want to use the custom branding package. In your `local/environment.json` file, add a setting named `branding` and set it to the name of the custom branding package directory.
+
+```sh
+  "branding": "sample_branding",
+```
+
+See [Environment Settings](Environment.html) for more information about the `local/environment.json` file. Note that for the file to be valid JSON the last setting cannot have a trailing comma.
+
+## Overriding templates
+
+Any of the templates that make up GovReady-Q's frontend can be overridden. The full list of templates can be browsed in GovReady-Q's GitHub repository at
+
+https://github.com/GovReady/govready-q/tree/master/templates
+
+Start by trying to override the `navbar.html` template, which is inserted at the top of every page. Use your favorite text editor to create a file at `sample_branding/templates/navbar.html`. Copy the content of GovReady-Q's stock `navbar.html` from https://github.com/GovReady/govready-q/blob/master/templates/navbar.html into it. (GitHub's "Raw" button is handy for getting a clean version to save or copy/paste.)
+
+At the bottom of the file, add some custom HTML, such as:
+
+```html
+<div>
+  <b>Welcome to my organization&rsquo;s custom site!</b>
+</div>
+```
+
+Start GovReady-Q on your workstation (see the [development docs](deploy_local_dev.html)) and visit a page. You should see your new content below the navbar at the top of every page.
+
+## Adding custom CSS
+
+You can also add a custom CSS stylesheet to your branded GovReady-Q by taking the following steps:
+
+a) Add the CSS file as a static asset.
+b) Insert a `<link rel="stylesheet" href="...">` tag into the `<head>` section of each page's HTML by overriding the `head.html` template.
+
+To create the static asset, make a new file named `sample_branding/static/custom.css`. Let's say you want to make the background color of each page red. The file should contain:
+
+```css
+body {
+	background: red !important;
+}
+```
+
+Then override the `head.html` template. GovReady-Q's base for `head.html` is empty --- its purpose is only to allow you to add to the `<head>` element. So create a new file at `sample_branding/templates/head.html` and put in it:
+
+```html
+{% load static %}
+<link rel="stylesheet" href="{% static "custom.css" %}">
+```
+
+See the [Django documentation for static files](https://docs.djangoproject.com/en/2.1/howto/static-files/) for more information about the `static` template tag.
+
+Open any page in your locally running GovReady-Q and you should see that the background color of every page has changed.
+
+## Keeping your templates up to date
+
+With each new released verison of GovReady-Q, there is the possibility that the stock templates have changed. Some changes may require you to re-engineer your template overrides to preserve functionality.
+
+## Creating a custom Docker image
+
+If your organization is deploying GovReady-Q using Docker, you will need to embed your custom branding package within a Docker image. You have two options:
+
+1. Modify GovReady-Q's stock Dockerfile, i.e. the one in GovReady-Q's source code, to add and activate your branding package and then _build your own GovReady-Q Docker image_ from the GovReady-Q source files that you cloned from GitHub.
+2. Make your own Dockerfile that _uses a released GovReady-Q image as its parent image_ and adds to it just the steps needed to add and activate your branding package.
+
+### Creating your own Dockerfile that uses a released GovReady-Q image as its parent image
+
+We recommend method 2. To create your own Dockerfile that uses a released GovReady-Q image as its parent image, create a new `Dockerfile` in your branding package directory, e.g. a new file named `Dockerfile` in the `sample_branding` directory you created earlier.
+
+Then choose which parent image you will use from the available [GovReady-Q tags](https://hub.docker.com/r/govready/govready-q/tags). Each tag corresponds to a release version. Your Dockerfile begins with a `FROM` line that combines `govready/govready-q:` with the tag name you choose. In this example we use the `latest` tag which is an alias for the most recent version of GovReady-Q:
+
+```Dockerfile
+FROM govready/govready-q:latest
+```
+
+The subsequent commands in your Dockerfile configures the container, picking up where the parent image's Dockerfile leaves off. For more information about the parent image, refer to [GovReady-Q's Dockerfile on GitHub](https://github.com/GovReady/govready-q/blob/master/Dockerfile).
+
+Your Dockerfile's next step is to add your branding package into the image in a directory named `branding`:
+
+```Dockerfile
+RUN mkdir branding
+COPY . branding
+```
+
+Finally, you'll need some commands to adjust permissions, to activate the branding package when GovReady-Q starts, and to prepare teh static assets to be served. The complete Dockerfile should look like this:
+
+```Dockerfile
+# Build an image on top of the stock GovReady-Q image.
+FROM govready/govready-q:latest
+
+# The parent Dockerfile ends with 'USER application' to run the
+# container as a non-privileged user. But we need to go back to
+# root to add additional files and then switch back to the non-
+# root user at the end.
+USER root
+
+# Copy our public app files into place.
+RUN mkdir branding
+COPY . branding
+
+# Activate the branding package. The environment variable is read
+# by dockerfile_exec.sh in the GovReady-Q parent image. And modifying
+# /tmp/environment.json is necessary at this step so that collectstatic
+# picks it up below.
+ENV BRANDING branding
+RUN sed -i "s/}/,\"branding\": \"branding\" }/" /tmp/environment.json
+
+# Flatten static files. The base image did it once, but we may have
+# added new static files so we must do it again.
+RUN python3.6 manage.py collectstatic --noinput
+
+# Run the container's process zero as this user --- see above.
+USER application
+
+# Check that everything looks good.
+RUN python3.6 manage.py check
+```
+
+Finally you can build and test your custom image.
+
+### Building your docker image
+
+If you were in the GovReady-Q sources directory, move into your branding package directory:
+
+```bash
+cd sample_branding
+```
+
+Then fetch the parent image and build your image:
+
+```bash
+docker image pull govready/govready-q:latest
+docker image build --tag myorg/govready-q-branded:latest .
+```
+
+(Substitute the right tag depending on the tag you chose for the `FROM` line in your Dockerfile.)
+
+Test that your image works by launching a new container based on your image:
+
+```bash
+docker container run --rm -it -p 127.0.0.1:8000:8000 myorg/govready-q-branded:latest
+```
+
+Once GovReady-Q is running in the container, visit it at `http://localhost:8000`. Use CTRL+C in the console to terminate and destroy the test container running your image.
+
+For more about running GovReady-Q with Docker, see [Deploying with Docker](deploy_docker.html).

--- a/docs/source/Deploy.md
+++ b/docs/source/Deploy.md
@@ -10,3 +10,4 @@ Deploying GovReady-Q
    deploy_rhel7_centos7.md
    deploy_ubuntu.md
    Environment.md
+   CustomBranding.md

--- a/docs/source/Environment.md
+++ b/docs/source/Environment.md
@@ -17,7 +17,7 @@ A production system may need to set more options in `local/environment.json`. He
 Custom Branding
 ---------------
 
-You may override the templates and stylesheets that are used for GovReady-Q's branding by adding a new key named `branding` that is the name of an installed Django app Python module (i.e. created using `manage.py startapp`) that holds templates and static files.
+You may override the templates and stylesheets that are used for GovReady-Q's branding by adding a new key named `branding` that is the name of an installed Django app Python module (i.e. created using `manage.py startapp`) that holds templates and static files. See [Applying Custom Organization Branding](CustomBranding.html).
 
 Enterprise Login
 ----------------

--- a/docs/source/deploy_docker.md
+++ b/docs/source/deploy_docker.md
@@ -293,7 +293,7 @@ The following environment variables are used to configure the container when lau
 
 `MAILGUN_API_KEY` - An API key for Mailgun which is used to validate incoming webhook requests from Mailgun when an incoming email is received, when Mailgun is configured to handle incoming mail. (Default: None)
 
-`BRANDING` (downstream packaging only): You may override the templates and stylesheets that are used for GovReady-Q's branding by setting this environment variable to the name of an installed Django app Python module (i.e. created using `manage.py startapp`) that holds templates and static files. No such app is provided in the GovReady-Q published Docker image, so this variable can only be used by downstream image maintainers.
+`BRANDING` (downstream packaging only): You may override the templates and stylesheets that are used for GovReady-Q's branding by setting this environment variable to the name of an installed Django app Python module (i.e. created using `manage.py startapp`) that holds templates and static files. No such app is provided in the GovReady-Q published Docker image, so this variable can only be used by downstream image maintainers.  See [Applying Custom Organization Branding](CustomBranding.html).
 
 `PROXY_AUTHENTICATION_USER_HEADER` and `PROXY_AUTHENTICATION_EMAIL_HEADER`: GovReady-Q can be deployed behind a reverse proxy that authenticates users and passes the authenticated user's username and email address in HTTP headers. These environment variables correspond to the settings documented in [Enterprise Login](Environment.html#proxy-authentication-sever).
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,7 +1,4 @@
 {% load static %}
-{% load notifications_tags %}
-{% load q %}
-{% load notification_helpers %}
 <!DOCTYPE html>
 <html lang="en">
     <head>
@@ -23,6 +20,7 @@
         <link rel="stylesheet" href="{% static "css/govready-q.css" %}">
         <link rel="stylesheet" href="{% static "vendor/bootstrap/css/bootstrap-theme.min.css" %}">
         <script defer src="{% static "vendor/fontawesome.js" %}"></script>
+        {% include "head.html" %}
 
         {% block head %}{% endblock %}
 
@@ -35,132 +33,7 @@
     <!--[if lt IE 8]><p>Internet Explorer version 8 or any modern web browser is required to use this website, sorry.<![endif]-->
     <!--[if gt IE 7]><!-->
 
-    <nav class="navbar navbar-inverse navbar-fixed-top">
-      <div class="container-fluid">
-        <div class="navbar-header">
-          <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar-collapse-target" aria-expanded="false">
-            <span class="sr-only">Toggle navigation</span>
-            <span class="icon-bar"></span>
-            <span class="icon-bar"></span>
-            <span class="icon-bar"></span>
-          </button>
-          <a class="navbar-brand" href="/" style="color: #EEE; font-weight: bold;">
-              <img alt="GovReady Q logo" src="{% static "img/brand/navbar-logo.png" %}" width="110px;" style="float: left; margin: -2px 20px;">
-              {% if request.organization  %}
-                {% with logo=request.organization.get_logo %}
-                  {% if logo %}
-                    <img src="{{logo.url}}" height="30" alt="Organization Logo" style="float: left; margin: -5px 5px;">
-                  {% else %}
-                    <span class="glyphicon glyphicon-globe"></span>
-                  {% endif %}
-                {% endwith %}
-                <span style="margin-left: .5em;">{{request.organization.name}}</span>
-              {% else %}
-                {{request.get_host}}
-              {% endif %}
-          </a>
-        </div>
-        <div id="navbar-collapse-target" class="collapse navbar-collapse">
-          {% comment %}
-          <ul class="nav navbar-nav">
-            <li class="active"><a href="/">System Catalog</a></li>
-          </ul>
-          {% endcomment %}
-          <ul class="nav navbar-nav navbar-right">
-            {# On some special pages like the homepage and login page, we allow users who are not members of the organization to view the page so that they may log in. When enterprise SSO is used, the user might even be logged in in this state. But if they are not a part of the organization, we can't show these links and we don't have profile information for the user so we can't query for that either. #}
-            {% if request.user.is_authenticated and request.user.localized_to %}
-            <li class="dropdown">
-              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
-                MENU
-                <span class="caret"></span>
-              </a>
-              <ul class="dropdown-menu">
-                <li><a href="/projects">Projects</a></li>
-                <li><a href="/store">Compliance Apps</a></li>
-                {% if user.can_see_org_settings or user.is_staff %}
-                  <li role="separator" class="divider"></li>
-                  <li><a href="/settings">Settings</a></li>
-                {% endif %}
-                {% if user.is_staff %}
-                  <li><a href="{% url "guidedmodules_analytics" %}">Analytics</a></li>
-                {% endif %}
-              </ul>
-            </li>
-
-            <li class="dropdown">
-              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false" id="user-menu-dropdown">
-                {% with url=request.user.get_profile_picture_absolute_url %}
-                  {% if url %}
-                    <img src="{{url}}" height="30" alt="Profile Picture"
-                      style="margin: -5px 5px;">
-                  {% endif %}
-                {% endwith %}
-                {{request.user}}
-                <span class="caret"></span>
-              </a>
-              <ul class="dropdown-menu">
-                <li><a href="{{user.user_settings_task_create_if_doesnt_exist.get_absolute_url}}" id="user-menu-account-settings">Account Settings</a></li>
-                <li><a href="/api-keys">Your API Keys</a></li>
-                <li role="separator" class="divider"></li>
-                <li><a href="/accounts/logout/">Log Out</a></li>
-              </ul>
-            </li>
-
-            {% notifications_unread as unread_count %}
-            <li class="dropdown">
-              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"><span class="badge">{{ unread_count }}</span> <span class="caret"></span></a>
-              <ul class="dropdown-menu">
-                <li>
-                    <div style="display: block; padding: 3px 20px; clear: both; font-weight: 400; line-height: 1.42857143; white-space: nowrap;"> {# copied bootstrap's .dropdown-menu>li>a styles so we can have an drop-down entry that isn't a link #}
-                        <div style="font-size: 90%; text-align: right; color: #444;">
-                            {% if request.user.notifications.all.count > 0 %}
-                                <a href="/user/notifications">View All</a>
-                                {% if unread_count > 0 %}
-                                |
-                                <a href="#"
-                                   onclick="$(this).parents('.dropdown').find('.badge').text('0'); return mark_notifications_read({ upto_id: {{request.user.notifications.all.0.id}} })">Mark All Read</a>
-                                {% endif %}
-                            {% else %}
-                                No notifications.
-                            {% endif %}
-                        </div>
-                    </div>
-                </li>
-
-                {% for n in request.user.notifications.all|slice:":5" %}
-                  <li class="notification {% if n.unread %}unread{% endif %}" data-notification-id="{{n.id}}">
-                    {# the link has an onclick handler that cancels the click, runs ajax to mark the notification as read, and then on the ajax callback redirects to the target url #}
-                    <a
-                        href="{% if n.target and not n.target.supress_link_from_notifications %}{{n.target|get_notification_link:n}}{% else %}javascript:false;{% endif %}"
-                        onclick="return mark_notifications_read({ id: {{n.id}} }{% if n.target and not n.target.supress_link_from_notifications %}, function() { window.location = '{{n.target|get_notification_link:n|escapejs}}'; }{% endif %})">
-                        <span>{{ n.actor }} {{ n.verb }} {% if n.target %}{{ n.target }}{% endif %}</span>
-                        {{ n.timesince }} ago
-                    </a>
-                  </li>
-                {% endfor %}
-              </ul>
-            </li>
-
-            {% elif request.user.is_authenticated %}
-              {# The user is logged in but is not a member of the organization so we can't query for profile information. #}
-
-              <li class="dropdown">
-                <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false" id="user-menu-dropdown">
-                  {{request.user}}
-                  <span class="caret"></span>
-                </a>
-                <ul class="dropdown-menu">
-                  <li><a href="/accounts/logout/">Log Out</a></li>
-                </ul>
-              </li>
-
-            {% elif LOGIN_ENABLED %}
-            <li><a href="{% url "account_login" %}">Log In</a></li>
-            {% endif %}
-          </ul>          
-        </div><!-- /.navbar-collapse -->
-      </div><!-- /.container-fluid -->
-    </nav>
+    {% include "navbar.html" %}
 
     {% block contextbar %}
     <div id="context-bar">

--- a/templates/head.html
+++ b/templates/head.html
@@ -1,0 +1,1 @@
+{# this file is empty but is provided as a template path that can be overridden #}

--- a/templates/navbar-notifications.html
+++ b/templates/navbar-notifications.html
@@ -1,0 +1,37 @@
+{% load notifications_tags %}
+{% load notification_helpers %}
+
+{% notifications_unread as unread_count %}
+<li class="dropdown">
+  <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"><span class="badge">{{ unread_count }}</span> <span class="caret"></span></a>
+  <ul class="dropdown-menu">
+    <li>
+        <div style="display: block; padding: 3px 20px; clear: both; font-weight: 400; line-height: 1.42857143; white-space: nowrap;"> {# copied bootstrap's .dropdown-menu>li>a styles so we can have an drop-down entry that isn't a link #}
+            <div style="font-size: 90%; text-align: right; color: #444;">
+                {% if request.user.notifications.all.count > 0 %}
+                    <a href="/user/notifications">View All</a>
+                    {% if unread_count > 0 %}
+                    |
+                    <a href="#"
+                       onclick="$(this).parents('.dropdown').find('.badge').text('0'); return mark_notifications_read({ upto_id: {{request.user.notifications.all.0.id}} })">Mark All Read</a>
+                    {% endif %}
+                {% else %}
+                    No notifications.
+                {% endif %}
+            </div>
+        </div>
+    </li>
+
+    {% for n in request.user.notifications.all|slice:":5" %}
+      <li class="notification {% if n.unread %}unread{% endif %}" data-notification-id="{{n.id}}">
+        {# the link has an onclick handler that cancels the click, runs ajax to mark the notification as read, and then on the ajax callback redirects to the target url #}
+        <a
+            href="{% if n.target and not n.target.supress_link_from_notifications %}{{n.target|get_notification_link:n}}{% else %}javascript:false;{% endif %}"
+            onclick="return mark_notifications_read({ id: {{n.id}} }{% if n.target and not n.target.supress_link_from_notifications %}, function() { window.location = '{{n.target|get_notification_link:n|escapejs}}'; }{% endif %})">
+            <span>{{ n.actor }} {{ n.verb }} {% if n.target %}{{ n.target }}{% endif %}</span>
+            {{ n.timesince }} ago
+        </a>
+      </li>
+    {% endfor %}
+  </ul>
+</li>

--- a/templates/navbar.html
+++ b/templates/navbar.html
@@ -1,0 +1,90 @@
+{% load static %}
+
+<nav class="navbar navbar-inverse navbar-fixed-top">
+  <div class="container-fluid">
+    <div class="navbar-header">
+      <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar-collapse-target" aria-expanded="false">
+        <span class="sr-only">Toggle navigation</span>
+        <span class="icon-bar"></span>
+        <span class="icon-bar"></span>
+        <span class="icon-bar"></span>
+      </button>
+      <a class="navbar-brand" href="/" style="color: #EEE; font-weight: bold;">
+          <img alt="GovReady Q logo" src="{% static "img/brand/navbar-logo.png" %}" width="110px;" style="float: left; margin: -2px 20px;">
+          {% if request.organization  %}
+            {% with logo=request.organization.get_logo %}
+              {% if logo %}
+                <img src="{{logo.url}}" height="30" alt="Organization Logo" style="float: left; margin: -5px 5px;">
+              {% else %}
+                <span class="glyphicon glyphicon-globe"></span>
+              {% endif %}
+            {% endwith %}
+            <span style="margin-left: .5em;">{{request.organization.name}}</span>
+          {% else %}
+            {{request.get_host}}
+          {% endif %}
+      </a>
+    </div>
+    <div id="navbar-collapse-target" class="collapse navbar-collapse">
+      <ul class="nav navbar-nav navbar-right">
+        {# On some special pages like the homepage and login page, we allow users who are not members of the organization to view the page so that they may log in. When enterprise SSO is used, the user might even be logged in in this state. But if they are not a part of the organization, we can't show these links and we don't have profile information for the user so we can't query for that either. #}
+        {% if request.user.is_authenticated and request.user.localized_to %}
+          <li class="dropdown">
+            <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
+              MENU
+              <span class="caret"></span>
+            </a>
+            <ul class="dropdown-menu">
+              <li><a href="/projects">Projects</a></li>
+              <li><a href="/store">Compliance Apps</a></li>
+              {% if user.can_see_org_settings or user.is_staff %}
+                <li role="separator" class="divider"></li>
+                <li><a href="/settings">Settings</a></li>
+              {% endif %}
+              {% if user.is_staff %}
+                <li><a href="{% url "guidedmodules_analytics" %}">Analytics</a></li>
+              {% endif %}
+            </ul>
+          </li>
+
+          <li class="dropdown">
+            <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false" id="user-menu-dropdown">
+              {% with url=request.user.get_profile_picture_absolute_url %}
+                {% if url %}
+                  <img src="{{url}}" height="30" alt="Profile Picture"
+                    style="margin: -5px 5px;">
+                {% endif %}
+              {% endwith %}
+              {{request.user}}
+              <span class="caret"></span>
+            </a>
+            <ul class="dropdown-menu">
+              <li><a href="{{user.user_settings_task_create_if_doesnt_exist.get_absolute_url}}" id="user-menu-account-settings">Account Settings</a></li>
+              <li><a href="/api-keys">Your API Keys</a></li>
+              <li role="separator" class="divider"></li>
+              <li><a href="/accounts/logout/">Log Out</a></li>
+            </ul>
+          </li>
+
+          {% include "navbar-notifications.html" %}
+
+        {% elif request.user.is_authenticated %}
+          {# The user is logged in but is not a member of the organization so we can't query for profile information. #}
+
+          <li class="dropdown">
+            <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false" id="user-menu-dropdown">
+              {{request.user}}
+              <span class="caret"></span>
+            </a>
+            <ul class="dropdown-menu">
+              <li><a href="/accounts/logout/">Log Out</a></li>
+            </ul>
+          </li>
+
+        {% elif LOGIN_ENABLED %}
+          <li><a href="{% url "account_login" %}">Log In</a></li>
+        {% endif %}
+      </ul>          
+    </div><!-- /.navbar-collapse -->
+  </div><!-- /.container-fluid -->
+</nav>

--- a/tools/simple_iam_proxy_server/README.md
+++ b/tools/simple_iam_proxy_server/README.md
@@ -53,4 +53,8 @@ In a second console, start GovReady-Q:
 
 In the default configuration, the proxy server is listening at http://localhost:8000 and forwards to the backend GovReady-Q server listening on port 8001. GovReady-Q is configured in `local/environment.json` to know what its public URL is, and the default `http://localhost:8000` will correctly match this setup.
 
+You can also try starting up GovReady-Q using our docker image:
+
+	deployment/docker/docker_container_run.sh --relaunch --bind 8001 -- -e PROXY_AUTHENTICATION_USER_HEADER=IAM-Username -e PROXY_AUTHENTICATION_EMAIL_HEADER=IAM-Email
+
 ---


### PR DESCRIPTION
This PR reorganizes our templates to make it easier to add custom CSS and override the header nav bar, by moving the nav bar and the notifications drop-down into their own templates. Documentation is added for how to do this and how to package it up as a Docker image with custom branding.