### PR TITLE
PK runserver doc fix 20190729

### DIFF
--- a/docs/source/deploy_all.md
+++ b/docs/source/deploy_all.md
@@ -93,7 +93,7 @@ Click one of the tab belows to see quickstart for indicated platform.
         .. code-block:: bash
 
             # run the server
-            python3 manage.py migrate
+            python3 manage.py runserver
 
         Visit your GovReady-Q site in your web browser at:
 
@@ -168,7 +168,7 @@ Click one of the tab belows to see quickstart for indicated platform.
         .. code-block:: bash
 
             # run the server
-            python3 manage.py migrate
+            python3 manage.py runserver
 
         Visit your GovReady-Q site in your web browser at:
 
@@ -237,7 +237,7 @@ Click one of the tab belows to see quickstart for indicated platform.
         .. code-block:: bash
 
             # run the server
-            python3 manage.py migrate
+            python3 manage.py runserver
 
         Visit your GovReady-Q site in your web browser at:
 

--- a/docs/source/deploy_macos.md
+++ b/docs/source/deploy_macos.md
@@ -61,7 +61,7 @@
         .. code-block:: bash
 
             # run the server
-            python3 manage.py migrate
+            python3 manage.py runserver
 
         Visit your GovReady-Q site in your web browser at:
 

--- a/docs/source/deploy_rhel7_centos7.md
+++ b/docs/source/deploy_rhel7_centos7.md
@@ -74,7 +74,7 @@
         .. code-block:: bash
 
             # run the server
-            python3 manage.py migrate
+            python3 manage.py runserver
 
         Visit your GovReady-Q site in your web browser at:
 

--- a/docs/source/deploy_ubuntu.md
+++ b/docs/source/deploy_ubuntu.md
@@ -67,7 +67,7 @@
         .. code-block:: bash
 
             # run the server
-            python3 manage.py migrate
+            python3 manage.py runserver
 
         Visit your GovReady-Q site in your web browser at:
 

--- a/docs/source/version.0.9.0.md
+++ b/docs/source/version.0.9.0.md
@@ -293,7 +293,7 @@ Click one of the tab belows to see quickstart for indicated platform.
         .. code-block:: bash
 
             # run the server
-            python3 manage.py migrate
+            python3 manage.py runserver
 
         Visit your GovReady-Q site in your web browser at:
 
@@ -366,7 +366,7 @@ Click one of the tab belows to see quickstart for indicated platform.
         .. code-block:: bash
 
             # run the server
-            python3 manage.py migrate
+            python3 manage.py runserver
 
         Visit your GovReady-Q site in your web browser at:
 


### PR DESCRIPTION
In the docs, in a number of the deployment sections, after the comment `# run the server`, the command that is shown is `python3 manage.py migrate`.

This commit changes those commands to `python3 manage.py runserver`.