### PR TITLE
Get quickstart (and related commands) working on 0.9.0

### DIFF
--- a/quickstart.sh
+++ b/quickstart.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+
+# this script can be used to quickly set up a new  GovReady-Q instance
+# for local testing, from a freshly-cloned repository.
+
+# note that this script DOES NOT install libraries from a package manager,
+# and does not edit /etc/hosts. those will have to be done manually
+
+
+# When adding users, we expect they'll be created for test purposes. Therefore, a
+# static easy-to-remember password is useful.
+DEFAULT_USER_PASSWORD="GovReadyTest2019"
+
+# some of these commands generate a big wall of text, so we may want visual space
+# between them
+SPACER="..."
+
+# make sure we're not running in an environment with the wrong Python
+# command names (Docker, for instance, has python3.6 as the command)
+function check_has_command() {
+	which $1 >/dev/null 2>&1
+	return $?
+}
+if check_has_command python3 && check_has_command pip3
+then
+	: # we're good
+else
+	echo "ERROR: The commands 'python3' and 'pip3' are not available.";
+	exit 1;
+fi
+
+
+# install basic requirements either in venv or as the local user
+if test -f env/bin/activate
+then
+	source env/bin/activate;
+	pip3 install -r requirements.txt;
+else
+	pip3 install --user -r requirements.txt;
+fi
+echo $SPACER
+./fetch-vendor-resources.sh
+
+# create the local/environment.json file, if it is missing (it generally will be)
+if [ ! -e local/environment.json ];
+then
+	echo "creating DEV environment.json file"
+
+	# this is an easy way for us to get a random secret key
+	SECRET_KEY_LINE="$(python3 manage.py | grep '"secret-key":')"
+
+	# need to use a <<- heredoc if we want to have tabs be ignored
+	cat <<- ENDJSON > local/environment.json
+	{
+	  "debug": true,
+	  "host": "localhost:8000",
+	  "https": false,
+	  "organization-parent-domain": "localhost",
+	$SECRET_KEY_LINE
+	}
+	ENDJSON
+else
+	echo "environment.json file already exists, proceeding"
+fi
+
+
+# run various DB setup scripts (schema, core data, etc.)
+python3 manage.py migrate
+python3 manage.py load_modules
+echo $SPACER
+echo $SPACER
+echo $SPACER
+python3 manage.py first_run
+echo $SPACER
+
+# prompt the user if they want to run data generation
+while true;
+do
+	read -p "Do you want to add some simulated starting data (users, a second organization, and assessments)? [y/n] " answer
+	case $answer in
+		[Yy]* ) python3 manage.py populate --full --password "$DEFAULT_USER_PASSWORD"; break;;
+		[Nn]* ) break;;
+		* ) echo "Please answer 'yes' or 'no'";;
+	esac
+done
+
+echo $SPACER
+
+# prompt the user if they want to run the webserver now
+# this currently runs synchronously, in the foreground, so it needs to be the last
+# functional line of the script
+while true;
+do
+	read -p "Do you want to run the webserver now, in the foreground? [y/n] " answer
+	case $answer in
+		[Yy]* ) python3 manage.py runserver; break;;
+		[Nn]* ) break;;
+		* ) echo "Please answer 'yes' or 'no'";;
+	esac
+done
+
+echo $SPACER
+
+echo 'Reminder: use the command `python3 manage.py runserver` to restart the webserver'

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -7,10 +7,6 @@
 # and does not edit /etc/hosts. those will have to be done manually
 
 
-# When adding users, we expect they'll be created for test purposes. Therefore, a
-# static easy-to-remember password is useful.
-DEFAULT_USER_PASSWORD="GovReadyTest2019"
-
 # some of these commands generate a big wall of text, so we may want visual space
 # between them
 SPACER="..."
@@ -76,7 +72,7 @@ echo $SPACER
 # prompt the user if they want to run data generation
 while true;
 do
-	read -p "Do you want to add some simulated starting data (assessments)? [y/n] " answer
+	read -p "Do you want to add some simulated starting data (users, assessments)? [y/n] " answer
 	case $answer in
 		[Yy]* ) python3 manage.py add_data; break;;
 		[Nn]* ) break;;

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -76,9 +76,9 @@ echo $SPACER
 # prompt the user if they want to run data generation
 while true;
 do
-	read -p "Do you want to add some simulated starting data (users, a second organization, and assessments)? [y/n] " answer
+	read -p "Do you want to add some simulated starting data (assessments)? [y/n] " answer
 	case $answer in
-		[Yy]* ) python3 manage.py populate --full --password "$DEFAULT_USER_PASSWORD"; break;;
+		[Yy]* ) python3 manage.py add_data; break;;
 		[Nn]* ) break;;
 		* ) echo "Please answer 'yes' or 'no'";;
 	esac

--- a/testmocking/data_management.py
+++ b/testmocking/data_management.py
@@ -62,27 +62,6 @@ def create_user(username=None, password=None, pw_hash=None):
         file.write("\n")
     return u 
 
-def create_organization(name=None, admin=None, help_squad=[], reviewers=[]):
-    if name == None:
-        name = get_name(2)
-        name += " " + get_name(1, path='company_suffixes.txt')
-    slug = name.replace(' ', '-').lower()
-
-    with open(_getpath(Organization), 'a+') as file:
-        org = Organization.create(
-            name=name,
-            slug=slug,
-            admin_user=admin,
-        )
-        file.write(str(org.id))
-        file.write("\n")
-
-    for user in help_squad:
-        org.help_squad.add(user)
-    for user in reviewers:
-        org.reviewers.add(user)
-    return org 
-
 def create_portfolio(user):
     portfolio = Portfolio.objects.create(title=user.username)
     portfolio.assign_owner_permissions(user)

