### PR TITLE
(0.9.0 docs) small doc fixes

### DIFF
--- a/docs/source/Test.md
+++ b/docs/source/Test.md
@@ -8,7 +8,7 @@ GovReady-Q's unit tests and integration tests are currently combined. Our integr
 To run the integration tests, you'll also need to install chromedriver:
 
 	sudo apt-get install chromium-chromedriver   (on Ubuntu)
-	brew install chromedriver                    (on Mac)
+	brew cask install chromedriver               (on Mac)
 
 Navigate within your terminal to GovReady-Q top level directory.
 

--- a/docs/source/version.0.9.0.md
+++ b/docs/source/version.0.9.0.md
@@ -2,7 +2,7 @@
 
 ## What's New in 0.9.0
 
-Release 0.9.0 (coming Summer 2019) is a minor release improving
+Release 0.9.0 (coming Autumn 2019) is a minor release improving
 the user experience and performance.
 
 * Faster loading and launching of Assessments/questionnaires
@@ -24,13 +24,13 @@ Release 0.9.0 progress can be found on the `0.9.0.dev` and `0.9.0.rc-xxx` branch
 
 ## Release Date
 
-The target release date 0.9.0 is Summer 2019.
+The target release date 0.9.0 is Autumn 2019.
 
 ## Upgrading to 0.9.0 from 0.8.x
 
 **Backup your database before upgrading to 0.9.0. Release 0.9.0 performs database changes that makes rolling back difficult.**
 
-See [Migration Guide for GovReady-Q (0.8.6 to 0.9.0)](migration_guide_086_090.md).
+See [Migration Guide for GovReady-Q (0.8.6 to 0.9.0)](migration_guide_086_090.html).
 
 ## Installing 0.9.0
 


### PR DESCRIPTION
Small changes to docs
* change "Summer 2019" to "Autumn 2019"
* fix relative link for migration_guide_086_090.{md,html} to work on ReadTheDocs instead of GitHub
*chromedriver has been migrated to Cask, so the install command is now 'brew cask install'. See (amongst other references) [chromedriver: migrate to cask](https://github.com/Homebrew/homebrew-core/pull/25566)