### PR TITLE
Add '/health/request' and '/health/request-headers' command URLs

### DIFF
--- a/siteapp/urls.py
+++ b/siteapp/urls.py
@@ -75,6 +75,7 @@ urlpatterns = [
     url(r'^health/check-vendor-resources$', views_health.check_vendor_resources),
     url(r'^health/list-vendor-resources$', views_health.list_vendor_resources),
     url(r'^health/load-base/(?P<args>.*)$', views_health.load_base),
+    url(r'^health/request-headers$', views_health.request_headers),
 ]
 
 if 'django.contrib.auth.backends.ModelBackend' in settings.AUTHENTICATION_BACKENDS:

--- a/siteapp/urls.py
+++ b/siteapp/urls.py
@@ -76,6 +76,7 @@ urlpatterns = [
     url(r'^health/list-vendor-resources$', views_health.list_vendor_resources),
     url(r'^health/load-base/(?P<args>.*)$', views_health.load_base),
     url(r'^health/request-headers$', views_health.request_headers),
+    url(r'^health/request$', views_health.request),
 ]
 
 if 'django.contrib.auth.backends.ModelBackend' in settings.AUTHENTICATION_BACKENDS:

--- a/siteapp/views_health.py
+++ b/siteapp/views_health.py
@@ -6,10 +6,10 @@ from django.shortcuts import render
 def index(request):
     html = (
         '<html><body><ul>'
-        '<li><a href="/health/check-system">check-system</a></li>'
-        '<li><a href="/health/check-vendor-resources">check-vendor-resources</a></li>'
-        '<li><a href="/health/list-vendor-resources">list-vendor-resources</a></li>'
-        '<li><a href="/health/load-base">load-base</a></li>'
+        '<li><a href="/health/check-system">check-system</a> - View OS health (from "top").</li>'
+        '<li><a href="/health/check-vendor-resources">check-vendor-resources</a> - Checksum fetched vendor resources.</li>'
+        '<li><a href="/health/list-vendor-resources">list-vendor-resources</a> - List fetched vendor resources.</li>'
+        '<li><a href="/health/load-base">load-base</a> - Load base page template with toggleable libraries. Use "all" or "none" link at bottom of page, or edit URL to change which libraries are loaded.</li>'
         '</body></html>' )
     return HttpResponse(html)
 

--- a/siteapp/views_health.py
+++ b/siteapp/views_health.py
@@ -29,8 +29,6 @@ def list_vendor_resources(request):
     return HttpResponse(html)
 
 def load_base(request, args):
-    print(args)
     args = args.split(",")
-    print(args)
     context = {'args': args}
     return render(request, 'base-conditional.html', context)

--- a/siteapp/views_health.py
+++ b/siteapp/views_health.py
@@ -4,7 +4,6 @@ from django.http import HttpResponse
 from django.shortcuts import render
 
 def index(request):
-    output = subprocess.check_output(["./check-system.sh"]).decode("utf-8")
     html = (
         '<html><body><ul>'
         '<li><a href="/health/check-system">check-system</a></li>'

--- a/siteapp/views_health.py
+++ b/siteapp/views_health.py
@@ -10,6 +10,7 @@ def index(request):
         '<li><a href="/health/check-vendor-resources">check-vendor-resources</a> - Checksum fetched vendor resources.</li>'
         '<li><a href="/health/list-vendor-resources">list-vendor-resources</a> - List fetched vendor resources.</li>'
         '<li><a href="/health/load-base">load-base</a> - Load base page template with toggleable libraries. Use "all" or "none" link at bottom of page, or edit URL to change which libraries are loaded.</li>'
+        '<li><a href="/health/request-headers">request-headers</a> - View HTTP headers present in request sent by web browser.</li>'
         '</body></html>' )
     return HttpResponse(html)
 
@@ -32,3 +33,9 @@ def load_base(request, args):
     args = args.split(",")
     context = {'args': args}
     return render(request, 'base-conditional.html', context)
+
+def request_headers(request):
+    from pprint import pformat
+    output = pformat({k:v for k,v in request.headers.items()})
+    html = "<html><body><pre>{}</pre></body></html>".format(output)
+    return HttpResponse(html)

--- a/siteapp/views_health.py
+++ b/siteapp/views_health.py
@@ -2,6 +2,7 @@ import subprocess #nosec
 
 from django.http import HttpResponse
 from django.shortcuts import render
+from django.conf import settings
 
 def index(request):
     html = (
@@ -11,6 +12,7 @@ def index(request):
         '<li><a href="/health/list-vendor-resources">list-vendor-resources</a> - List fetched vendor resources.</li>'
         '<li><a href="/health/load-base">load-base</a> - Load base page template with toggleable libraries. Use "all" or "none" link at bottom of page, or edit URL to change which libraries are loaded.</li>'
         '<li><a href="/health/request-headers">request-headers</a> - View HTTP headers present in request sent by web browser.</li>'
+        '<li><a href="/health/request">request</a> - View entire request (must have DEBUG set).</li>'
         '</body></html>' )
     return HttpResponse(html)
 
@@ -38,4 +40,13 @@ def request_headers(request):
     from pprint import pformat
     output = pformat({k:v for k,v in request.headers.items()})
     html = "<html><body><pre>{}</pre></body></html>".format(output)
+    return HttpResponse(html)
+
+def request(request):
+    if settings.DEBUG:
+        from pprint import pformat
+        output = pformat(vars(request))
+        html = "<html><body><pre>{}</pre></body></html>".format(output)
+    else:
+        html = "<html><body><p>Please set DEBUG and try again.</p></body></html>"
     return HttpResponse(html)


### PR DESCRIPTION
Add '/health/request' and '/health/request-headers' command URLs, which return either the full request, or just the HTTP headers which came from web browser respectively.

The '/health/request' command requires DEBUG to be true, because it prints potentially sensitive system information.

Example output from '/health/request-headers':

```
{'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9',
 'Accept-Encoding': 'gzip, deflate, br',
 'Accept-Language': 'en-US,en;q=0.9',
 'Connection': 'close',
 'Content-Length': '',
 'Content-Type': 'text/plain',
 'Cookie': 'iam_session=username=testuser&email=testuser%40example.com; '
           'csrftoken=hrAm5pzGjAc09EGdS0zAHzQza68SWqkMM0l4saBTzwgqVpwj2nUxzafLIv7SpmXV; '
           'sessionid=kipus910b91fjac1m0jb85ltf0imf3sg',
 'Host': 'localhost:8000',
 'Iam-Email': 'testuser@example.com',
 'Iam-Username': 'testuser',
 'Sec-Fetch-Mode': 'navigate',
 'Sec-Fetch-Site': 'none',
 'Sec-Fetch-User': '?1',
 'Upgrade-Insecure-Requests': '1',
 'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) '
               'AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.88 '
               'Safari/537.36',
 'X-Forwarded-For': '127.0.0.1'}
```

Also, some tidying and improving of other things in the `/health/*` view code.