--- a/testmocking/management/commands/add_data.py
+++ b/testmocking/management/commands/add_data.py
@@ -12,6 +12,10 @@ from testmocking.web import WebClient
 
 import re
 
+# When adding users, we expect they'll be created for test purposes. Therefore, a
+# static easy-to-remember password is useful.
+DEFAULT_USER_PASSWORD="GovReadyTest2019"
+
 class Command(BaseCommand):
     client = None
 
@@ -49,10 +53,15 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         delay = 0
         count = 1
+        user_count = 0
 
         if not options['non_interactive']:
+            user_count = self.prompt("How many users do you want to create? (0 or more)")
             count = self.prompt("How many assessments do you want to create and populate? (note: if you want to run until canceled, enter a large number, and hit Ctrl-C when you want to stop)")
             print("")
             delay = self.prompt_for_time("It's possible to insert a delay between each action, while generating data. Enter the desired number of seconds to wait, or 0 for no delay.")
             
+        if int(user_count) > 0:
+            call_command("populate", "--user-count", user_count, "--password", DEFAULT_USER_PASSWORD)
+
         call_command('create_and_fill_assessment', '--action-delay', delay, '--count', count)

--- a/testmocking/management/commands/populate.py
+++ b/testmocking/management/commands/populate.py
@@ -22,7 +22,6 @@ class Command(BaseCommand):
         parser.add_argument('--password', help="The password to set for all users. Optional, but recommended. If not set, all users will have the same random password, instead.")
         
         parser.add_argument('--user-count', type=int, default=5, help="How many users to create at once")
-        parser.add_argument('--org-count', type=int, default=1, help="How many organizations to create at once")
 
         parser.add_argument('--full', action="store_true", help="Also start and fill out assessments, etc., for each organization")
 
@@ -40,26 +39,6 @@ class Command(BaseCommand):
                 print("Created user #" + str(x+1))
             create_portfolio(u)
             print("Created portfolio for user {}".format(u.username))
-        for x in range(0, options['org_count']):
-            admin = sample(users, 1)[0]
-            help_squad = sample(users, 5)
-            reviewers = sample(users, 5)
-            org = create_organization(admin=admin, help_squad=help_squad, reviewers=reviewers)
-            print("Admin for " + org.name + ": " + admin.username)
-
-            if options['full']:
-                print('Adding system...')
-                call_command('add_system', '--username', admin.username, '--org', org.slug)
-                print('Adding assessments...')
-                call_command('start_section', '--to-completion', '--username', admin.username, '--org', org.slug)
-
-                print('Prepping assessments (tasks, pass #1)...')
-                call_command('answer_all_tasks', '--quiet', '--impute', 'answer', '--org', org.slug)
-
-                print('Filling assessments (tasks, pass #2)...')
-                call_command('answer_all_tasks', '--quiet', '--impute', 'answer', '--org', org.slug)
-
-                final_output.append('Finished org {}. Login using user:pass {} : {}'.format(org.name, admin.username, options['password']))
 
         for line in final_output:
             print(line)

--- a/testmocking/management/commands/populate.py
+++ b/testmocking/management/commands/populate.py
@@ -13,7 +13,7 @@ from guidedmodules.models import AppSource, Module
 from siteapp.models import User, Organization
 
 from django.utils.crypto import get_random_string
-from testmocking.data_management import create_user, create_organization, create_portfolio
+from testmocking.data_management import create_user, create_portfolio
 
 class Command(BaseCommand):
     help = 'Create a set of dummy data for extended testing/verification. Creates users, portfolios, organizations, user/org assignments, and with --full, can also populate the created organizations with assessments.'

--- a/testmocking/web.py
+++ b/testmocking/web.py
@@ -77,17 +77,22 @@ class WebClient():
             url = self._url(form.attrib['action'])
         else:
             url = self.base_url
+        self.post(url, base_fields)
+
+    def post(self, url, fields):
         print("POST on: <{}>".format(url))
-        req = self.session.post(url, base_fields)
+        req = self.session.post(url, fields)
         req.user = self.user
         req.organization = self.org
         self._resolve(req)
 
 
     def add_system(self):
-        self.load("/store")
+        portfolio = sample(list(self.user.portfolio_list()), 1)[0]
+        print("Adding project to portfolio: {} (#{})".format(portfolio.title, portfolio.id))
+        self.post("/store", {"portfolio":portfolio.id})
 
-        form = sample(self.selector.css('[action^="/store"]'), 1)[0]
+        form = sample(self.selector.css('[action^="/store/"]'), 1)[0]
         self.form_by_ref(form)
         print(self.response.url)
         #self.html_debug()


### PR DESCRIPTION
Makes `quickstart.sh` work on 0.9.0. Has the following key changes:

- Fixes assessment-creating commands (broke due to portfolio changes, not caught in the original merge)
- Removes obsolete Organization-related data generation code. Organizations are no longer generated, and new code would need to be written for equivalent functionality.
- Due to datagen reorganization in 0.9.0, adds `quickstart.sh` script, and patches it to match the current commands. (otherwise, a second PR against 0.8.6 would be needed)
- Updates 0.9.0 data gen to have one command for adding users and assessments, similar to 0.8.6 behavior of quickstart.sh