### PR TITLE
Ge fix helpers 0901

### DIFF
--- a/siteapp/admin.py
+++ b/siteapp/admin.py
@@ -15,7 +15,7 @@ def all_user_fields_still_exist(fieldlist):
 
 class UserAdmin(contribauthadmin.UserAdmin):
     ordering = ('username',)
-    list_display = ('id', 'email', 'date_joined') # base has first_name, etc. fields that we don't have on our model
+    list_display = ('username', 'email', 'date_joined', 'id') # base has first_name, etc. fields that we don't have on our model
     fieldsets = [
         (None, {'fields': ('email', 'password')}),
     ] + [fs for fs in contribauthadmin.UserAdmin.fieldsets if all_user_fields_still_exist(fs[1]['fields'])]
@@ -23,7 +23,7 @@ class UserAdmin(contribauthadmin.UserAdmin):
     pass
 
 class OrganizationAdmin(admin.ModelAdmin):
-    list_display = ('slug', 'name')
+    list_display = ('slug', 'name', 'id')
     filter_horizontal = ('help_squad', 'reviewers')
 
     def save_model(self, request, obj, form, change):

--- a/siteapp/models.py
+++ b/siteapp/models.py
@@ -203,6 +203,9 @@ class User(AbstractUser):
         except:
             pass
 
+        # Add username to profile
+        profile["username"] = self.username
+
         return profile
 
 

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -98,7 +98,7 @@ GovReady-Q Setup
         },
         template: function(value) {
           var node = $("<span></span>");
-          node.text(value.name_and_email);
+          node.text(value.username + " " + value.name_and_email);
           return node.html();
         },
         replace: function(value, event) {

--- a/templates/settings_usertable.html
+++ b/templates/settings_usertable.html
@@ -40,6 +40,6 @@
 {% endif %}
 
 <p>
-  <input id="{{listid}}-select-user" type="text" class="form-control" style="width: 20em; display: inline-block; height: 30px" placeholder="name, username, or email">
+  <input id="{{listid}}-select-user" type="text" class="form-control" style="width: 20em; display: inline-block; height: 30px" placeholder="">
   <button id="{{listid}}-select-user-submit" class="btn btn-primary btn-sm" disabled onclick="org_user_list_add(this)"><span class="glyphicon glyphicon-plus"></span> Add User to {{listname}}</button>
 </p>


### PR DESCRIPTION
Fix help squad, reviewer settings management in 0.9.0.

Management of help squad and reviewers was tied to Organization in 0.8.6. Javascript calls for adding/removing users to help squad and reviewers assumed request passed organization value.

For initial fix, we stop looking to request for organization and set organization to the main organization.
    
Also add username to User.render_context_dict() method so we can autocomplete on username.

Tweak Organization and User Admin list to see id and username respectively in records list.
