### PR TITLE
(0.8.6 docs) a couple small docs fixes

### DIFF
--- a/docs/source/Test.md
+++ b/docs/source/Test.md
@@ -8,7 +8,7 @@ GovReady-Q's unit tests and integration tests are currently combined. Our integr
 To run the integration tests, you'll also need to install chromedriver:
 
 	sudo apt-get install chromium-chromedriver   (on Ubuntu)
-	brew install chromedriver                    (on Mac)
+	brew cask install chromedriver               (on Mac)
 
 Navigate within your terminal to GovReady-Q top level directory.
 

--- a/docs/source/version.0.9.0.md
+++ b/docs/source/version.0.9.0.md
@@ -11,7 +11,8 @@ table, tr, td {
 
 ## What's New in 0.9.0
 
-Release 0.9.0 (coming July 2019) is a minor release improving
+Release 0.9.0 (coming Autumn 2019) is a minor release improving
+
 the user experience and performance.
 
 * Faster loading and launching of Assessments/questionnaires
@@ -121,7 +122,7 @@ Release 0.9.0 progress can be found on the `0.9.0.dev` and `0.9.0.rc-xxx` branch
 
 ## Release Date
 
-The target release date for 0.9.0 is September 2019.
+The target release date for 0.9.0 is Autumn 2019.
 
 ## Installing 0.9.0
 
@@ -540,7 +541,7 @@ Click one of the tab belows to see the release 0.9.0 quickstart for the indicate
 
 **Backup your database before upgrading to 0.9.0. Release 0.9.0 performs database changes that makes rolling back difficult.**
 
-See [Migration Guide for GovReady-Q (0.8.6 to 0.9.0)](migration_guide_086_090.md).
+See [Migration Guide for GovReady-Q (0.8.6 to 0.9.0)](migration_guide_086_090.html).
 
 ## Adding and Managing "Compliance Apps" in 0.9.0
 


### PR DESCRIPTION
This is like PR #753, but for 0.8.6 instead of 0.9.0. It's needed mostly to fix the migration guide link, but the other two fixes are nice to have, too.

* change "July/September 2019" to "Autumn 2019"
* fix relative link for migration_guide_086_090.{md,html} to work on ReadTheDocs instead of GitHub
* fix chromedriver install instructions
