### PR TITLE
Ge fix perms proj and comments 0830

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-v0.9.0.dev42+devel
+v0.9.0.dev44+devel

--- a/discussion/models.py
+++ b/discussion/models.py
@@ -71,14 +71,13 @@ class Discussion(models.Model):
             return "<Deleted Discussion>"
 
     def is_participant(self, user):
-        # No one is a participant of a dicussion attached to (a question
-        # of) a deleted Task.
+        # No one is a participant of a discussion attached to (a question of) a deleted Task.
         if self.attached_to_obj is not None and self.attached_to_obj.is_discussion_deleted():
             return False
         return user in self.get_all_participants()
 
     def get_all_participants(self):
-        # because get_discussion_participants uses distinct, self.guests must too
+        # Because get_discussion_participants uses distinct, self.guests must too
         participants = self.guests.all().distinct()
         if self.attached_to_obj is not None:
             participants = (participants | self.attached_to_obj.get_discussion_participants()).distinct()
@@ -303,7 +302,6 @@ class Comment(models.Model):
 
         # Reset the creation date to the moment it's published.
         self.created = timezone.now()
-
         # Save.
         self.save()
 

--- a/discussion/templates/discussion/discussion.html
+++ b/discussion/templates/discussion/discussion.html
@@ -441,11 +441,13 @@ function display_discussion(discussion, is_page_load) {
     // options
   });
 
-  // start polling the server for new events
+  // start poor-man's polling the server for new events
   // don't poll if the user can't comment because the discussion view
   // will say they don't have permission to poll
