### PR TITLE
Add project title edit button to main project page

### DIFF
--- a/templates/project-base.html
+++ b/templates/project-base.html
@@ -73,30 +73,43 @@ div.subtitle {
   </div>
   {% endif %}
 
-  <div class="{% if is_project_page %}col-md-pull-2{% endif %} col-md-10">
+  <div class="{% if is_project_page %}col-md-pull-2{% endif %} col-md-9">
     <div id="focus-area-wrapper">
       {% block above_title %}
       {% endblock %}
 
-      {% if project.root_task.get_app_icon_url %}
-        <img id="project-icon" src="{{project.root_task.get_app_icon_url}}" alt="Project Icon">
-      {% endif %}
+    <div id="project-title-info" class="row">
+      <div class="col-sm-10">
+        {% if project.root_task.get_app_icon_url %}
+          <img id="project-icon" src="{{project.root_task.get_app_icon_url}}" alt="Project Icon">
+        {% endif %}
 
-      {% if project.organization %}
-      <h1 id="project-title">
-        {{project.title}}
-        {% block title_suffix_text %}
-        {% endblock %}
-        <br><small>Project ID: {{project.id}} &nbsp;|&nbsp; Portfolio: <a href="{{project.portfolio.get_absolute_url}}" style="color: inherit;">{{project.portfolio.title}}</a></small>
-      </h1>
+        {% if project.organization %}
+        <h1 id="project-title">
+          {{project.title}}
+          {% block title_suffix_text %}
+          {% endblock %}
+          <br><small>Project ID: {{project.id}} &nbsp;|&nbsp; Portfolio: <a href="{{project.portfolio.get_absolute_url}}" style="color: inherit;">{{project.portfolio.title}}</a></small>
+        </h1>
 
-      {% if title != project.root_task.module.spec.title %}
-      <div class="subtitle">
-        {{project.root_task.module.spec.title}}
+        {% if title != project.root_task.module.spec.title %}
+        <div class="subtitle">
+          {{project.root_task.module.spec.title}}
+        </div>
+        {% endif %}
+        {% endif %}
+        <div class="clearfix"></div>
       </div>
-      {% endif %}
-      {% endif %}
-      <div class="clearfix"></div>
+      <div class="col-sm-2">
+        <div id="btn-edit-title" style="text-align: center;">
+          {% if not project.is_account_project or project.is_deletable %}
+            {% if project.is_deletable and is_admin %}
+              <button class="btn btn-default btn-small" onclick="return rename_project();">Edit</button>
+            {% endif %}
+          {% endif %}
+        </div>
+      </div>
+    </div><!-- /project-title-info -->
 
       {% if project.lifecycle_stage %}
       {% with nstages=project.lifecycle_stage.0.stages|length %}

--- a/templates/project.html
+++ b/templates/project.html
@@ -244,18 +244,21 @@ h3.question-group-title {
 {% endblock %}
 
 {% block body_content %}
-    {% if project.root_task.module.spec.introduction %}
-      <p style="margin: 1em 0;">
-      {{project.root_task.render_introduction|safe}}
-      </p>
-    {% endif %}
+    <div class="row">
+      <div class="col-sm-12">
+        {% if project.root_task.module.spec.introduction %}
+          <p style="margin: 1em 0;">
+          {{project.root_task.render_introduction|safe}}
+          </p>
+        {% endif %}
 
-    {% if project.root_task.module.spec.is_app_stub %}
-      {# This project is tied to an app that has not yet been imported. #}
-      <h2>Activate App</h2>
-      <p>This app must be activated by an administrator of your organization. Send them <a href="javascript:invite_user_into_project()">an invitation</a> to join this project. When they get here, they&rsquo;ll be able to activate the app.</p>
-    {% endif %}
-
+        {% if project.root_task.module.spec.is_app_stub %}
+          {# This project is tied to an app that has not yet been imported. #}
+          <h2>Activate App</h2>
+          <p>This app must be activated by an administrator of your organization. Send them <a href="javascript:invite_user_into_project()">an invitation</a> to join this project. When they get here, they&rsquo;ll be able to activate the app.</p>
+        {% endif %}
+      </div>
+    </div>
     <div class="row">
     {% with ncolumns=columns|length %}
     {% for column in columns %}


### PR DESCRIPTION
Reduce the number of clicks to change the title
of a project. Communicate to people that the project
title can be changed. Right now title change still
involves a up popup, but that can be improved later.