### PR TITLE
Fixes for data generation script for local dev environment (localhost subdomains, non-default ports)

### DIFF
--- a/testmocking/management/commands/populate.py
+++ b/testmocking/management/commands/populate.py
@@ -26,6 +26,7 @@ class Command(BaseCommand):
         parser.add_argument('--print-iter', type=int, default=100)
 
         parser.add_argument('--full', action="store_true", help="Also start and fill out assessments, etc., for each organization")
+        parser.add_argument('--port', type=str, help="Only needed in --full mode, when running on a non-default port (currently, the port isn't detected from the config file)")
 
     def handle(self, *args, **options):
         users = []
@@ -48,7 +49,10 @@ class Command(BaseCommand):
 
             if options['full']:
                 protocol = settings.ACCOUNT_DEFAULT_HTTP_PROTOCOL
-                base_url = '{}://{}.{}/'.format(protocol, org.subdomain, settings.ORGANIZATION_PARENT_DOMAIN)
+                port = ''
+                if options['port']:
+                    port = ':' + options['port']
+                base_url = '{}://{}.{}{}/'.format(protocol, org.subdomain, settings.ORGANIZATION_PARENT_DOMAIN, port)
                 print("Using base URL: {}".format(base_url))
                 print('Adding system...')
                 call_command('add_system',  '--password', options['password'], '--username', admin.username, '--base_url', base_url)

--- a/testmocking/web.py
+++ b/testmocking/web.py
@@ -1,6 +1,7 @@
 import requests
 import parsel
 from random import sample
+import re
 
 class WebClient():
     session = requests.Session()
@@ -11,6 +12,15 @@ class WebClient():
     comp_links = None
 
     def __init__(self, base_url):
+        if base_url.find('localhost') >= 0:
+            match = re.search(r'^http://(?P<host>(\w+\.)*localhost)(?P<port>:\d+)?/$', base_url)
+            if match:
+                host = match['host']
+                port = match['port'] or '' # in case we get None, don't want that junking up our URL
+                base_url = "http://localhost{}/".format(port)
+                self.session.headers.update({"Host": host})
+            else:
+                print("USAGE WARNING -- localhost suspected, but not in the standard format. This might fail.")
         self.base_url = base_url
 
     def _use_page(self, response):


### PR DESCRIPTION
This updates the data generation script to be friendlier for local dev environments.

* It detects `foo.localhost` non-standard host name patterns, and works as expected (i.e., treats that as a subdomain of localhost, and sets the `Host` header as needed)
* The user can supply a `--port` argument to `python3 manage.py populate --full`, to support non-default ports. Ideally, this would be pulled from the config file; but I don't actually see if there's anywhere which stores the port that we're running on, so this was a quicker patch.