### PR TITLE
Document `local/environment.json` keys

### DIFF
--- a/docs/source/Environment.md
+++ b/docs/source/Environment.md
@@ -1,5 +1,25 @@
 ## Environment Settings
 
+### top-level keys
+
+- `admins`
+- `branding`: used for [custom branding](Custombranding.html)
+- `db`: if supplied, this is the DB connection used. See [DB configuration](configure_db.html).
+- `debug`: should be `false` or absent in production environments. If set to `true`, turns on certain debug/development settings.
+- `email` <!-- this seems to be a multi-level key -->
+- `govready_cms_api_auth`
+- `host`: this is the domain name (HTTP `Host` header) used for root-level GovReady-Q pages. See also `organization-parent-domain`, which is used to construct organization subdomains (and which has a different default value!).
+- `https`
+- `mailgun_api_key`
+- `memcached`
+- `organization-parent-domain`: this is the domain name (HTTP `Host` header) suffix used for organization-specific GovReady-Q pages. The default value is `localhost:80`, regardless of the value supplied for `host` - if you have set the `host` key, and intend to use organization subdomains, you will almost certainly want to set `organization-parent-domain` as well.
+- `organization-seen-anonymously`
+- `secret-key`
+- `single-organization`
+- `static`
+- `syslog`
+- `trust-user-authentication-headers`
+
 ### Production Deployment Environment Settings
 
 A production system deployment may need to set more options in `local/environment.json`. Here are recommended settings:
@@ -27,6 +47,7 @@ To activate reverse proxy authentication, add the header names used by the proxy
       "email": "X-Authenticated-User-Email"
     },
   }
+
 
 GovReady-Q must be run at a private address that cannot be accessed except through the proxy server. The proxy server must be configured to proxy to GovReady-Q's private address. See [Enterprise Single-Sign On / Login](enterprise_sso.html) for additional details.
 

--- a/docs/source/Environment.md
+++ b/docs/source/Environment.md
@@ -1,6 +1,8 @@
 ## Environment Settings
 
-### top-level keys
+### Available Configuration Settings
+
+The following top-level keys are available in `local/environment.json`:
 
 - `admins`
 - `branding`: used for [custom branding](Custombranding.html)
@@ -8,11 +10,11 @@
 - `debug`: should be `false` or absent in production environments. If set to `true`, turns on certain debug/development settings.
 - `email` <!-- this seems to be a multi-level key -->
 - `govready_cms_api_auth`
-- `host`: this is the domain name (HTTP `Host` header) used for root-level GovReady-Q pages. See also `organization-parent-domain`, which is used to construct organization subdomains (and which has a different default value!).
+- `host`: this is the domain name (HTTP `Host` header) used for root-level GovReady-Q pages. See also `organization-parent-domain`, which is used to construct organization subdomains (if using a different base domain).
 - `https`
 - `mailgun_api_key`
 - `memcached`
-- `organization-parent-domain`: this is the domain name (HTTP `Host` header) suffix used for organization-specific GovReady-Q pages. The default value is `localhost:80`, regardless of the value supplied for `host` - if you have set the `host` key, and intend to use organization subdomains, you will almost certainly want to set `organization-parent-domain` as well.
+- `organization-parent-domain`: this is the domain name (HTTP `Host` header) suffix used for organization-specific GovReady-Q pages.
 - `organization-seen-anonymously`
 - `secret-key`
 - `single-organization`

--- a/docs/source/Environment.md
+++ b/docs/source/Environment.md
@@ -2,25 +2,27 @@
 
 ### Available Configuration Settings
 
-The following top-level keys are available in `local/environment.json`:
+The following environment variables are used to configure your GovReady-Q instance and can be configured through your local `local/environment.json` or passed in as environmental parameters when launching a container with GovReady-Q.
 
-- `admins`
+- `admins`: used to configure a display point of contact "Administrator" on site and unrelated to the configuration of actual administrators configured in the database.
 - `branding`: used for [custom branding](Custombranding.html)
 - `db`: if supplied, this is the DB connection used. See [DB configuration](configure_db.html).
 - `debug`: should be `false` or absent in production environments. If set to `true`, turns on certain debug/development settings.
-- `email` <!-- this seems to be a multi-level key -->
-- `govready_cms_api_auth`
+- `email`: used to configure access to a mail server for sending and receiving email. Ojbect has the following format: `{"host": "smtp.server.com", "port": "587", "user": "...", "pw": "....",
+  "domain": "webserver.hostname.com"}`. See [Configuring email](deploy_docker.html#configuring-email) and [Other Configuration Settings](deploy_prod.html#other-configuration-settings).
+},.
+- `govready_cms_api_auth`: used to store API key to interact with GovReady's CMS agent and dashboard. Not relevant to most users. See [GovReady-CMS-API](https://github.com/GovReady/GovReady-CMS-API).
 - `host`: this is the domain name (HTTP `Host` header) used for root-level GovReady-Q pages. See also `organization-parent-domain`, which is used to construct organization subdomains (if using a different base domain).
-- `https`
-- `mailgun_api_key`
-- `memcached`
+- `https`: set to true to generate HTTPS headers and urls when site is running behind a proxy terminating HTTPS connections. See [Configuring a Reverse Proxy Webserver for Production Use](configure_webserver.html).
+- `mailgun_api_key`: used to hold API key for using mailgun to send/receive emails.
+- `memcached`: if setting is true, enable a memcached cache using the default host/port
 - `organization-parent-domain`: this is the domain name (HTTP `Host` header) suffix used for organization-specific GovReady-Q pages.
-- `organization-seen-anonymously`
-- `secret-key`
-- `single-organization`
-- `static`
-- `syslog`
-- `trust-user-authentication-headers`
+- `organization-seen-anonymously`: show list of all created organizations to an anonymous (e.g., not signed-in) user on home page if set to true.
+- `secret-key` - used to make instance more secure by contributing a salt value to generating various random strings and hashes. Do not share.
+- `single-organization`: used to enforce single organization mode with "main" as subdomain of default organization instead of multi-tenant with different subdomains for different organizations.
+- `static`: used to prepend a root path to the default `/static/` URL path for accessing static assets.
+- `syslog`: used to set the host and port of a syslog-compatible log message sink. (Default: None.)
+- `trust-user-authentication-headers`: used to activate reverse proxy authentication. See [Proxy Authentication Sever](enterprise_sso.html#proxy-authentication-sever).
 
 ### Production Deployment Environment Settings
 


### PR DESCRIPTION
This creates a list of all top-level keys used by `local/environment.json`, along with descriptions for some of them.

I considered a table instead of a bulleted list, but the current CSS doesn't seem to work well with descriptions in tables (long prose doesn't auto-wrap). Plus, a list will be more-easily expanded to nested keys, like the subkeys of `email`.

I could also add descriptions for all keys (instead of just some), if desired. But, I'll open this as-is, because it still seems useful.