### PR TITLE
Fix some documentation typos where "runserver" and "migrate" were swapped

### DIFF
--- a/docs/source/deploy_all.md
+++ b/docs/source/deploy_all.md
@@ -93,7 +93,7 @@ Click one of the tab belows to see quickstart for indicated platform.
         .. code-block:: bash
 
             # run the server
-            python3 manage.py migrate
+            python3 manage.py runserver
 
         Visit your GovReady-Q site in your web browser at:
 
@@ -168,7 +168,7 @@ Click one of the tab belows to see quickstart for indicated platform.
         .. code-block:: bash
 
             # run the server
-            python3 manage.py migrate
+            python3 manage.py runserver
 
         Visit your GovReady-Q site in your web browser at:
 
@@ -237,7 +237,7 @@ Click one of the tab belows to see quickstart for indicated platform.
         .. code-block:: bash
 
             # run the server
-            python3 manage.py migrate
+            python3 manage.py runserver
 
         Visit your GovReady-Q site in your web browser at:
 

--- a/docs/source/deploy_rhel7_centos7.md
+++ b/docs/source/deploy_rhel7_centos7.md
@@ -74,7 +74,7 @@
         .. code-block:: bash
 
             # run the server
-            python3 manage.py migrate
+            python3 manage.py runserver
 
         Visit your GovReady-Q site in your web browser at:
 

--- a/docs/source/deploy_ubuntu.md
+++ b/docs/source/deploy_ubuntu.md
@@ -67,7 +67,7 @@
         .. code-block:: bash
 
             # run the server
-            python3 manage.py migrate
+            python3 manage.py runserver
 
         Visit your GovReady-Q site in your web browser at:
 

--- a/docs/source/version.0.9.0.md
+++ b/docs/source/version.0.9.0.md
@@ -287,7 +287,7 @@ Click one of the tab belows to see the release 0.9.0 quickstart for the indicate
         .. code-block:: bash
 
             # run the server
-            python3 manage.py migrate
+            python3 manage.py runserver
 
         Visit your GovReady-Q site in your web browser at:
 
@@ -360,7 +360,7 @@ Click one of the tab belows to see the release 0.9.0 quickstart for the indicate
         .. code-block:: bash
 
             # run the server
-            python3 manage.py migrate
+            python3 manage.py runserver
 
         Visit your GovReady-Q site in your web browser at:
 


### PR DESCRIPTION
Fixes some erroneous commands in the installation documentation.