### PR TITLE
Refactor documentation...

### DIFF
--- a/docs/source/Deploy.md
+++ b/docs/source/Deploy.md
@@ -5,9 +5,11 @@ Deploying GovReady-Q
    :maxdepth: 3
    :caption: In This Section:
 
+   requirements.md
    deploy_local_dev.md
    deploy_docker.md
    deploy_rhel7_centos7.md
    deploy_ubuntu.md
    Environment.md
+   enterprise_sso.md
    CustomBranding.md

--- a/docs/source/Environment.md
+++ b/docs/source/Environment.md
@@ -1,7 +1,8 @@
-Environment Settings
-====================
+## Environment Settings
 
-A production system may need to set more options in `local/environment.json`. Here are recommended settings:
+### Production Deployment Environment Settings
+
+A production system deployment may need to set more options in `local/environment.json`. Here are recommended settings:
 
 	{
 	  "debug": false,
@@ -14,35 +15,21 @@ A production system may need to set more options in `local/environment.json`. He
 	  "static": "/root/public_html"
 	}
 
-Custom Branding
----------------
+### Enterprise Single-Sign On Environment Settings
 
-You may override the templates and stylesheets that are used for GovReady-Q's branding by adding a new key named `branding` that is the name of an installed Django app Python module (i.e. created using `manage.py startapp`) that holds templates and static files. See [Applying Custom Organization Branding](CustomBranding.html).
-
-Enterprise Login
-----------------
-
-### Proxy Authentication Sever
-
-GovReady-Q can be deployed behind a reverse proxy that authenticates users and passes the authenticated user's username and email address in HTTP headers. In this configuration:
-
-* The user points their browser to the reverse proxy authentication server.
-* The proxy authenticates users and proxies the request to GovReady-Q if and only if the user is authenticated and authorized to access GovReady-Q. The proxy passes the user's username and email address in HTTP headers of the proxy's choosing. 
-* GovReady-Q will create a user account for a new user or treat the user as logged in as soon as the user requests a page. Therefore, there is no sign-up or log-in process within GovReady-Q when a proxy authentication server is used.
-* All other authentication methods to GovReady-Q are disabled when proxy authentication is enabled. Therefore you should ensure that the Django admin's username matches the admin's username as provided by the proxy server. Otherwise, you will lose access to the admin page. However, if there is a mismatch, you may disable proxy authentication, log in to the Django admin with your admin username and password, and change your admin username to match the username sent by the proxy server.
-* GovReady-Q must be run at a private address that cannot be accessed except through the proxy server.
+GovReady-Q supports Enterprise Login via IAM (Identity and Access Management). In this configuration, GovReady-Q is deployed behind a reverse proxy that authenticates users and passes the authenticated user’s username and email address in HTTP headers.
 
 To activate reverse proxy authentication, add the header names used by the proxy to your `local/environment.json`, e.g.:
 
-	{
-	  "trust-user-authentication-headers": {
-	    "username": "X-Authenticated-User-Username",
-	    "email": "X-Authenticated-User-Email"
-	  },
-	}
+  {
+    "trust-user-authentication-headers": {
+      "username": "X-Authenticated-User-Username",
+      "email": "X-Authenticated-User-Email"
+    },
+  }
 
-The proxy server must be configured to proxy to GovReady-Q's private address. But the `host` and `https` settings in GovReady-Q's `local/environment.json` file must reflect the host and protocol used in the URL the *end user* uses to access GovReady-Q. They do *not* need to match the address that the proxy server uses to reach the GovReady-Q server.
+GovReady-Q must be run at a private address that cannot be accessed except through the proxy server. The proxy server must be configured to proxy to GovReady-Q's private address. See [Enterprise Single-Sign On / Login](enterprise_sso.html) for additional details.
 
