### PR TITLE
Remove stray docs/source file

### DIFF
--- a/docs/source/DatabaseStructure.md
+++ b/docs/source/DatabaseStructure.md
@@ -1,4 +1,0 @@
-immutable history
-computational stuff isn't in db, lazy loaded b/c __
-but can be from api
-optimized for other things


### PR DESCRIPTION
File `docs/source/DatabaseStructure.md` had 4 lines of random notes. Appears to have been accidentally committed to repo. Removing.