### PR TITLE
fix typo in docs: sever->server

### DIFF
--- a/docs/source/Environment.md
+++ b/docs/source/Environment.md
@@ -22,7 +22,7 @@ The following environment variables are used to configure your GovReady-Q instan
 - `single-organization`: used to enforce single organization mode with "main" as subdomain of default organization instead of multi-tenant with different subdomains for different organizations.
 - `static`: used to prepend a root path to the default `/static/` URL path for accessing static assets.
 - `syslog`: used to set the host and port of a syslog-compatible log message sink. (Default: None.)
-- `trust-user-authentication-headers`: used to activate reverse proxy authentication. See [Proxy Authentication Sever](enterprise_sso.html#proxy-authentication-sever).
+- `trust-user-authentication-headers`: used to activate reverse proxy authentication. See [Proxy Authentication Server](enterprise_sso.html#proxy-authentication-server).
 
 ### Production Deployment Environment Settings
 

--- a/docs/source/deploy_docker.md
+++ b/docs/source/deploy_docker.md
@@ -322,7 +322,7 @@ The following environment variables are used to configure the container when lau
 
 `BRANDING` (downstream packaging only): You may override the templates and stylesheets that are used for GovReady-Q's branding by setting this environment variable to the name of an installed Django app Python module (i.e. created using `manage.py startapp`) that holds templates and static files. No such app is provided in the GovReady-Q published Docker image, so this variable can only be used by downstream image maintainers.  See [Applying Custom Organization Branding](CustomBranding.html).
 
-`PROXY_AUTHENTICATION_USER_HEADER` and `PROXY_AUTHENTICATION_EMAIL_HEADER`: GovReady-Q can be deployed behind a reverse proxy that authenticates users and passes the authenticated user's username and email address in HTTP headers. These environment variables correspond to the settings documented in [Enterprise Login](Environment.html#proxy-authentication-sever).
+`PROXY_AUTHENTICATION_USER_HEADER` and `PROXY_AUTHENTICATION_EMAIL_HEADER`: GovReady-Q can be deployed behind a reverse proxy that authenticates users and passes the authenticated user's username and email address in HTTP headers. These environment variables correspond to the settings documented in [Enterprise Login](Environment.html#proxy-authentication-server).
 
 ### Running tests
 

--- a/docs/source/enterprise_sso.md
+++ b/docs/source/enterprise_sso.md
@@ -1,6 +1,6 @@
 ## Enterprise Single-Sign On / Login
 
-### Proxy Authentication Sever
+### Proxy Authentication Server
 
 GovReady-Q can be deployed behind a reverse proxy that authenticates users and passes the authenticated user's username and email address in HTTP headers. In this configuration:
 


### PR DESCRIPTION
Fixes instance of typo and two links.