-Per the [Django Documentation](https://docs.djangoproject.com/en/dev/howto/auth-remote-user/) on authentication using REMOTE_USER, you must be sure that your proxy server always sets or strips the special username and email headers, including headers that normalize to the same Django key (in particular headers with underscores), from the client request and **does not permit an end-user to submit a fake (or “spoofed”) header value**.
+### Custom Branding Environment Settings
 
-We have an example reverse proxy authentication server at https://github.com/GovReady/govready-q/tree/master/tools/simple_iam_proxy_server which can be used for debugging purposes.
+You may override the templates and stylesheets that are used for GovReady-Q's branding by adding a new key named `branding` that is the name of an installed Django app Python module (i.e. created using `manage.py startapp`) that holds templates and static files. See [Applying Custom Organization Branding](CustomBranding.html).

--- a/docs/source/deploy_local_dev.md
+++ b/docs/source/deploy_local_dev.md
@@ -1,13 +1,6 @@
 Installing GovReady-Q Compliance Server on Workstations for Development
 =======================================================================
 
-## Installing with Docker
-
-The easiest way to get started with GovReady-Q is to launch Q through Docker.
-
-See [Deploying GovReady-Q with Docker](deploy_docker.md).
-
-
 ## Installing source code on workstations to contribute
 
 You can also install this repository on your workstation to contribute to improving GovReady-Q's functionality.

--- a/docs/source/enterprise_sso.md
+++ b/docs/source/enterprise_sso.md
@@ -1,0 +1,26 @@
+## Enterprise Single-Sign On / Login
+
+### Proxy Authentication Sever
+
+GovReady-Q can be deployed behind a reverse proxy that authenticates users and passes the authenticated user's username and email address in HTTP headers. In this configuration:
+
+* The user points their browser to the reverse proxy authentication server.
+* The proxy authenticates users and proxies the request to GovReady-Q if and only if the user is authenticated and authorized to access GovReady-Q. The proxy passes the user's username and email address in HTTP headers of the proxy's choosing. 
+* GovReady-Q will create a user account for a new user or treat the user as logged in as soon as the user requests a page. Therefore, there is no sign-up or log-in process within GovReady-Q when a proxy authentication server is used.
+* All other authentication methods to GovReady-Q are disabled when proxy authentication is enabled. Therefore you should ensure that the Django admin's username matches the admin's username as provided by the proxy server. Otherwise, you will lose access to the admin page. However, if there is a mismatch, you may disable proxy authentication, log in to the Django admin with your admin username and password, and change your admin username to match the username sent by the proxy server.
+* GovReady-Q must be run at a private address that cannot be accessed except through the proxy server.
+
+To activate reverse proxy authentication, add the header names used by the proxy to your `local/environment.json`, e.g.:
+
+  {
+    "trust-user-authentication-headers": {
+      "username": "X-Authenticated-User-Username",
+      "email": "X-Authenticated-User-Email"
+    },
+  }
+
+The proxy server must be configured to proxy to GovReady-Q's private address. But the `host` and `https` settings in GovReady-Q's `local/environment.json` file must reflect the host and protocol used in the URL the *end user* uses to access GovReady-Q. They do *not* need to match the address that the proxy server uses to reach the GovReady-Q server.
+
+Per the [Django Documentation](https://docs.djangoproject.com/en/dev/howto/auth-remote-user/) on authentication using REMOTE_USER, you must be sure that your proxy server always sets or strips the special username and email headers, including headers that normalize to the same Django key (in particular headers with underscores), from the client request and **does not permit an end-user to submit a fake (or “spoofed”) header value**.
+
+We have an example reverse proxy authentication server at https://github.com/GovReady/govready-q/tree/master/tools/simple_iam_proxy_server which can be used for debugging purposes.

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -15,10 +15,10 @@ The code is open source, and [available on GitHub](The code is open source, and 
    :caption: Contents:
 
    introduction.md
-   Automation.md
-   Authoring.md
    Deploy.md
    Permissions.md
+   Authoring.md
+   Automation.md
    DataDesign.md
    Test.md
    

--- a/docs/source/introduction.md
+++ b/docs/source/introduction.md
@@ -81,69 +81,6 @@ The hosted version is an excellent solution if have one project/system you are t
 
 If you have questions about the hosted version, email <a href="mailto:info@govready.com">info@govready.com</a>.
 
-## System Requirements for GovReady-Q
-
-If you prefer, you can download and install GovReady-Q on your own servers or servers under your control.
-
-GovReady-Q is a Python 3.6, Django 2.0 application with a relational database back-end. GovReady-Q is compatible with operating systems and components generally supported by Django 2.0 and Python 3.6.
-
-GovReady-Q has been successfully deployed on multiple Linux distros (RHEL 7, CentOS 7, Ubuntu 14 & 16), as a Docker container, as Docker container in AWS Elastic Container Service, as a Docker container on OpenShift, and as a Vagrant virtual machine.
-
-We've tried to make GovReady-Q installation straightforward and complete. Our documentation includes configuring the Python uWSGI environment, installing and running testing tools, adding sources for compliance security plan apps, and setting up your admin account and initial organization.
-
-#### Hardware Requirements
-
-| Minimum Hardware |
-| --- |
-| Single server to host both multi-tenant GovReady-Q application and Database |
-| Linux-compatible hardware |
-| 2GB RAM |
-| 10 GB storage (for database) |
-
-| Recommended Hardware |
-| --- |
-| 2 servers: 1 for multi-tenant GovReady-Q application; 1 for Database Server |
-| Linux-compatible hardware (64 bit architecture; FIPS-140-2 validated cryptographic module) |
-| 8GB RAM for each server |
-| 100 GB storage (for database server) |
-
-#### Software Requirements
-
-| Required Software Packages (partial list) |
-| --- |
-| (GovReady-Q application) |
-| Python 3.6 |
-| Django 2.x |
-| Jinja 2.x |
-| uwsgi 2.x |
-| unzip |
-| graphviz |
-| pandoc |
-| Wkhtmltopdf |
-| Git 2.x |
-| supervisor |
-
-| Supported Databases |
-| --- |
-| Postgres 9.4 (psycopg2 2.7.5 adapter) |
-| Mysql 7.6 and higher (mysqlclient 1.3.12 adapter) |
-| SQLite 3.x |
-
-| Recommended Database |
-| --- |
-| Postgres 9.4 (psycopg2 2.7.5 adapter) |
-
-| SMTP Mail Server (for sending email notifications and receiving comments via email) |
-| --- |
-| Any SMTP mail server (MTA) supporting STARTTLS connections. |
-
-For a more detailed list of software dependencies and requirements see:
-* https://github.com/GovReady/govready-q/blob/master/requirements.in
-* https://github.com/GovReady/govready-q/blob/master/requirements.txt
-* https://github.com/GovReady/govready-q/blob/master/requirements_mysql.in
-* https://github.com/GovReady/govready-q/blob/master/requirements_mysql.txt
-* https://github.com/GovReady/govready-q/blob/master/Vagrantfile
-
 #### System Architecture
 
 The following diagram depicts a generic, high-level system architecture GovReady-Q deployment including external ports and protocols. Architectures vary depending on redundancy requirements, use of containers, etc.

--- a/docs/source/requirements.md
+++ b/docs/source/requirements.md
@@ -1,0 +1,68 @@
+## System Requirements for GovReady-Q
+
+GovReady-Q is a Python 3.6, Django 2.0 application with a relational database back-end. GovReady-Q is compatible with operating systems and components generally supported by Django 2.0 and Python 3.6.
+
+GovReady-Q has been successfully deployed on multiple Linux distros (RHEL 7, CentOS 7, Ubuntu 14 & 16), as a Docker container, as Docker container in AWS Elastic Container Service, as a Docker container on OpenShift, and as a Vagrant virtual machine.
+
+We've tried to make GovReady-Q installation straightforward and complete. Our documentation includes configuring the Python uWSGI environment, installing and running testing tools, adding sources for compliance security plan apps, and setting up your admin account and initial organization.
+
+### Development Deployments
+
+GovReady-Q can be deployed on a modern, single Linux/Unix/MacOS workstation (or laptop) for development and exploration.
+
+GovReady-Q can be deployed on a Windows platform through the use of our Docker container.
+
+### Production Deployments
+
+#### Hardware Requirements
+
+| Minimum Hardware |
+| --- |
+| Single server to host both multi-tenant GovReady-Q application and Database |
+| Linux-compatible hardware |
+| 2GB RAM |
+| 10 GB storage (for database) |
+
+| Recommended Hardware |
+| --- |
+| 2 servers: 1 for multi-tenant GovReady-Q application; 1 for Database Server |
+| Linux-compatible hardware (64 bit architecture; FIPS-140-2 validated cryptographic module) |
+| 8GB RAM for each server |
+| 100 GB storage (for database server) |
+
+#### Software Requirements
+
+| Required Software Packages (partial list) |
+| --- |
+| (GovReady-Q application) |
+| Python 3.6 |
+| Django 2.x |
+| Jinja 2.x |
+| uwsgi 2.x |
+| unzip |
+| graphviz |
+| pandoc |
+| Wkhtmltopdf |
+| Git 2.x |
+| supervisor |
+
+| Supported Databases |
+| --- |
+| Postgres 9.4 (psycopg2 2.7.5 adapter) |
+| Mysql 7.6 and higher (mysqlclient 1.3.12 adapter) |
+| SQLite 3.x |
+
+| Recommended Database |
+| --- |
+| Postgres 9.4 (psycopg2 2.7.5 adapter) |
+
+| SMTP Mail Server (for sending email notifications and receiving comments via email) |
+| --- |
+| Any SMTP mail server (MTA) supporting STARTTLS connections. |
+
+For a more detailed list of software dependencies and requirements see:
+* https://github.com/GovReady/govready-q/blob/master/requirements.in
+* https://github.com/GovReady/govready-q/blob/master/requirements.txt
+* https://github.com/GovReady/govready-q/blob/master/requirements_mysql.in
+* https://github.com/GovReady/govready-q/blob/master/requirements_mysql.txt
+* https://github.com/GovReady/govready-q/blob/master/Vagrantfile


### PR DESCRIPTION
Reorder main index to include Deployment documentation second.
Move enterprise single-sign-on into own document.
Move system requirements to own document and organize
under installing and deploying. Refactor headings to
use "#" indicators instead of underlines.