### PR TITLE
Don't break easy first run on localhost:8000

### DIFF
--- a/docs/source/deploy_prod.md
+++ b/docs/source/deploy_prod.md
@@ -23,6 +23,16 @@ Create a file named `local/environment.json` (ensure it is not world-readable) t
 
 Because of host header checking, to test the site again using `python3 manage.py runserver` you will need to visit it using `webserver.hostname.com` and not `localhost`. (Be sure to replace `webserver.hostname.com` with your hostname.)
 
+### Remember to Define Your `host1` and `organization-parent-domain`
+
+The **DisallowedHost...Invalid HTTP_HOST header...You may need to add '<your domain name>' to ALLOWED_HOSTS** is a common error received when first trying to get GovReady-Q running on a server at a specific domain. The error indicates the domain you are trying to visit is not white listed in Django's special `ALLOWED_HOST` variable.
+
+For security, Django requires white listing your server's domain(s) in the `ALLOWED_HOST` variable. Ordinarily this is hardcoded into the `settings.py` file. GovReady-Q allows the `ALLOWED_HOST` to be set by a combination of the `host` and `organization-parent-domain` environment settings so the values can be passed at runtime.
+
+* `host` must be defined, or GovReady-Q will default value to `localhost`
+* `organization-parent-domain` should be defined, or GovReady-Q will default value to same as `host`
+* Beginning `organization-parent-domain` value with a `.` tells Django to respond to any subdomain (e.g., `.mydomain.com` will respond to `info.mydomain.com` and `www.mydomain.com`)
+
 ## Setting up the Database Server
 
 For production deployment, it is recommended to use dedicated database software, rather than SQLite.

--- a/siteapp/settings.py
+++ b/siteapp/settings.py
@@ -35,13 +35,16 @@ else:
 	environment = {
 		"secret-key": make_secret_key(),
 		"debug": True,
-		"host": "localhost:8000",
 		"https": False,
+		"host": "localhost:8000",
+		"organization-parent-domain": "localhost"
 	}
 
 	# Show the defaults.
-	print("Create a %s file! It should contain something like this:" % local("environment.json"))
+	print("\nCouldn't find `local/environment.json` file. Generating default environment params.")
+	print("Please create a '%s' file containing something like this:" % local("environment.json"))
 	print(json.dumps(environment, sort_keys=True, indent=2))
+	print()
 
 # DJANGO SETTINGS #
 ###################
@@ -53,7 +56,7 @@ SECRET_KEY = environment.get("secret-key") or make_secret_key()
 DEBUG = bool(environment.get("debug"))
 ADMINS = environment.get("admins") or []
 
-# Set ALLOWED_HOSTS from the host environment. If it has a port, strip it.
+# Set Django's ALLOWED_HOSTS parameter from the host environment. If it has a port, strip it.
 # The port is used in SITE_ROOT_URL must must be removed from ALLOWED_HOSTS.
 ALLOWED_HOSTS = [environment["host"].split(':')[0]]
 

--- a/siteapp/settings_application.py
+++ b/siteapp/settings_application.py
@@ -57,11 +57,12 @@ DEBUG_TOOLBAR_CONFIG = {
     'SHOW_TOOLBAR_CALLBACK': DEBUG_TOOLBAR_SHOW_TOOLBAR_CALLBACK,
 }
 
-# ALLWOED_HOSTS is set based on environment['host'], which gives us
+# ALLOWED_HOSTS is set based on environment['host'], which gives us
 # our landing page domain. Also allow all subdomains of the organization
 # parent domain.
 LANDING_DOMAIN = environment["host"]
-ORGANIZATION_PARENT_DOMAIN = environment.get('organization-parent-domain', LANDING_DOMAIN)
+# Set organization domain if defined, or to LANDING_DOMAIN with port information stripped
+ORGANIZATION_PARENT_DOMAIN = environment.get('organization-parent-domain', LANDING_DOMAIN.split(':')[0])
 ALLOWED_HOSTS += ['.' + ORGANIZATION_PARENT_DOMAIN]
 SINGLE_ORGANIZATION_KEY = environment.get('single-organization')
 REVEAL_ORGS_TO_ANON_USERS = (SINGLE_ORGANIZATION_KEY is not None) or environment.get('organization-seen-anonymously', False)


### PR DESCRIPTION
The fix in PR #612 caused GovReady-Q to throw a DisallowedHost error for local installs
where GovReady-Q was generating default values (to help guarantee
a successful first run).

Also added documentation for *DisallowedHost* error because it frequently occurs after developers get GovReady-Q running locally and then try to deploy on a server at a domain.