### PR TITLE
Ge priv tweaks 0830

### DIFF
--- a/discussion/models.py
+++ b/discussion/models.py
@@ -407,7 +407,6 @@ class Comment(models.Model):
             "emojis": self.emojis.split(",") if self.emojis else None,
         }
 
-
 class Attachment(models.Model):
     user = models.ForeignKey(User, on_delete=models.PROTECT, help_text="The user uploading this attachment.")
     comment = models.ForeignKey(Comment, blank=True, null=True, related_name="attachments", on_delete=models.CASCADE, help_text="The Comment that this Attachment is attached to. Null when the file has been uploaded before the Comment has been saved.")
@@ -433,7 +432,6 @@ def reldate(date, ref=None):
     if rd.hours >= 1: return c((rd.hours, "hour"), (rd.minutes, "minute"))
     if rd.minutes >= 1: return c((rd.minutes, "minute"),)
     return c((rd.seconds, "second"),)
-
 
 def render_text(text, autocompletes=None, comment=None, unwrap_p=False):
     # Render comment text into HTML.
@@ -464,7 +462,6 @@ def render_text(text, autocompletes=None, comment=None, unwrap_p=False):
         text = re.sub(r"^<p>(.*)</p>$", r"\1", text)
 
     return text
-
 
 def match_autocompletes(text, autocompletes, replace_mentions=None):
     import re

--- a/guidedmodules/models.py
+++ b/guidedmodules/models.py
@@ -11,6 +11,7 @@ from .module_logic import ModuleAnswers, render_content
 from .answer_validation import validator
 from siteapp.models import User, Organization, Project, ProjectMembership
 
+
 class AppSource(models.Model):
     is_system_source = models.BooleanField(default=False, help_text="This field is set to True for a single AppSource that holds the system modules such as user profiles.")
     slug = models.CharField(max_length=200, unique=True, help_text="A unique URL-safe string that names this AppSource.")
@@ -933,7 +934,7 @@ class Task(models.Model):
         return self.get_access_level(user, allow_access_to_deleted=allow_access_to_deleted) in ("READ", "WRITE") or self.project.has_read_priv(user)
 
     def has_write_priv(self, user, allow_access_to_deleted=False):
-        return self.get_access_level(user, allow_access_to_deleted=allow_access_to_deleted) == "WRITE" or self.project.has_read_priv(user)
+        return self.get_access_level(user, allow_access_to_deleted=allow_access_to_deleted) == "WRITE" or self.project.has_write_priv(user)
 
     def has_review_priv(self, user):
         if self.project.organization is None:

--- a/siteapp/models.py
+++ b/siteapp/models.py
@@ -572,6 +572,23 @@ class Project(models.Model):
             return True
         return False
 
+    def has_write_priv(self, user):
+        # TODO: Create interfaces for managing separate has_write_priv
+        # Meanwhile, during transition from 0.8.6 to 0.9.0 allow users who had access
+        # to continue access and be able to edit
+
+        # Who can edit this project('s questions)?
+        # + anyone who is a member of the project's portfolio
+        if (user.has_perm('change_portfolio', self.portfolio) or user.has_perm('view_portfolio', self.portfolio)):
+            return True
+        # + anyone who has read, view, change permission on project
+        if user.has_perm('change_project', self):
+            return True
+        # TODO: Is this too permissive?
+        if (not self.is_account_project) and (user in self.get_members()):
+            return True
+        return False
+
     def get_all_participants(self):
         # Get all users who have read access to this project. Inverse of
         # has_read_priv.


### PR DESCRIPTION
Add distinct project.has_write_priv method

Separate has_write_priv method created for write
permissions on project.

Incorporate Guardian Project, Portfolio permissions for comments

Leverage 0.9.0 Django Guardian Permissions to make sure
users who have access to portfolio or project can make comments in
discussion.

Fixes issue where users could not start discussions