### PR TITLE
Require special env var to prevent accidental migrations to 0.9.0

### DIFF
--- a/deployment/docker/dockerfile_exec.sh
+++ b/deployment/docker/dockerfile_exec.sh
@@ -90,7 +90,35 @@ echo "Starting at ${ADDRESS} with HTTPS ${HTTPS-false}."
 python3.6 manage.py check --deploy
 
 # Check if 0.9.0 upgrade has happened
-DB_BEFORE_090 ="$(python3.6 manage.py db_before_090_migration_check)"
+DB_BEFORE_090=$(python3.6 manage.py db_before_090)
+if [ $DB_BEFORE_090 = "True" ]
+then
+	echo "** WARNING!! **"
+	echo "Launching this container will automatically upgrade your GovReady-Q deployment to version 0.9.0!"
+	echo "Upgrading to version 0.9.0 will migrate your database."
+	echo "Please review migration notes at https://govready-q.readthedocs.io/en/latest/migration_guide_086_090.html"
+	if [ -z "${DB_BACKED_UP_DO_UPGRADE-}" ]
+		then
+			echo "'DB_BACKED_UP_DO_UPGRADE' environment variable not set."
+			echo "To confirm you have backed up your database and deploy version 0.9.0, set the 'DB_BACKED_UP_DO_UPGRADE' environment variable to 'True' for your deployment."
+			echo "Launch and deployment halted to protect your existing database."
+			exit 1
+		else
+			echo "Confirmed 'DB_BACKED_UP_DO_UPGRADE' environment variable is set."
+		fi
+		if [ "${DB_BACKED_UP_DO_UPGRADE-}" != "True" ]
+		then
+			echo "'DB_BACKED_UP_DO_UPGRADE' environment variable not set to 'True'."
+			echo "To confirm you have backed up your database and deploy version 0.9.0, set the 'DB_BACKED_UP_DO_UPGRADE' environment variable to 'True' for your deployment."
+			echo "Launch and deployment halted to protect your existing database."
+			exit 1
+		else
+			echo "Confirmed 'DB_BACKED_UP_DO_UPGRADE' environment variable is set to 'True'."
+			echo "Continuing with deployment."
+		fi
+else
+	echo "Confirmed that database has been migrated, and is compatible with version 0.9.0."
+fi
 
 # Initialize the database.
 python3.6 manage.py migrate

--- a/docs/source/migration_guide_086_090.md
+++ b/docs/source/migration_guide_086_090.md
@@ -67,7 +67,7 @@ Complete list of changes: [https://github.com/GovReady/govready-q/blob/0.9.0.dev
 * Back up the most recent version of the production database.
 * Test a restore of most recent version of the database.
 * Synchronize your container customizations to produce a new version of your container.
-* Deploy Container running version 0.9.0 <!--with the paramater YYY for deployment -->
+* Deploy Container running version 0.9.0 **with environment variable `DB_BACKED_UP_DO_UPGRADE` set to "True"**. (This special environment variable is required to avoid accidental running of database migrations before database has been backed up.)
 * Docker will automatically run migrations as part of deployment.
 
 ### Migration Finalization and Testing


### PR DESCRIPTION
Because Docker automatically runs database migrations, we add
the special environment variable DB_BACKED_UP_DO_UPGRADE that
must be intentionnally set to 'True' for dockerfile_exec.sh to
fully execute and migrate the database in deployments using Docker.

We test to make see if deployment's database is still in state
of version 0.8.6 and if so, then look for the DB_BACKED_UP_DO_UPGRADE
environment variable. If database has already been migrated, test
is ignored. If DB_BACKED_UP_DO_UPGRADE is set correctly to "True",
we proceed with migration.

This test avoids accidental migrations of databases without
organization first reading about upgrade to 0.9.0 and being
given the opportunity to back up database.