### PR TITLE
More question types in data generation

### DIFF
--- a/testmocking/data_management.py
+++ b/testmocking/data_management.py
@@ -164,7 +164,7 @@ def answer_randomly(task, overwrite=False, halt_impute=True, skip_impute=False, 
             log("doing subtask")
             continue
         
-        if not answer and type != 'interstitial':
+        if not answer and not (type == 'interstitial' or type == 'raw'):
             print("Cannot answer question of type '" + type + "'")
             continue
         

--- a/testmocking/data_management.py
+++ b/testmocking/data_management.py
@@ -146,6 +146,13 @@ def answer_randomly(task, overwrite=False, halt_impute=True, skip_impute=False, 
             answer = get_random_email()
         elif type == 'url':
             answer = get_random_url()
+        elif type == 'date':
+            year = randint(2010, 2030)
+            month = randint(1, 12)
+            # stopping our day at 28 means we don't need to worry about varying month lengths
+            day = randint(1, 28) 
+            # internal answer format seems to be yyyy-mm-dd
+            answer = "{}-{:02}-{:02}".format(year, month, day)
         elif type == 'choice':
             answer = sample(question.spec['choices'], 1)[0]['key']
         elif type == 'multiple-choice':

--- a/testmocking/data_management.py
+++ b/testmocking/data_management.py
@@ -28,6 +28,19 @@ def get_name(count, separator=' ', path='eff_short_wordlist_1.txt'):
     wordlist = get_wordlist(path=path)
     return separator.join([name.title() for name in sample(wordlist, count)])
 
+
+def get_random_sentence():
+    # Potential future improvement: generate some lorem ipsum instead
+    count = randint(5, 10)
+    wordlist = get_wordlist()
+    words = ' '.join(sample(wordlist, count))
+    return words
+
+def get_random_paragraph():
+    count = randint(2, 5)
+    sents = [get_random_sentence() + '.' for x in range(0, count)]
+    return '\n\n'.join(sents)
+
 def create_user(username=None, password=None, pw_hash=None):
     if username == None:
         username = get_name(1, '_', path='names.txt')
@@ -116,7 +129,9 @@ def answer_randomly(task, overwrite=False, halt_impute=True, skip_impute=False, 
         if type == 'yesno':
             answer = sample(['yes', 'no'],1)[0]
         elif type == 'text':
-            answer = get_random_string(20)
+            answer = get_random_sentence()
+        elif type == 'longtext':
+            answer = get_random_paragraph()
         elif type == 'choice':
             answer = sample(question.spec['choices'], 1)[0]['key']
         elif type == 'multiple-choice':

--- a/testmocking/data_management.py
+++ b/testmocking/data_management.py
@@ -41,6 +41,16 @@ def get_random_paragraph():
     sents = [get_random_sentence() + '.' for x in range(0, count)]
     return '\n\n'.join(sents)
 
+def get_random_email():
+    wordlist = get_wordlist()
+    word = sample(wordlist, 1)[0]
+    return "{}@example.com".format(word)
+
+def get_random_url():
+    wordlist = get_wordlist()
+    word = sample(wordlist, 1)[0]
+    return "http://example.com/some_path/{}".format(word)
+
 def create_user(username=None, password=None, pw_hash=None):
     if username == None:
         username = get_name(1, '_', path='names.txt')
@@ -132,6 +142,10 @@ def answer_randomly(task, overwrite=False, halt_impute=True, skip_impute=False, 
             answer = get_random_sentence()
         elif type == 'longtext':
             answer = get_random_paragraph()
+        elif type == 'email-address':
+            answer = get_random_email()
+        elif type == 'url':
+            answer = get_random_url()
         elif type == 'choice':
             answer = sample(question.spec['choices'], 1)[0]['key']
         elif type == 'multiple-choice':


### PR DESCRIPTION
This adds support to the data gen scripts for answering more types of questions:

- "longtext" (backported from 0.8.6, as a cherry-pick to hopefully minimize merge conflicts)
- "email" (uses example.com)
- "url" (uses example.com)
- "date"

Additionally, it marks "raw" as safely skippable (the same as "interstitial"), meaning that there isn't any message when a "raw" question is skipped.