+  /* Temporarily stop our polling to make logs quieter
   if (discussion_info.can_comment)
-    discussion_poll();
+     discussion_poll();
+  */
 }
 
 function render_events(discussion, initial) {

--- a/discussion/views.py
+++ b/discussion/views.py
@@ -38,14 +38,13 @@ def update_discussion_comment_draft(request):
     # Return the comment's id and rendered text for displaying a preview.
     return JsonResponse(comment.render_context_dict(request.user))
 
-
 @login_required
 @transaction.atomic
 def submit_discussion_comment(request):
     # Get the discussion object.
     discussion = get_object_or_404(Discussion, id=request.POST['discussion'])
     if not discussion.can_comment(request.user):
-        return HttpResponseForbidden()
+        return HttpResponseForbidden("You do not have permission to post to this discussion.")
 
     # Get the Comment draft.
     try:
@@ -55,13 +54,11 @@ def submit_discussion_comment(request):
 
     if not comment.draft:
         return JsonResponse({ "status": "error", "message": "It looks like the comment was already submitted from another browser session." })
-
     # Publish it.
     comment.publish()
 
     # Return the comment for display.
     return JsonResponse(comment.render_context_dict(request.user))
-
 
 @login_required
 def edit_discussion_comment(request):

--- a/guidedmodules/models.py
+++ b/guidedmodules/models.py
@@ -930,10 +930,10 @@ class Task(models.Model):
         return None
 
     def has_read_priv(self, user, allow_access_to_deleted=False):
-        return self.get_access_level(user, allow_access_to_deleted=allow_access_to_deleted) in ("READ", "WRITE")
+        return self.get_access_level(user, allow_access_to_deleted=allow_access_to_deleted) in ("READ", "WRITE") or self.project.has_read_priv(user)
 
     def has_write_priv(self, user, allow_access_to_deleted=False):
-        return self.get_access_level(user, allow_access_to_deleted=allow_access_to_deleted) == "WRITE"
+        return self.get_access_level(user, allow_access_to_deleted=allow_access_to_deleted) == "WRITE" or self.project.has_read_priv(user)
 
     def has_review_priv(self, user):
         if self.project.organization is None:
@@ -1836,7 +1836,6 @@ class TaskAnswer(models.Model):
             for user in self.task.project.organization.help_squad.all():
                 if user in self.get_notification_watchers(): continue # no need to invite
                 inv = Invitation.objects.create(
-                    organization=self.task.project.organization,
                     from_user=comment.user,
                     from_project=self.task.project,
                     target=comment.discussion,

--- a/guidedmodules/views.py
+++ b/guidedmodules/views.py
@@ -85,7 +85,7 @@ def download_module_asset(request, taskid, taskslug, asset_path):
 # decorator for pages that render tasks
 def task_view(view_func):
     @login_required
-    def inner_func(request, taskid, taskslug, pagepath, question_key, *args):
+    def new_view_func(request, taskid, taskslug, pagepath, question_key, *args):
         # Get the Task.
         task = get_object_or_404(Task, id=taskid)
 
@@ -124,9 +124,9 @@ def task_view(view_func):
 
             return False
         if not read_priv():
-            return HttpResponseForbidden()
+            return HttpResponseForbidden("You do not have read privileges to this page.")
 
-        # We skiped the check for whether the Task is deleted above. Now
+        # We skipped the check for whether the Task is deleted above. Now
         # check for that and provide a more specific error.
         if task.deleted_at:
             # The Task is deleted. If the user would have had access to it,
@@ -167,8 +167,7 @@ def task_view(view_func):
 
         # Render the view.
         return view_func(request, task, answered, context, question, *args)
-
-    return inner_func
+    return new_view_func
 
 
 @task_view

--- a/templates/portfolios/detail.html
+++ b/templates/portfolios/detail.html
@@ -46,29 +46,41 @@ Remove contextbar from top of page
     {% endif %}
 
     <div class="container">
+      <div class="row">
+        <div class="col-sm-1">&nbsp;</div>
+        <div class="col-xs-10 col-md-4">Project</div>
+        <div class="col-xs-6 col-sm-1">ID</div>
+        <div class="col-xs-6 col-sm-2">Portfolio</div>
+        <div class="col-xs-6 col-sm-2">Role</div>
+        <div class="col-xs-12 col-md-2">Updated</div>
+      </div>
+
       {% for project in projects %}
       <div class="row" style="border-top: 1px solid #aaa;padding: 8px 0px 8px 0px;">
-        <div class="col-md-6">
+
+        <div class="col-sm-1">
           {% if project.root_task.get_app_icon_url %}
-          <a href="{{project.get_absolute_url}}" class="project-image">
-            <img src="{{project.root_task.get_app_icon_url}}" class="img-responsive">
-          </a>
+            <a href="{{project.get_absolute_url}}" class="project-image">
+              <img src="{{project.root_task.get_app_icon_url}}" class="img-responsive" alt="App Icon">
+            </a>
           {% else %}
           &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
           {% endif %}
-          &nbsp;&nbsp;&nbsp;
+        </div>
+
+        <div class="col-xs-10 col-md-4">
           <a href="{{project.get_absolute_url}}" style="color: black;">{{project.title}}</a>
         </div>
 
-        <div class="col-md-3">&nbsp;</div>
+        <div class="col-xs-6 col-sm-1"><small style="color: #888;">{{project.id}}</small></div>
+        <div class="col-xs-6 col-sm-2"><small style="color: #888;">{{project.portfolio.title}}</small></div>
 
-        <div class="col-md-1">
-          <small style="color: #888;">(ID: {{project.id}})</small>
-        </div>
+        {# get_obj_perms request.user for project as "perms" #}
+        <div class="col-xs-6 col-sm-2"><small style="color: #888;">PERMISSIONS HERE</small></div>
 
         <div class="col-md-2">
           <small style="color: #888;">
-            Updated {{project.root_task.updated|naturaltime}}
+            {{project.root_task.updated|naturaltime}}
           </small>
         </div>
 

--- a/templates/portfolios/portfolios_table.html
+++ b/templates/portfolios/portfolios_table.html
@@ -3,27 +3,37 @@
 {% load guardian_tags %}
 
 <div class="container">
+<div class="row">
+  <div class="col-xs-10 col-md-5">Portfolio</div>
+  <div class="col-xs-6 col-sm-1">ID</div>
+  <div class="col-xs-6 col-sm-2">Role</div>
+  <div class="col-md-2">&nbsp;</div>
+  <div class="col-xs-12 col-md-2">Created</div>
+</div>
 
   {% for portfolio in portfolios %}
   <div class="row" style="border-top: 1px solid #aaa;padding: 8px 0px 8px 0px;">
 
-    <div class="col-md-4">
+    <div class="col-xs-10 col-md-5">
       <div>
         <span class="glyphicon glyphicon-folder-close"></span>&nbsp;&nbsp;&nbsp;
         <a href="/portfolios/{{portfolio.id}}/projects" id="portfolio_{{portfolio.title}}" style="color: black;">{{portfolio.title}}</a>
       </div>
     </div>
 
+    <div class="col-md-1"><small style="color: #888;">{{portfolio.id}}</small></div>
+
     {% get_obj_perms request.user for portfolio as "perms" %}
     {% if "can_grant_portfolio_owner_permission" in perms %}
-    <div class="col-md-2"><small style="color: #888;">Role: Owner</small></div>
+    <div class="col-md-2"><small style="color: #888;">Owner</small></div>
     {% elif "change_portfolio" in perms%}
-    <div class="col-md-2"><small style="color: #888;">Role: Can Edit</small></div>
+    <div class="col-md-2"><small style="color: #888;">Portfolio Member</small></div>
+    {% else %}
+    <div class="col-md-2"><small style="color: #888;">Project Member</small></div>
     {% endif %}
     <div class="col-md-2">&nbsp;</div>
-    <div class="col-md-1"><small style="color: #888;">ID: {{portfolio.id}}</small></div>
 
-    <div class="col-md-2" style="text-align: right;"><small style="color: #888;">Created
+    <div class="col-xs-12 col-md-2" style="text-align: left;"><small style="color: #888;">
         {{portfolio.created|naturaltime}}</small></div>
   </div>
   {% endfor %}

--- a/templates/project.html
+++ b/templates/project.html
@@ -298,6 +298,7 @@ h3.question-group-title {
                         {# This is a module-type question that has been started. Clicking the question doesn't start a new task --- instead, it's just a link to the started Task. #}
 
                         {# Link to the Task. #}
+                        {# This is a module-type question that has been answered already (e.g., it has a Task answer). We are making the display of the information about the module one big link. Here we open the link tag and put everything that follows, including the progress bar and the buttons will clickable. #}
                         <a href="{{q.task.get_absolute_url}}" style="display: block;">
 
                       {% elif not q.question.spec.protocol %}

--- a/templates/projects.html
+++ b/templates/projects.html
@@ -121,6 +121,15 @@ Your Compliance Projects
 {% endif %}
 
 <div class="container">
+<div class="row">
+  <div class="col-sm-1">&nbsp;</div>
+  <div class="col-xs-10 col-md-4">Project</div>
+  <div class="col-xs-6 col-sm-1">ID</div>
+  <div class="col-xs-6 col-sm-2">Portfolio</div>
+  <div class="col-xs-6 col-sm-2">Role</div>
+  <div class="col-xs-12 col-md-2">Updated</div>
+</div>
+
 {% for project in projects %}
 <div class="row" style="border-top: 1px solid #aaa;padding: 8px 0px 8px 0px;">
   <div class="col-sm-1">
@@ -132,26 +141,27 @@ Your Compliance Projects
     &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
     {% endif %}
   </div>
-  <div class="col-xs-10 col-md-5">
+  <div class="col-xs-10 col-md-4">
     <a href="{{project.get_absolute_url}}" style="color: black;">{{project.title}}</a>
   </div>
+
+  <div class="col-xs-6 col-sm-1"><small style="color: #888;">{{project.id}}</small></div>
+  <div class="col-xs-6 col-sm-2"><small style="color: #888;">{{project.portfolio.title}}</small></div>
 
   {% get_obj_perms request.user for project as "perms" %}
   {% get_obj_perms request.user for project.portfolio as "portfolio_perms" %}
   {% if "delete_project" in perms %}
-  <div class="col-xs-6 col-sm-1"><small style="color: #888;">Role: Owner</small></div>
+  <div class="col-xs-6 col-sm-2"><small style="color: #888;">Owner</small></div>
   {% elif "change_project" in perms%}
-  <div class="col-xs-6 col-sm-1"><small style="color: #888;">Role: Member</small></div>
+  <div class="col-xs-6 col-sm-2"><small style="color: #888;">Project Member</small></div>
   {% elif "portfolio_perms"%}
-  <div class="col-xs-6 col-sm-1"><small style="color: #888;">Portfolio Permission</small></div>
+  <div class="col-xs-6 col-sm-2"><small style="color: #888;">Portfolio Member</small></div>
   {% endif %}
-  <div class="col-xs-6 col-sm-2"><small style="color: #888;">Portfolio: {{project.portfolio.title}}</small></div>
-  <div class="col-xs-6 col-sm-1"><small style="color: #888;">ID: {{project.id}}</small></div>
 
-  <div class="col-xs-12 col-md-2" style="text-align: right;">
+  <div class="col-xs-12 col-md-2" style="text-align: left;">
       <small style="color: #888;">
       <!-- App version: {{project.root_task.module.spec.catalog.version|force_escape}} -->
-      Updated {{project.root_task.updated|naturaltime}}
+      {{project.root_task.updated|naturaltime}}
       <!-- Started: {{project.created|naturaltime}} -->
     </small>
   </div>


### PR DESCRIPTION

Fix Portfolio members editing Portfolio Projects

Append new Django Guardian permission check to legacy
0.8.6 permission checks to make sure users with
permissions to view, edit, change a portfolio can
view, edit, change all portfolio projects. In other words,
a Portfolio member can edit all Portfolio Projects.

Learned from Josh that we have many permissions on individual
tasks because we created tasks (and teir permissions) before
we created Projects (or Portfolios). So we have a lot of bottom-up
permissions management sprinkled throughout the code.

Now that we have Projects, and Django Guardian, it will make
more sense to check Project permissions rather than task permissions.
In future we can increase the granularity of the permissions back to
questions (tasks) and answers.

The fast fix is to append 0.9.0 Guardian permission check to
a legacy 0.8.6 check, which we do here.

We also fix a few typos in comments and HttpResponseForbidden message
to help debug.

Remove legacy Organization from discussion invites, turn off discussion polling

Non-super users were not able to submit discussion comments
because the invitations being sent upon comment add still included
legacy organization reference. Invitations no longer have Organizations
in model after the removal of multi-tenant sub domains.

Removing the reference to organizations solved the issue with users
not being able to add comments.

We won't need organizations on discussion in future either, because
discussions will be tied to projects (or tasks) that still have
organization structure built-in.

Also turned of javascript initiation of polling for updates on
discussions in order to remove that noise from log. Polling was
a cheap way to check.

Add column headers to Projects, Portfolios listing