### PR TITLE
Fix dockerfile_exec.sh

### DIFF
--- a/deployment/docker/dockerfile_exec.sh
+++ b/deployment/docker/dockerfile_exec.sh
@@ -51,7 +51,7 @@ cat > local/environment.json << EOF;
 	"syslog": $(echo ${SYSLOG-} | jq -R .),
 	"admins": ${ADMINS-[]},
 	"static": "static_root",
-	"db": $(echo ${DBURL-} | jq -R .)
+	"db": $(echo ${DBURL-} | jq -R .),
 	"trust-user-authentication-headers": {
 		"username": "ICAM_EMAIL_ADDRESS",
 		"email": "ICAM_EMAIL_ADDRESS"

--- a/siteapp/settings.py
+++ b/siteapp/settings.py
@@ -31,6 +31,7 @@ if os.path.exists(local("environment.json")):
                 environment = json.load(open(local("environment.json")))
         except json.decoder.JSONDecodeError as e:
                 print("%s is not in JSON format" % local("environment.json"))
+                print(open(local("environment.json")).read())
                 exit(1)
 else:
 	# Make some defaults and show the user.


### PR DESCRIPTION
A missing comma in `deployment/docker/dockerfile_exec.sh` causes the app container to die right after it starts up.  This PR fixes the problem.

This PR also enhances an error message when `local/environment.json`, to print the contents of `local/environment.json`, instead of just complaining that it's broken, without any other feedback.