### PR TITLE
Fix another timing-dependent test failure (#inputctrl).

### DIFF
--- a/siteapp/tests.py
+++ b/siteapp/tests.py
@@ -407,9 +407,10 @@ class GeneralTests(OrganizationSiteFunctionalTests):
         # Answer the questions.
 
         # Introduction screen.
+        var_sleep(1)
         self.assertRegex(self.browser.title, "Next Question: Introduction")
         self.click_element("#save-button")
-        var_sleep(1.5)
+        var_sleep(1)
 
         # Text question.
         self.assertIn("| A Simple Module - GovReady-Q", self.browser.title)


### PR DESCRIPTION
Fixes this error:

```
File "govready/govready-q/siteapp/tests.py", line 416, in test_simple_module
...
selenium.common.exceptions.NoSuchElementException: Message: no such element: Unable to locate element: {"method":"css selector","selector":"#inputctrl"}
```