### PR TITLE
Fix a major markdown/Sphinx mis-parse issue in docker deploy docs

### DIFF
--- a/docs/source/deploy_docker.md
+++ b/docs/source/deploy_docker.md
@@ -1,6 +1,6 @@
 # Deploying GovReady-Q with Docker
 
-#### GovReady-Q on Docker Hub
+## GovReady-Q on Docker Hub
 
 | Container                 | Where                                                                                                           |
 |---------------------------|-----------------------------------------------------------------------------------------------------------------|


### PR DESCRIPTION
There's an issue on the Docker deployment docs where most of the section headers are at the wrong level, resulting in issues with the ToC for this page, as well as display issues in the text itself.

This turns out to be because markdown allows for headers in any arbitrary order, whereas (based on debugging) Sphinx and/or reStructuredText appears to rely on the first h4-level header being after the first h3-level header (and in turn after the first h2-level header).

Changing the second header encountered from an h4 to an h2 fixes this issue in the resulting HTML output.

Found while working on #581, but this issue is succinct-enough and major-enough that it feels worthwhile to break it out and submit individually.