### PR TITLE
Docs/add libmagic requirement

### DIFF
--- a/docs/source/deploy_local_dev.md
+++ b/docs/source/deploy_local_dev.md
@@ -4,7 +4,7 @@ This page provides additional tips for installing and run GovReady-Q in a mode s
 
 ## Quickstart
 
-For local development, there is a quickstart script available to speed up environment setup. After installing system requirements through your package manager, run the following four commands in order to set up GovReady-Q in a new directory:
+For local development, there is a quickstart script available to speed up environment setup. After installing [system requirements](https://govready-q.readthedocs.io/en/latest/requirements.html#system-requirements) through your package manager, run the following four commands in order to set up GovReady-Q in a new directory:
 
 ```
 git clone https://github.com/govready/govready-q

--- a/docs/source/requirements.md
+++ b/docs/source/requirements.md
@@ -13,6 +13,7 @@ GovReady-Q is a Python 3.6 and higher, Django 2.x application with a relational 
 | uwsgi 2.x |
 | unzip |
 | graphviz |
+| libmagic |
 | pandoc |
 | Wkhtmltopdf |
 | Git 2.x |


### PR DESCRIPTION
Small update to docs to add the required libmagic package that blocked the `quickstart.sh` script for me in MacOS local development. @gregelin @cityinohio2019 FYI.