### PR TITLE
Add and edit questions remotely on server

### DIFF
--- a/guidedmodules/urls.py
+++ b/guidedmodules/urls.py
@@ -22,6 +22,7 @@ urlpatterns = [
     url(r'^_authoring_tool/new-question$', guidedmodules.views.authoring_new_question),
     url(r'^_authoring_tool/edit-question$', guidedmodules.views.authoring_edit_question),
     url(r'^_authoring_tool/edit-module$', guidedmodules.views.authoring_edit_module),
+    url(r'^_authoring_tool/download-app$', guidedmodules.views.authoring_download_app),
     url(r'^_upgrade-app$', guidedmodules.views.upgrade_app),
 ]
 

--- a/siteapp/static/js/authoring_tool.js
+++ b/siteapp/static/js/authoring_tool.js
@@ -177,7 +177,7 @@ function authoring_tool_download_app() {
     url: "/tasks/_authoring_tool/download-app",
     method: "POST",
     data: data,
-    keep_indicator_forever: true, // keep the ajax indicator up forever --- it'll go away when we issue the redirect
+    keep_indicator_forever: false,
     success: function(res) {
       // Modal can stay up until the redirect finishes.
       // Stay on same page to see new content

--- a/siteapp/static/js/authoring_tool.js
+++ b/siteapp/static/js/authoring_tool.js
@@ -49,6 +49,7 @@ function init_authoring_tool(state) {
   // done after it's visible.
   $('#question_authoring_tool').on('shown.bs.modal', function() { autosize.update($(this).find('textarea')) });
   $('#module_authoring_tool').on('shown.bs.modal', function() { autosize.update($(this).find('textarea')) });
+  $('#questionnaire_authoring_tool').on('shown.bs.modal', function() { autosize.update($(this).find('textarea')) });
 
   // Init autocompletes for inputs/textareas that are interpreted as templates.
   init_authoring_tool_autocomplete($('#authoring_tool_qprompt'), "template");
@@ -164,6 +165,27 @@ function authoring_tool_add_impute_condition_fields() {
   $('#authoring_tool_impute_conditions').append(n);
   init_authoring_tool_autocomplete($(n.find("input")[0], "expression"));
   return n;
+}
+
+function authoring_tool_download_app() {
+  // console.log(q_authoring_tool_state.questions)
+  // console.log(q_authoring_tool_state.questions.spec)
+  // console.log(Object.getOwnPropertyNames(q_authoring_tool_state.questions)[0]);
+  var data = [{ name: "task", value: q_authoring_tool_state.task }]
+  data.push( { name: "question", value: Object.getOwnPropertyNames(q_authoring_tool_state.questions)[0] } );
+  ajax_with_indicator({
+    url: "/tasks/_authoring_tool/download-app",
+    method: "POST",
+    data: data,
+    keep_indicator_forever: true, // keep the ajax indicator up forever --- it'll go away when we issue the redirect
+    success: function(res) {
+      // Modal can stay up until the redirect finishes.
+      // Stay on same page to see new content
+      $('#questionnaire_authoring_tool_mspec').val(res.data);
+      // Show modal.
+      $('#questionnaire_authoring_tool').modal();
+    }
+  });
 }
 
 function authoring_tool_save_question() {

--- a/templates/authoring-tool-modal.html
+++ b/templates/authoring-tool-modal.html
@@ -63,6 +63,7 @@ div.modal-content{
   .modal.right.fade.in .modal-dialog {
     right: 0;
   }
+k
 
 /* ----- MODAL STYLE ----- */
   .modal-content {
@@ -278,7 +279,17 @@ label {
               <span class="help-block">Optional question specification YAML data not defined above.</span>
             </div>
           </div>
+          <div class="form-group">
+            <label for="other" class="col-sm-2 control-label">Other</label>
+            <div class="col-sm-10">
+              <button class="" title="New question" onclick="authoring_tool_new_question({{task.id}}, false); return false;">
+                <span class="glyphicon glyphicon-plus"></span>
+                New question
+              </button>
+            </div>
+          </div>
         </form>
+
       </div>
       <div class="modal-footer">
         <button type="button" class="btn btn-danger btn" onclick="authoring_tool_delete_question()">Delete Question</button>
@@ -287,5 +298,35 @@ label {
       </div>
     </div>
     </form>
+  </div>
+</div>
+
+<div id="questionnaire_authoring_tool" class="modal center fade" tabindex="-1" role="dialog" aria-labelledby="questionnaire_authoring_tool_title" aria-hidden="true" data-keyboard="false" data-backdrop="false">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+        <h4 class="modal-title" id="questionnaire_authoring_tool_title">
+          View Questionnaire Source
+        </h4>
+      </div>
+      <div class="modal-body">
+        <form class="form-horizontal" onsubmit="return false;">
+          <div class="form-group">
+            <label for="questionnaire_authoring_tool_mspec" class="col-sm-1 control-label">Questionnaire</label>
+            <div class="col-sm-10">&nbsp;</div>
+            <div class="col-sm-12">
+              <textarea class="form-control" id="questionnaire_authoring_tool_mspec" name="spec">{ }</textarea>
+              <span class="help-block">Questionnaire definition in YAML.</span>
+            </div>
+          </div>
+        </form>
+      </div>
+      <div class="modal-footer">
+        <!-- <button type="button" class="btn btn-danger" onclick="authoring_tool_delete_question()">Delete Question</button> -->
+        <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+        <!-- <button type="button" class="btn btn-success" onclick="authoring_tool_save_module()">Save Changes</button> -->
+      </div>
+    </div>
   </div>
 </div>

--- a/templates/authoring-tool-modal.html
+++ b/templates/authoring-tool-modal.html
@@ -197,7 +197,11 @@ label {
           <div class="form-group authoring_q_type_text authoring_q_type_email-address authoring_q_type_url authoring_q_type_longtext">
             <label for="authoring_tool_default" class="col-sm-2 control-label">Default</label>
             <div class="col-sm-10">
+              {% if q.spec.type == "longtext" %}
+              <textarea class="form-control" id="authoring_tool_default" name="default"></textarea>
+              {% else %}
               <input type="text" class="form-control" id="authoring_tool_default" name="default">
+              {% endif %}
               <span class="help-block">Template text provided as a default value. Do not set both a placeholder and a default.</span>
             </div>
           </div>

--- a/templates/question.html
+++ b/templates/question.html
@@ -574,7 +574,12 @@ label:hover .onhover { display: inline; }
     <div style="margin: 2em 0; font-size: 90%;">
       <a id="show_question_authoring_tool" href="#" onclick="show_question_authoring_tool('{{q.key|escapejs}}'); return false;">
         <span class="glyphicon glyphicon-pencil"></span>
-        Authoring Tool
+        Authoring tool
+      </a>
+      <br />
+      <a id="download_questionnaire" href="#" target="_blank" onclick="authoring_tool_download_app('{{q.key|escapejs}}'); return false;">
+        <span class="glyphicon glyphicon-save"></span>
+        View questionnaire YAML
       </a>
     </div>
     {% endif %}


### PR DESCRIPTION
Modifications add ability to add a question to a questionnaire
Modifications also allow editing questionnaire even if app is
running on a server.

Previously, it was only possible to edit questions when running
Q locally on a workstation for apps sources that were local to file
system because previously questionnaires were always loaded from
the app source when started.

Now that we are pre-loading the app sources into the database,
the definition of the questionnaire is in the database and
can be edited directly.

If app source happens to be local, then Q will also update the
the local YAML file. If app source is not local, Q will update in
database and it is up to user to "view" the updated YAML and update
the app source.

Future work should allow changing of the version number, etc.
