### PR TITLE
HOLD Till 0.9.0. merge to master - 0.9.0.dev remove uneeded migration

### DIFF
--- a/siteapp/migrations/0027_auto_20190708_1517.py
+++ b/siteapp/migrations/0027_auto_20190708_1517.py
@@ -20,7 +20,7 @@ class Migration(migrations.Migration):
                 ('projects', models.ManyToManyField(blank=True, help_text='The Projects that are listed within this Portfolio.', related_name='in_folders', to='siteapp.Project')),
             ],
             options={
-                'permissions': (('view_portfolio', 'View portfolio'), ('can_grant_portfolio_owner_permission', 'Grant a user portfolio owner permission')),
+                'permissions': (('can_grant_portfolio_owner_permission', 'Grant a user portfolio owner permission')),
             },
         ),
         migrations.AlterField(

--- a/siteapp/migrations/0027_auto_20190708_1517.py
+++ b/siteapp/migrations/0027_auto_20190708_1517.py
@@ -20,7 +20,7 @@ class Migration(migrations.Migration):
                 ('projects', models.ManyToManyField(blank=True, help_text='The Projects that are listed within this Portfolio.', related_name='in_folders', to='siteapp.Project')),
             ],
             options={
-                'permissions': (('can_grant_portfolio_owner_permission', 'Grant a user portfolio owner permission')),
+                'permissions': ('can_grant_portfolio_owner_permission', 'Grant a user portfolio owner permission'),
             },
         ),
         migrations.AlterField(

--- a/siteapp/migrations/0029_auto_20190801_2000.py
+++ b/siteapp/migrations/0029_auto_20190801_2000.py
@@ -11,10 +11,6 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.AlterModelOptions(
-            name='project',
-            options={'permissions': (('view_project', 'View project'),)},
-        ),
         migrations.AlterField(
             model_name='portfolio',
             name='title',

--- a/siteapp/models.py
+++ b/siteapp/models.py
@@ -359,9 +359,9 @@ class Portfolio(models.Model):
     updated = models.DateTimeField(auto_now_add=True, db_index=True)
 
     class Meta:
-        permissions = (
+        permissions = [
             ('can_grant_portfolio_owner_permission', 'Grant a user portfolio owner permission'),
-        )
+        ]
 
     def get_absolute_url(self):
         return "/portfolios/%s/projects" % (self.id)

--- a/siteapp/models.py
+++ b/siteapp/models.py
@@ -360,7 +360,6 @@ class Portfolio(models.Model):
 
     class Meta:
         permissions = (
-            ('view_portfolio', 'View portfolio'),
             ('can_grant_portfolio_owner_permission', 'Grant a user portfolio owner permission'),
         )
 
@@ -485,9 +484,6 @@ class Project(models.Model):
 
     class Meta:
         unique_together = [('organization', 'is_organization_project')] # ensures only one can be true
-        permissions = (
-            ('view_project', 'View project'),
-        )
 
     def __str__(self):
         # For the admin, notification strings


### PR DESCRIPTION
The 'view_portfolio' and 'view_project' permissions are being removed in this pull request because when the master branch is upgraded to the latest version of Django (2.2) the 'view' permission in all models comes by default. Because 0.9.0 will be merged after the upgrade not removing these parts of the migration will cause a duplicate error. 