### PR TITLE
Enable trusted auth variable names to be passed via environment

### DIFF
--- a/docs/source/enterprise_sso.md
+++ b/docs/source/enterprise_sso.md
@@ -2,15 +2,15 @@
 
 ### Proxy Authentication Server
 
-GovReady-Q can be deployed behind a reverse proxy that authenticates users and passes the authenticated user's username and email address in HTTP headers. In this configuration:
+GovReady-Q can be deployed behind a reverse proxy that authenticates users and passes the authenticated user's username and email address in HTTP headers or environment variables. In this configuration:
 
 * The user points their browser to the reverse proxy authentication server.
-* The proxy authenticates users and proxies the request to GovReady-Q if and only if the user is authenticated and authorized to access GovReady-Q. The proxy passes the user's username and email address in HTTP headers of the proxy's choosing. 
+* The proxy authenticates users and proxies the request to GovReady-Q if and only if the user is authenticated and authorized to access GovReady-Q. The proxy passes the user's username and email address in HTTP headers or environment variables of the proxy's choosing. 
 * GovReady-Q will create a user account for a new user or treat the user as logged in as soon as the user requests a page. Therefore, there is no sign-up or log-in process within GovReady-Q when a proxy authentication server is used.
 * All other authentication methods to GovReady-Q are disabled when proxy authentication is enabled. Therefore you should ensure that the Django admin's username matches the admin's username as provided by the proxy server. Otherwise, you will lose access to the admin page. However, if there is a mismatch, you may disable proxy authentication, log in to the Django admin with your admin username and password, and change your admin username to match the username sent by the proxy server.
 * GovReady-Q must be run at a private address that cannot be accessed except through the proxy server.
 
-To activate reverse proxy authentication, add the header names used by the proxy to your `local/environment.json`, e.g.:
+To activate reverse proxy authentication, add the variable names used by the proxy to your `local/environment.json`, e.g.:
 
     {
       "trust-user-authentication-headers": {
@@ -18,6 +18,8 @@ To activate reverse proxy authentication, add the header names used by the proxy
         "email": "X-Authenticated-User-Email"
       },
     }
+
+If the variables are passed in HTTP headers, you must ensure the variable names begin with  `HTTP_`.  If the variables are passed in the environment, specify them as-is. 
 
 The proxy server must be configured to proxy to GovReady-Q's private address. But the `host` and `https` settings in GovReady-Q's `local/environment.json` file must reflect the host and protocol used in the URL the *end user* uses to access GovReady-Q. They do *not* need to match the address that the proxy server uses to reach the GovReady-Q server.
 

--- a/siteapp/middleware.py
+++ b/siteapp/middleware.py
@@ -55,7 +55,6 @@ class ProxyHeaderUserAuthenticationMiddleware(django.contrib.auth.middleware.Rem
     else:
         # use as-is
         header = proxy_authentication_username
-    print("header: {}".format(header)) ### DEBUG ###
 class ProxyHeaderUserAuthenticationBackend(django.contrib.auth.backends.RemoteUserBackend):
     def authenticate(self, request, remote_user):
         # Let the Django class get the user.
@@ -70,7 +69,6 @@ class ProxyHeaderUserAuthenticationBackend(django.contrib.auth.backends.RemoteUs
             else:
                 # use as-is
                 email_header = proxy_authentication_email
-            print("email_header: {}".format(email_header)) ### DEBUG ###
             email_addr = request.META.get(email_header)
             if email_addr and user.email != email_addr:
                 user.email = email_addr


### PR DESCRIPTION
Trusted auth variable names were originally allowed only via HTTP headers. This commit expands the capability to also include variable names passed in the environment.

Previously, variable names passed via HTTP headers had "HTTP_" prepended internally. This must now be done by the user in local/environment.json.  So for instance, specify variable names passed via HTTP headers like this:

    "trust-user-authentication-headers": {
	"username": "HTTP_IAM-Username",
	"email": "HTTP_IAM-Email"
    }

For environment variables, just use their name as-is:

    "trust-user-authentication-headers": {
	"username": "ICAM_DISPLAYNAME",
	"email": "ICAM_EMAIL_ADDRESS"
    }