### PR TITLE
Add 'New question' button in author tool block

### DIFF
--- a/templates/question.html
+++ b/templates/question.html
@@ -564,12 +564,17 @@ label:hover .onhover { display: inline; }
     </div> <!-- /question-history-context -->
 
     {% if authoring_tool_enabled %}
-    <div id="author-tools" style="margin: 1em 0; font-size: 90%;">
+    <div id="author-tools" style="margin: 1em 0; font-size: 80%;">
       <a id="show_question_authoring_tool" href="#" onclick="show_question_authoring_tool('{{q.key|escapejs}}'); return false;">
         <span class="glyphicon glyphicon-pencil" style="color: "></span>
         Edit
       </a>
-      &nbsp;&nbsp;&nbsp;&nbsp;
+      &nbsp;&nbsp;
+      <a id="add_new_question" href="#" target="_blank" onclick="authoring_tool_new_question({{task.id}}, false); return false;">
+        <span class="glyphicon glyphicon-plus-sign"></span>
+        New
+      </a>
+      &nbsp;&nbsp;
       <a id="download_questionnaire" href="#" target="_blank" onclick="authoring_tool_download_app('{{q.key|escapejs}}'); return false;">
         <span class="glyphicon glyphicon-eye-open"></span>
         Source


### PR DESCRIPTION
Adding the "New question" button to the displayed question authoring links makes it much faster to add questions instead of opening up the editing modal, scrolling down to bottom of modal, and clicking "New question" button there.