### PR TITLE
Typo fixes, only in docs/source/*.md

### DIFF
--- a/docs/source/Apps.md
+++ b/docs/source/Apps.md
@@ -128,7 +128,7 @@ The below screenshot of the `AppSource` module in the Django admin interfaces sh
 
 ![Screenshot of AppSource from GovReady-Q Django admin interface](assets/appsources.png)
 
-The `AppSource` module also contains fields to indicate to which subdomains of the deployment the source's apps are avaiable.
+The `AppSource` module also contains fields to indicate to which subdomains of the deployment the source's apps are available.
 
 ### App Source virtual filesystem layout
 

--- a/docs/source/Automation.md
+++ b/docs/source/Automation.md
@@ -58,7 +58,7 @@ Every call to the API requires an API key. Each user has three API keys listed o
 
 * The read-write API key gives external tools the ability to see and make changes to anything the associated user can see and make changes to on Q. 
 
-* The write-only API key gives external tools the ability to make changes to anything the associated user can make changes to on Q but does not include the abiliy to see any data values stored in Q. The write-only key is useful in situations where the external tool needs to be able to upload data but does not need to read existing data values.
+* The write-only API key gives external tools the ability to make changes to anything the associated user can make changes to on Q but does not include the ability to see any data values stored in Q. The write-only key is useful in situations where the external tool needs to be able to upload data but does not need to read existing data values.
 
 ### Getting data from the app using the GET API
 

--- a/docs/source/CreatingApps.md
+++ b/docs/source/CreatingApps.md
@@ -1,6 +1,6 @@
 # Compliance App Authoring Tutorial
 
-This is a step-by-step guide to creating compliance apps using the Docker version of the GovReady-Q Commpliance Server.
+This is a step-by-step guide to creating compliance apps using the Docker version of the GovReady-Q Compliance Server.
 
 In this guide you will learn how to:
 
@@ -16,7 +16,7 @@ In this guide you will learn how to:
 
 GovReady-Q compliance apps are generally developed in an off-line development environment, usually on the app developer's macOS or Linux workstation --- any environment that can run Docker. In this environment, the compliance app data files will be stored in a local directory. This guide assumes the use of a local workstation for development and discusses production deployment at the end.
 
-(Once the apps are ready to be published to the rest of the organization, the apps can be uploaded to a git repository, such as Github or an on-premis equivalent. The production instance of GovReady-Q will typically read compliance apps from the git repository directly and not from a local disk.)
+(Once the apps are ready to be published to the rest of the organization, the apps can be uploaded to a git repository, such as GitHub or an on-premise equivalent. The production instance of GovReady-Q will typically read compliance apps from the git repository directly and not from a local disk.)
 
 On the development workstation, create a folder to hold GovReady's install script, the GovReady-Q database (in development, Sqlite is used), and the compliance apps that you will be authoring. The folder can be anywhere:
 
@@ -40,7 +40,7 @@ Next download GovReady's [docker\_container\_run.sh](docker_container_run.sh) sc
 `docker_container_run.sh` supports a variety of [advanced configuration settings](README.md#advanced-configuration) via command line parameters. The ones we care about for developing compliance apps are:
 
 * `--sqlitedb /path/to/govready-q-database.sqlite`, which sets an absolute path to a Sqlite database that holds all persistent information across container runs
-* `--appsdevdir /path/to/apps`, which sets an absolute path to the directoy in which app YAML files will be developed
+* `--appsdevdir /path/to/apps`, which sets an absolute path to the directory in which app YAML files will be developed
 * `--relaunch`, which removes any existing `govready-q` Docker container if one is running
 
 Download and start GovReady-Q:
@@ -101,7 +101,7 @@ In this section we'll create our first compliance app. The app will appear in th
 
 ![Compliance apps catalog](assets/appcatalog.png)
 
-Let's create our first commpliance app! Use the command below:
+Let's create our first compliance app! Use the command below:
 
 	docker container exec -it govready-q ./manage.py compliance_app host myfirstapp
 
@@ -310,13 +310,13 @@ Copy the public key in the newly generated file `repo_deploy_key.pub` into the d
 
 As with local development, the production system's compliance app catalog may be cached. To see new apps, restart the production instance of GovReady-Q.
 
-See [App Sources](AppSources.html) for more information about how to configure your production instance of GovReady-Q to load apps from local filesystem directories, git repositories (including on-prem git repositories), or Github.
+See [App Sources](AppSources.html) for more information about how to configure your production instance of GovReady-Q to load apps from local filesystem directories, git repositories (including on-prem git repositories), or GitHub.
 
 ### Advanced setups for development with a repository of apps
 
 In this guide we have used the `--appsdevdir` command to specify a location in which app YAML files and assets are stored. In a small setup, all apps could be stored in a subdirectory of the location given to `--appsdevdir`. But you may want to separate apps into different folders, such as if they are divided between folders in a single git repository or across multiple git repositories, then a more advanced configuration of GovReady-Q is necessary.
 
-Imagine the following directory structure where two Github repositories are cloned into two separate local directories within `apps`, and each has a `compliance_apps` directory holding its apps:
+Imagine the following directory structure where two GitHub repositories are cloned into two separate local directories within `apps`, and each has a `compliance_apps` directory holding its apps:
 
 	.
 	├── apps (`--appsdevdir` directory)

--- a/docs/source/CustomBranding.md
+++ b/docs/source/CustomBranding.md
@@ -80,7 +80,7 @@ Open any page in your locally running GovReady-Q and you should see that the bac
 
 ## Keeping your templates up to date
 
-With each new released verison of GovReady-Q, there is the possibility that the stock templates have changed. Some changes may require you to re-engineer your template overrides to preserve functionality.
+With each new released version of GovReady-Q, there is the possibility that the stock templates have changed. Some changes may require you to re-engineer your template overrides to preserve functionality.
 
 ## Creating a custom Docker image
 
@@ -108,7 +108,7 @@ RUN mkdir branding
 COPY . branding
 ```
 
-Finally, you'll need some commands to adjust permissions, to activate the branding package when GovReady-Q starts, and to prepare teh static assets to be served. The complete Dockerfile should look like this:
+Finally, you'll need some commands to adjust permissions, to activate the branding package when GovReady-Q starts, and to prepare the static assets to be served. The complete Dockerfile should look like this:
 
 ```Dockerfile
 # Build an image on top of the stock GovReady-Q image.

--- a/docs/source/DataDesign_guidedmodules.md
+++ b/docs/source/DataDesign_guidedmodules.md
@@ -11,7 +11,7 @@ Information gathering is at the heart of GovReady-Q's `guidedmodules` data model
 
 The tables are described is additional detail below and their relationships are summarized in the following diagram:
 
-![Guildedmodules data model (not all tables represented)](assets/govready-q-guidedmodules-erd.png)
+![Guidedmodules data model (not all tables represented)](assets/govready-q-guidedmodules-erd.png)
 
 <!-- The image above was generated with:
 
@@ -22,7 +22,7 @@ The tables are described is additional detail below and their relationships are 
 Compliance Apps (Questions, Business Logic, and Templates)
 ----------------------------------------------------------
 
-The smallest unit of a compliance app is a `Question`. Questions come in different types, such as text, number, and date ([full list](Schema.html)). Questions are grouped into questionnaires called `Modules`. And Modules are grouped into `AppInstances`, which are the versions of a compliance app that are loaded into the GovReady-Q database. AppInstances are loaded from AppSources, which define how to load compliance apps from remote sources such as GitHub or an on-premesis enterprise source control system.
+The smallest unit of a compliance app is a `Question`. Questions come in different types, such as text, number, and date ([full list](Schema.html)). Questions are grouped into questionnaires called `Modules`. And Modules are grouped into `AppInstances`, which are the versions of a compliance app that are loaded into the GovReady-Q database. AppInstances are loaded from AppSources, which define how to load compliance apps from remote sources such as GitHub or an on-premise enterprise source control system.
 
 `AppInstances`, `Modules`, and `Questions` define the structure of a compliance app but do not store any user-submitted content. Separating structure from content is a common pattern in application design and is motivated by several GovReady-Q goals:
 
@@ -31,11 +31,11 @@ The smallest unit of a compliance app is a `Question`. Questions come in differe
 * One type of Question allows the user to choose a complete set of answers to another Module, which allows question answers (i.e. user data) to be accessed from the business logic and templates of not only the Modules the Questions are defined in but also from other Modules and even other compliance apps.
 * Compliance apps are versioned and apps that have been started by users can be updated in non-destructive ways, preserving answered questionnaires over the course of years,
 
-GovReady-Q administrators will configure GovReady-Q with an `AppSource` record for each source of compliance apps that will be made available to GovReady-Q users. Each AppSource has a "slug," which is its unique name on the GovReady-Q installation. An AppSource also defines a remote location --- such as a GitHub repository, local directory, or on-premis git server --- to query for compliance apps, which will be listed in the app catalog. A typical GovReady-Q installation might have one AppSource providing compliance apps published by GovReady PBC and a second AppSource for providing compliance apps defined by the organization. Each AppSource defines the remote location as well as local permissions such as which compliance apps in the store to make available to GovReady-Q users and, in a multi-tenant setup, which site Organizations can see the compliance apps from the AppSource. See [App Sources](AppSources.html) for more information.
+GovReady-Q administrators will configure GovReady-Q with an `AppSource` record for each source of compliance apps that will be made available to GovReady-Q users. Each AppSource has a "slug," which is its unique name on the GovReady-Q installation. An AppSource also defines a remote location --- such as a GitHub repository, local directory, or on-premise git server --- to query for compliance apps, which will be listed in the app catalog. A typical GovReady-Q installation might have one AppSource providing compliance apps published by GovReady PBC and a second AppSource for providing compliance apps defined by the organization. Each AppSource defines the remote location as well as local permissions such as which compliance apps in the store to make available to GovReady-Q users and, in a multi-tenant setup, which site Organizations can see the compliance apps from the AppSource. See [App Sources](AppSources.html) for more information.
 
 Each time a compliance app is started by a user, an `AppSource` is queried for the latest version of the selected compliance app and an `AppInstance` is created that holds the complete set of questions, business logic, and templates defined in that version of the compliance app. Therefore there will be a separate AppInstance in the database for every version of every compliance app being used by GovReady-Q users.
 
-Each AppInstance links back to the AppSource it was created from (the "source" field) and holds the name it was given (the "appname" field). Each AppInstance brings along with it the `Modules` and `Questions` defined in that version of the compliance app. In other words, Modules and Questions are specific to a AppInstancex. Therefore if two versions of a compliane app are present in the database, a question that exists in both versions of the app is represented as two Question records --- one for each version of the app. Similarly, there will be (at least) two Modules, one for each version of the app.
+Each AppInstance links back to the AppSource it was created from (the "source" field) and holds the name it was given (the "appname" field). Each AppInstance brings along with it the `Modules` and `Questions` defined in that version of the compliance app. In other words, Modules and Questions are specific to a AppInstancex. Therefore if two versions of a compliance app are present in the database, a question that exists in both versions of the app is represented as two Question records --- one for each version of the app. Similarly, there will be (at least) two Modules, one for each version of the app.
 
 All compliance apps have at least two `Modules`. The first module, whose "module_name" identifier is always `app`, defines the layout of the starting page of a compliance app, which can list one or more `Modules` to complete:
 
@@ -108,7 +108,7 @@ Database Query Examples
 
 *Scenario: Unix File Server App contains a text-type question named "Hostname". Many users have finished answering all of the questions in the app. However, our reviewers have only approved some of the answers so far. I want to write an SQL query to return all approved answers to the "Hostname" question.*
 
-In this section, we will build up an SQL query to extract the data identified in the scenario. The query will be built progressively over the next several sections to explain the rationale behind the GovReady-Q data model. Some of GovReady-Q's design choices --- including separating the defintions of compliance apps from user-submitted data, as well as recording an immutable history of user answers --- are reflected in the SQL queries below. The complete SQL query is shown at the end.
+In this section, we will build up an SQL query to extract the data identified in the scenario. The query will be built progressively over the next several sections to explain the rationale behind the GovReady-Q data model. Some of GovReady-Q's design choices --- including separating the definitions of compliance apps from user-submitted data, as well as recording an immutable history of user answers --- are reflected in the SQL queries below. The complete SQL query is shown at the end.
 
 You may prefer to use the GovReady-Q API instead of writing a low-level database query, but this example is illustrative for understanding GovReady-Q's data model no matter which method you use to query the data.
 

--- a/docs/source/DataDesign_siteapp.md
+++ b/docs/source/DataDesign_siteapp.md
@@ -5,6 +5,6 @@ The diagram below provides a summary representation of GovReady-Q's Django `site
 
 ![Siteapp data model (not all tables represented)](assets/govready-q-siteapp-erd.png)
 
-GovReady-Q is multi-tenant. The siteapp data model represents users who are uniquely associated with an oragnization and have membership in different organization projects. Users must be invited to projects.
+GovReady-Q is multi-tenant. The siteapp data model represents users who are uniquely associated with an organization and have membership in different organization projects. Users must be invited to projects.
 
-Access control is based on organization and projects. Information cannot be shared acrossed organizations and only limited information can be shared across projects within an organization.
+Access control is based on organization and projects. Information cannot be shared across organizations and only limited information can be shared across projects within an organization.

--- a/docs/source/Permissions.md
+++ b/docs/source/Permissions.md
@@ -14,7 +14,7 @@ GovReady-Q tracks the following major entities
 * Membership - associating individual users with organizations and systems
 * Tasks/Modules - coherent grouping of questions and educational content
 * Questions/Answers - specific snippet of content within a Task
-* Templates - drives automatic generation of artifacts, supporting variable subsitution
+* Templates - drives automatic generation of artifacts, supporting variable substitution
 
 Users
 -----
@@ -120,7 +120,7 @@ A Task has an editor, which is the User who has primary responsibility for compl
 A User has both *read* and *write* access to a Task if any of the following are true:
 
 * They are the editor of the Task.
-* They are a _member_ or _adminstrator_ of the Project that the Task belongs to.
+* They are a _member_ or _administrator_ of the Project that the Task belongs to.
 
 A User with *read* access can see the Task on the page for the Project that it belongs to and can see all of its questions, answers, and outputs and can start a Discussion on questions.
 

--- a/docs/source/RUNBOOK.md
+++ b/docs/source/RUNBOOK.md
@@ -37,7 +37,7 @@ As of this writing, we are looking at two main paths for running Q in a Cloud Se
 
 Pivotal's implementation of Cloud Foundry as a service is PWS: Pivotal Web Services.  In this doc PWS refers to this platform, and CF or Foundry refers to any implementation of Cloud Foundry.
 
-This doc, as of July 2016, is focussed on operationalizing Q for PWS.
+This doc, as of July 2016, is focused on operationalizing Q for PWS.
 
 **AWS**
 

--- a/docs/source/Schema.md
+++ b/docs/source/Schema.md
@@ -147,7 +147,7 @@ The document can also be stored in a separate file by replacing the document dat
 	...
 	Hello!
 
-When using a separate file, the document properties (`id`, `title`, and `format`) are given in a YAML block at the top of the file. A line containig just three dots signifies the end of the YAML block, separating it from the document template. The document template follows.
+When using a separate file, the document properties (`id`, `title`, and `format`) are given in a YAML block at the top of the file. A line containing just three dots signifies the end of the YAML block, separating it from the document template. The document template follows.
 
 ### Document Format
 
@@ -473,7 +473,7 @@ This question type should be avoided if one of the other question types specifie
 
 ### Imputing Answers
 
-The answer to one question may provide the answer to another. In such cases, the latter question is said to have an imputed value and the user is not asked to answer the question. To imput a value, specify on the question whose value is being imputed:
+The answer to one question may provide the answer to another. In such cases, the latter question is said to have an imputed value and the user is not asked to answer the question. To impute a value, specify on the question whose value is being imputed:
 
     impute:
       - condition: q1 == 'no'
@@ -510,7 +510,7 @@ In both conditions and `expression`-type values, as well as in documents, the va
 * `project.question_id`, `project.question_id.subquestion_id`, etc. to access questions within the project
 * `organization`, which gives the organization name
 
-We also have a funtion to retreive the URL of a module's static assets, e.g.:
+We also have a function to retrieve the URL of a module's static assets, e.g.:
 
 	<script src="{{static_asset_path_for('myscript.js')}}"></script>
 

--- a/docs/source/deploy_docker.md
+++ b/docs/source/deploy_docker.md
@@ -99,9 +99,9 @@ You can use a Sqlite file stored on the host machine:
 
 	./docker_container_run.sh --sqlitedb /path/to/govready-q-database.sqlite
 
-You must specify an absolute path. The path is mounted using a Docker bind mount into the container filesytem.
+You must specify an absolute path. The path is mounted using a Docker bind mount into the container filesystem.
 
-The file must be readable & writable by the container process, which is running as user 1000/group 1000. Although the container is running as a user isolated from the host environment, filesystem permissions for mounted files are based on comparing the raw user/group IDs of the file's owner/group on the host to the raw user/group ID of the process running in the container. Consider granting user 1000 read/write permission to the database using ACLs:
+The file must be readable and writable by the container process, which is running as user 1000/group 1000. Although the container is running as a user isolated from the host environment, filesystem permissions for mounted files are based on comparing the raw user/group IDs of the file's owner/group on the host to the raw user/group ID of the process running in the container. Consider granting user 1000 read/write permission to the database using ACLs:
 
 	setfacl -m u:1000:rw /path/to/govready-q-database.sqlite
 
@@ -134,7 +134,7 @@ You can also use a MySQL or MariaDB server using the syntax `mysql://USER:PASSWO
 ### Configuring email
 
 GovReady-Q sends outbound emails for notifications about invitations and discussions.
-It also receives inbound emails --- replies to dicussion notifications can be used to
+It also receives inbound emails --- replies to discussion notifications can be used to
 post discussion comments by email.
 
 To configure outbound email, use:
@@ -244,9 +244,9 @@ See the [uWSGI](http://uwsgi-docs.readthedocs.io/) application server JSON proce
 
 Periodically there will be a new release of GovReady-Q as an new image on the Docker Hub. Updating is easy by re-running the same commands again.
 
-1) There may be an update to `docker_container_run.sh`. Since this script is not a part of the Docker image, you will need to get it again from this Github repository.
+1) There may be an update to `docker_container_run.sh`. Since this script is not a part of the Docker image, you will need to get it again from this GitHub repository.
 
-2) You should be using a persistent database as described above. When using a persistent database, it is safe to detroy the `govready-q` Docker container and start a new one to deploy an update.
+2) You should be using a persistent database as described above. When using a persistent database, it is safe to destroy the `govready-q` Docker container and start a new one to deploy an update.
 
 3) Use the same arguments to `docker_container_run.sh` as when you started the container the last time, but add `--relaunch` to kill the previous container --- you cannot have two containers with the same name or two containers listening on the same port. (You can change the name and port, as described above, if you would like to keep the old container running.)
 

--- a/docs/source/deploy_ubuntu.md
+++ b/docs/source/deploy_ubuntu.md
@@ -2,7 +2,7 @@
 
 This document provides some basic guidance on setting up GovReady-Q on an Ubuntu 16.04 server with Nginx. These commands should be run from the root directory of the GovReady-Q code repository.
 
-Update system packages and install packages helpful for GovReay-Q:
+Update system packages and install packages helpful for GovReady-Q:
 
 	apt-get update && apt-get upgrade -y
 

--- a/docs/source/introduction.md
+++ b/docs/source/introduction.md
@@ -146,7 +146,7 @@ For a more detailed list of software dependencies and requirements see:
 
 The following diagram depicts a generic, high-level system architecture GovReady-Q deployment including external ports and protocols. Architectures vary depending on redundancy requirements, use of containers, etc.
 
-![System architecure of a generic GovReady-Q deployment](assets/govready-q_system_architecture.png)
+![System architecture of a generic GovReady-Q deployment](assets/govready-q_system_architecture.png)
 
 
 ## Downloading GovReady-Q


### PR DESCRIPTION
Words fixed: abiliy acrossed adminstrator architecure avaiable commpliance compliane defintions detroy dicussion directoy filesytem focussed funtion Github GovReay Guildedmodules imput oragnization premesis premis retreive subsitution teh verison