### PR TITLE
Hide project list column headings with no projects

### DIFF
--- a/templates/portfolios/detail.html
+++ b/templates/portfolios/detail.html
@@ -43,7 +43,6 @@ Remove contextbar from top of page
 
     {% if projects|length > 0 %}
     <p>This portfolio has {{ projects|length }} project{{ projects|pluralize }}</p>
-    {% endif %}
 
     <div class="container">
       <div class="row">
@@ -54,6 +53,7 @@ Remove contextbar from top of page
         <div class="col-xs-6 col-sm-2">Role</div>
         <div class="col-xs-12 col-md-2">Updated</div>
       </div>
+    {% endif %}
 
       {% for project in projects %}
       <div class="row" style="border-top: 1px solid #aaa;padding: 8px 0px 8px 0px;">

--- a/templates/portfolios/portfolios_table.html
+++ b/templates/portfolios/portfolios_table.html
@@ -2,6 +2,7 @@
 {% load humanize %}
 {% load guardian_tags %}
 
+{% if portfolios %}
 <div class="container">
 <div class="row">
   <div class="col-xs-10 col-md-5">Portfolio</div>
@@ -10,6 +11,7 @@
   <div class="col-md-2">&nbsp;</div>
   <div class="col-xs-12 col-md-2">Created</div>
 </div>
+{% endif %}
 
   {% for portfolio in portfolios %}
   <div class="row" style="border-top: 1px solid #aaa;padding: 8px 0px 8px 0px;">

--- a/templates/projects.html
+++ b/templates/projects.html
@@ -118,7 +118,6 @@ Your Compliance Projects
 
 {% if projects|length > 0 %}
 <p>You have access to {{ projects|length }} project{{ projects|pluralize }}</p>
-{% endif %}
 
 <div class="container">
 <div class="row">
@@ -129,6 +128,7 @@ Your Compliance Projects
   <div class="col-xs-6 col-sm-2">Role</div>
   <div class="col-xs-12 col-md-2">Updated</div>
 </div>
+{% endif %}
 
 {% for project in projects %}
 <div class="row" style="border-top: 1px solid #aaa;padding: 8px 0px 8px 0px;">


### PR DESCRIPTION
Small UI tweak to hider the column headings in portfolio pages that list the projects.