### PR TITLE
Install entire sqlite3 command instead of just sqlite3 library.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,8 @@ RUN safety check
 # Copy in the vendor resources and fetch them.
 COPY fetch-vendor-resources.sh ./
 RUN ./fetch-vendor-resources.sh
+# Confirm that sqlite3 command runs, for users who use it.
+RUN sqlite3 --version
 
 # Copy in remaining source code. (We put this last because these
 # change most frequently, so there is less to rebuild if we put

--- a/fetch-vendor-resources.sh
+++ b/fetch-vendor-resources.sh
@@ -49,19 +49,18 @@ mkdir -p $VENDOR
 
 # Fetch resources.
 
-# sqlite3 3.8.5 (Public Domain)
+# sqlite3 3.8.3 (Public Domain)
 # Django 2.2 requires SQLite 3.8.3 or later; on CentOS 7 an upgrade is needed
+# We borrow the package from Fedora Project, https://koji.fedoraproject.org/koji/packageinfo?packageID=485
 if command -v rpm > /dev/null 2>&1 ; then
   if test $(rpm --eval %{centos_ver}) = 7; then
-    echo "Upgrading SQLite library to 3.8.5"
+    echo "Upgrading SQLite to 3.8.3"
     download \
-      http://www6.atomicorp.com/channels/atomic/centos/7/x86_64/RPMS/atomic-sqlite-sqlite-3.8.5-3.el7.art.x86_64.rpm \
-      /tmp/atomic-sqlite-sqlite-3.8.5-3.el7.art.x86_64.rpm \
-      '72ec76327ce9816b258d5cbeffc2930d93edd0bf50ff567c30fa775583eabf85'
-    yum -y localinstall /tmp/atomic-sqlite-sqlite-3.8.5-3.el7.art.x86_64.rpm
-    mv /lib64/libsqlite3.so.0.8.6{,-3.17}
-    cp /opt/atomic/atomic-sqlite/root/usr/lib64/libsqlite3.so.0.8.6 /lib64
-    rm -f /tmp/atomic-sqlite-sqlite-3.8.5-3.el7.art.x86_64.rpm
+      https://kojipkgs.fedoraproject.org/packages/sqlite/3.8.3/1.fc20/x86_64/sqlite-3.8.3-1.fc20.x86_64.rpm \
+      /tmp/sqlite-3.8.3-1.fc20.x86_64.rpm \
+      '4c976fc17e3676ce76aa71ce604be6d16cef36c73515e9bf1ebcdbdc6cc6e7d4'
+    yum -y install /tmp/sqlite-3.8.3-1.fc20.x86_64.rpm
+    rm -f /tmp/sqlite-3.8.3-1.fc20.x86_64.rpm
   fi
 fi
 


### PR DESCRIPTION
For users who use the sqlite3 command inside a Docker container, this
branch makes sure to install the whole command, instead of just the
library.  It runs sqlite3 during the Docker build, as a test to make
sure it's working.

We use the least recent sqlite3 version acceptable to Django (v3.8.3)
instead of anything more recent, after observing large and small
compatibility problems between Django or other libraries and more
recent sqlite versions (3.22.x and up; previous versions weren't
tested). v3.8.5 was probably fine, but v3.8.3 seems more conservative,
and is still acceptable to Django.