### PR TITLE
Change default value for org subomains to match `host` setting

### DIFF
--- a/siteapp/settings_application.py
+++ b/siteapp/settings_application.py
@@ -61,7 +61,7 @@ DEBUG_TOOLBAR_CONFIG = {
 # our landing page domain. Also allow all subdomains of the organization
 # parent domain.
 LANDING_DOMAIN = environment["host"]
-ORGANIZATION_PARENT_DOMAIN = environment.get('organization-parent-domain', 'localhost')
+ORGANIZATION_PARENT_DOMAIN = environment.get('organization-parent-domain', LANDING_DOMAIN)
 ALLOWED_HOSTS += ['.' + ORGANIZATION_PARENT_DOMAIN]
 SINGLE_ORGANIZATION_KEY = environment.get('single-organization')
 REVEAL_ORGS_TO_ANON_USERS = (SINGLE_ORGANIZATION_KEY is not None) or environment.get('organization-seen-anonymously', False)


### PR DESCRIPTION
This should address the main aspect of #589 (namely, the fact that the default value is probably never useful). I know that's marked as "best" priority, but this commit was trivial to write while working on #607 and #581.