### PR TITLE
Production and Development environment docs

### DIFF
--- a/docs/source/Deploy.md
+++ b/docs/source/Deploy.md
@@ -9,6 +9,7 @@ Deploying GovReady-Q
    deploy_docker.md
    deploy_host_os.md
    deploy_prod.md
+   deploy_local_dev.md
    configure_db.md
    configure_webserver.md
    Environment.md

--- a/docs/source/Deploy.md
+++ b/docs/source/Deploy.md
@@ -8,6 +8,7 @@ Deploying GovReady-Q
    requirements.md
    deploy_docker.md
    deploy_host_os.md
+   deploy_prod.md
    configure_db.md
    configure_webserver.md
    Environment.md

--- a/docs/source/deploy_generic_unix.md
+++ b/docs/source/deploy_generic_unix.md
@@ -1,0 +1,45 @@
+# Deploying to a generic Unix-based OS
+
+If you are using a Unix-based OS (or POSIX-compliant OS) which is not specifically listed, here are the generic steps to take when installing GovReady-Q.
+
+## System Requirements
+
+First, install sufficient [system requirements](requirements.html#software-requirements).
+
+Typically, this will include:
+
+- python3
+- pip3
+- unzip
+- pandoc
+- wkhtmltopdf and xvfb
+- gcc
+- git
+- bash 4.0+ (note: macOS may have an older version)
+
+## Download and Install GovReady-Q
+
+Run the following commands to download the GovReady-Q source code, install necessary Python modules, and perform app-specific installation steps.
+
+	# Clone this repository.
+	git clone https://github.com/GovReady/govready-q
+	cd govready-q
+
+	# Install dependencies.
+	pip3 install --user -r requirements.txt
+	./fetch-vendor-resources.sh
+
+	# if you intend to use optional configurations, such as the MySQL adapter, you
+	# may need to run additional `pip3 install` commands, such as:
+	# pip3 install --user -r requirements_mysql.txt
+
+	# Set up the database (sqlite3 will be used until you configure another database).
+	python3 manage.py migrate
+	python3 manage.py load_modules
+
+
+## Next steps (Production or Development configuration)
+
+If you're deploying GovReady-Q to a production environment, see the [Production deployment steps](deploy_prod.html).
+
+If you're deploying GovReady-Q for development or evaluation purposes, [Development deployment steps](deploy_local_dev.html) may be useful for you.

--- a/docs/source/deploy_host_os.md
+++ b/docs/source/deploy_host_os.md
@@ -4,6 +4,6 @@
    :maxdepth: 2
    :caption: In This Section:
 
-   deploy_local_dev.md
    deploy_rhel7_centos7.md
    deploy_ubuntu.md
+   deploy_generic_unix.md

--- a/docs/source/deploy_local_dev.md
+++ b/docs/source/deploy_local_dev.md
@@ -1,33 +1,17 @@
-Installing GovReady-Q Compliance Server on Workstations for Development
+Installing GovReady-Q for Development or Contributing
 =======================================================================
 
-## Installing source code on workstations to contribute
+This page provides instructions on how to install and run GovReady-Q in a mode suitable for making and testing changes to the software (i.e., in a Dev environment).
 
-You can also install this repository on your workstation to contribute to improving GovReady-Q's functionality.
+## Initial Prep & Installation
 
-First, run the following commands to set up your local development environment:
+Begin by installing Q and its dependencies. This can be done either [on the host OS](deploy_host_os.html), or as a [Docker container](deploy_docker.html). For development purposes, installing on the host OS is currently the recommended approach.
 
-	# Install Python 3, pip, and other system packages appropriately for your
-	# environment. The commands below demonstrate how to do this on Ubuntu 16.04:
-	sudo apt-get install python3-pip unzip pandoc xvfb wkhtmltopdf
-	
-	# Clone this repository.
-	git clone https://github.com/GovReady/govready-q
-	cd govready-q
-	
-	# Install dependencies.
-	pip3 install --user -r requirements.txt
-	./fetch-vendor-resources.sh
+When installing to the host OS, there are instructions for several operating systems, such as [yum-based Linux distributions](deploy_rhel7_centos7.html) and [apt-based Linux distributions](deploy_ubuntu.html). On other [Unix-based operating systems](deploy_generic_unix.html) (including macOS), GovReady-Q can generally be installed successfully, although some troubleshooting may be neccessary if we do not have instructions for your OS/distro. On Windows, only Docker containers are currently supported.
 
-	# if you intend to use optional configurations, such as the MySQL adapter, you
-	# may need to run additional `pip3 install` commands, such as:
-	# pip3 install --user -r requirements_mysql.txt
-	
-	# Set up the database (sqlite3 will be used until you configure another database).
-	python3 manage.py migrate
-	python3 manage.py load_modules
+## Check Installation
 
-Then create your admin account and an initial organization:
+Once GovReady-Q is installed, create your admin account and an initial organization, if you have not already done so:
 
 	python3 manage.py first_run
 

--- a/docs/source/deploy_prod.md
+++ b/docs/source/deploy_prod.md
@@ -1,0 +1,77 @@
+# Deploying GovReady-Q in Production environments
+
+These instructions assume that GovReady-Q is installed by the user `govready-q`, in the directory `/home/govready-q/govready-q/`.
+
+To verify that this is the case, run the following command, and check whether GovReady-Q responds to HTTP requests (on `localhost:8000` by default).
+
+	cd /home/govready-q/govready-q/ && python3 manage.py runserver
+
+If GovReady-Q is installed successfully, proceed with the rest of these configuration instructions. If it doesn't, see [OS-specific install instructions](deploy_host_os.html).
+
+## Set basic configuration variables
+
+Create a file named `local/environment.json` (ensure it is not world-readable) that contains site configuration in JSON, with some recommended settings:
+
+	{
+	  "debug": false,
+	  "host": "webserver.hostname.com",
+	  "organization-parent-domain": "webserver.hostname.com",
+	  "https": true,
+	  "secret-key": "generate random string using e.g. https://www.miniwebtool.com/django-secret-key-generator/",
+	  "static": "/home/govready-q/public_html/static"
+	}
+
+Because of host header checking, to test the site again using `python3 manage.py runserver` you will need to visit it using `webserver.hostname.com` and not `localhost`. (Be sure to replace `webserver.hostname.com` with your hostname.)
+
+## Setting up the Database Server
+
+For production deployment, it is recommended to use dedicated database software, rather than SQLite.
+
+The recommended database is PostgreSQL - see [instructions on setting up Q with PostgreSQL](configure_db.html)
+
+## Setting up a Webserver
+
+It's recommended to run a dedicated webserver software, such as Apache or Nginx, as a reverse proxy in front of the Q application (running through uWSGI). To read how to do this, see [instructions on setting up Q with a reverse proxy webserver](configure_webserver.html).
+
+## Creating the First User
+
+If you are setting up a multi-tenant instance of Q where different organizations will use the site on different subdomains, create the administrative user using:
+
+    python3 manage.py createsuperuser
+
+and then log into the admin to create initial organizations.
+
+Otherwise, for a single-tenant setup, add to `local/environment.json`:
+
+  "single-organization": "main",
+
+which will serve just the Organization instance whose subdomain field is "main", and then create the initial user and the "main" organization using:
+
+	python3 manage.py first_run
+
+You should now be able to log into GovReady-Q using the user created in this section.
+
+## Other Configuration Settings
+
+Set up email by adding to `local/environment.json`:
+
+	  "admins": [["Your Name", "you@company.com"]],
+	  "email": {
+	    "host": "smtp.server.com", "port": "587", "user": "...", "pw": "....",
+	    "domain": "webserver.hostname.com"
+	  },
+	  "mailgun_api_key": "...",
+
+## Updating Deployment
+
+When there are changes to the GovReady-Q software, pull new sources and restart processes with:
+
+    # replace $DISTRO with an appropriate value.
+    # Currently-supported options include "rhel" and "ubuntu"
+    sudo -iu govready-q /home/govready-q/govready-q/deployment/$DISTRO/update.sh
+    
+As root, you can also restart just the Python/Django process:    
+
+    sudo supervisorctl restart all
+    
+But this won't do a full update so don't normally do that (it won't restart the separate notifications process or generate static assets, etc.).

--- a/docs/source/deploy_rhel7_centos7.md
+++ b/docs/source/deploy_rhel7_centos7.md
@@ -72,68 +72,8 @@ And test that the site starts in debug mode at localhost:8000:
 
 	python3 manage.py runserver
 
-### Set basic configuration variables
+## Next steps (Production or Development configuration)
 
-Create a file named `local/environment.json` (ensure it is not world-readable) that contains site configuration in JSON:
+If you're deploying GovReady-Q to a production environment, see the [Production deployment steps](deploy_prod.html).
 
-	{
-	  "debug": false,
-	  "host": "webserver.hostname.com",
-	  "organization-parent-domain": "webserver.hostname.com",
-	  "https": true,
-	  "secret-key": "generate random string using e.g. https://www.miniwebtool.com/django-secret-key-generator/",
-	  "static": "/home/govready-q/public_html/static"
-	}
-
-Because of host header checking, to test the site again using `python3 manage.py runserver` you will need to visit it using `webserver.hostname.com` and not `localhost`. (Be sure to replace `webserver.hostname.com` with your hostname.)
-
-## Setting up the Database Server
-
-For production deployment, it is recommended to use dedicated database software, rather than SQLite.
-
-The recommended database is PostgreSQL - see [instructions on setting up Q with PostgreSQL](configure_db.html)
-
-## Setting up a Webserver
-
-It's recommended to run a dedicated webserver software, such as Apache or Nginx, as a reverse proxy in front of the Q application (running through uWSGI). To read how to do this, see [instructions on setting up Q with a reverse proxy webserver](configure_webserver.html).
-
-## Creating the First User
-
-If you are setting up a multi-tenant instance of Q where different organizations will use the site on different subdomains, create the administrative user using:
-
-    python3 manage.py createsuperuser
-
-and then log into the admin to create initial organizations.
-
-Otherwise, for a single-tenant setup, add to `local/environment.json`:
-
-  "single-organization": "main",
-
-which will serve just the Organization instance whose subdomain field is "main", and then create the initial user and the "main" organization using:
-
-	python3 manage.py first_run
-
-You should now be able to log into GovReady-Q using the user created in this section.
-
-## Other Configuration Settings
-
-Set up email by adding to `local/environment.json`:
-
-	  "admins": [["Your Name", "you@company.com"]],
-	  "email": {
-	    "host": "smtp.server.com", "port": "587", "user": "...", "pw": "....",
-	    "domain": "webserver.hostname.com"
-	  },
-	  "mailgun_api_key": "...",
-
-## Updating Deployment
-
-When there are changes to the GovReady-Q software, pull new sources and restart processes with:
-
-    sudo -iu govready-q /home/govready-q/govready-q/deployment/rhel/update.sh
-    
-As root, you can also restart just the Python/Django process:    
-
-    sudo supervisorctl restart all
-    
-But this won't do a full update so don't normally do that (it won't restart the separate notifications process or generate static assets, etc.).
+If you're deploying GovReady-Q for development or evaluation purposes, [Development deployment steps](deploy_local_dev.html) may be useful for you.

--- a/docs/source/deploy_ubuntu.md
+++ b/docs/source/deploy_ubuntu.md
@@ -49,6 +49,8 @@ Set up supervisor to run the uwsgi daemon:
 	ln -sf `pwd`/deployment/ubuntu/supervisor.conf /etc/supervisor/conf.d/q.govready.com.conf
 	service supervisor restart
 
-## Setting up a Webserver
+## Next steps (Production or Development configuration)
 
-It's recommended to run a dedicated webserver software, such as Apache or Nginx, as a reverse proxy in front of the Q application (running through uWSGI). To read how to do this, see [instructions on setting up Q with a reverse proxy webserver](configure_webserver.html).
+If you're deploying GovReady-Q to a production environment, see the [Production deployment steps](deploy_prod.html).
+
+If you're deploying GovReady-Q for development or evaluation purposes, [Development deployment steps](deploy_local_dev.html) may be useful for you.


### PR DESCRIPTION
This splits off some documentation into pages specific for Production environments and Development environments, as part of #581. It also creates a "generic Unix/POSIX" page, because that information was part of the "local dev" deployment instructions.