### PR TITLE
Loads $VENDOR from local/environment.json (if it exists)

### DIFF
--- a/check-vendor-resources.sh
+++ b/check-vendor-resources.sh
@@ -2,7 +2,15 @@
 
 set -euo pipefail
 
-VENDOR=siteapp/static/vendor
+# retrieve 'static' from local/environment.json
+if [ -f local/environment.json ] ; then
+  VENDOR=$(python -c "import json; f=open('local/environment.json', 'r'); env=json.load(f); print(env.get('static',''))")
+fi
+
+# if VENDOR not set above, use default
+if [ -z "$VENDOR" ] ; then
+  VENDOR=siteapp/static/vendor
+fi
 
 SHACMD="sha256sum"
 SHACMD_CHECK="$SHACMD --strict --check"

--- a/list-vendor-resources.sh
+++ b/list-vendor-resources.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
-VENDOR=siteapp/static/vendor
+# retrieve 'static' from local/environment.json
+if [ -f local/environment.json ] ; then
+  VENDOR=$(python -c "import json; f=open('local/environment.json', 'r'); env=json.load(f); print(env.get('static',''))")
+fi
+
+# if VENDOR not set above, use default
+if [ -z "$VENDOR" ] ; then
+  VENDOR=siteapp/static/vendor
+fi
 
 ls -l `find $VENDOR -type f | sort -f`


### PR DESCRIPTION
If local/environment.json doesn't exist, it uses a default.

Uses python to load the JSON, doesn't require other libraries or utilities.

Code tested under these conditions:

* python2 AND python3
* local/environment.json exists AND local/environment.json does not exist
* 'static' key exists in local/environment.json AND 'static' key does not exist in local/environment.json