### PR TITLE
Remove extra error format parameter block related to #585

### DIFF
--- a/guidedmodules/models.py
+++ b/guidedmodules/models.py
@@ -559,21 +559,18 @@ class Task(models.Model):
 
     def get_static_asset_image_data_url(self, asset_path, max_image_size):
         if asset_path not in self.module.app.asset_paths:
-            # TODO: figure out if second {} is needed below.
-            print("ERROR: '" + "{} {}".format(self.project) + "' - asset_path '" + asset_path + "'' is not in module.app.asset_paths")
+            print("ERROR: '" + "{}".format(self.project) + "' - asset_path '" + asset_path + "'' is not in module.app.asset_paths")
             return "/error/image/asset_path[" + asset_path + "]/not-in-module.app.asset_paths"
         if self.module.app is None or asset_path not in self.module.app.asset_paths:
             # This path is not an asset.
-            # TODO: figure out if second {} is needed below.
-            print("ERROR: '" + "{} {}".format(self.project) + "' - asset_path '" + asset_path + "'' is not an asset")
+            print("ERROR: '" + "{}".format(self.project) + "' - asset_path '" + asset_path + "'' is not an asset")
             return "/error/image/asset_path[" + asset_path + "]/path-is-not-an-asset."
         with self.module.app.get_asset(asset_path) as f:
             try:
                 return image_to_dataurl(f, max_image_size)
             except:
                 # image processing error
-                # TODO: figure out if second {} is needed below.
-                print("ERROR: '" + "{} {}".format(self.project) + "' - asset_path '" + asset_path + "'' has invalid image data.")
+                print("ERROR: '" + "{}".format(self.project) + "' - asset_path '" + asset_path + "'' has invalid image data.")
                 return "/error/image/asset_path[" + asset_path + "]/image-processing-error."
 
 


### PR DESCRIPTION
We did indeed have an extra `{}` in the error generation statement. That has been corrected.