### PR TITLE
Allow use of alternative virtual environments.

### DIFF
--- a/quickstart.sh
+++ b/quickstart.sh
@@ -33,7 +33,7 @@ then
 	pip3 install -r requirements.txt;
 elif [ -v $VIRTUALENV_ENV ]
 then
-  pip3 install -r requirements.txt;
+	pip3 install -r requirements.txt;
 else 
 	pip3 install --user -r requirements.txt;
 fi
@@ -51,11 +51,11 @@ then
 	# need to use a <<- heredoc if we want to have tabs be ignored
 	cat <<- ENDJSON > local/environment.json
 	{
-	  "debug": true,
-	  "host": "localhost:8000",
-	  "https": false,
-	  "organization-parent-domain": "localhost",
-	$SECRET_KEY_LINE
+		"debug": true,
+		"host": "localhost:8000",
+		"https": false,
+		"organization-parent-domain": "localhost",
+		$SECRET_KEY_LINE
 	}
 	ENDJSON
 else

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -31,7 +31,10 @@ if test -f env/bin/activate
 then
 	source env/bin/activate;
 	pip3 install -r requirements.txt;
-else
+elif [ -v $VIRTUALENV_ENV ]
+then
+  pip3 install -r requirements.txt;
+else 
 	pip3 install --user -r requirements.txt;
 fi
 echo $SPACER


### PR DESCRIPTION
@gregelin @cityinohio2019 nice to e-meet you. This is Ian Campbell - we emailed today / I'm speaking with Dayton tomorrow. I just started playing around a little with the platform using the local development tutorial and thought to make a couple (super tiny) contributions to see how things worked as well as check out the CI environment.

This PR allows users to use their own virtualenvironment setup vs. forcing the virtualenv to be part of the working directory.

Feel free to close if this isn't helpful - I'm just testing things out!

Checks for the presence of $VIRTUALENV_ENV to detect an existing
virtual environment, per https://stackoverflow.com/a/28388115/2532070.

If a virtualenvironment exists, install requirements to this
environment.