### PR TITLE
Fix appsource field error handling for Django 2.2

### DIFF
--- a/guidedmodules/admin.py
+++ b/guidedmodules/admin.py
@@ -1,7 +1,6 @@
 from django.contrib import admin
 from django import forms
 from django.utils.html import escape as escape_html
-from django.contrib import messages
 
 from .models import \
 	AppSource, AppVersion, Module, ModuleQuestion, ModuleAsset, \

--- a/guidedmodules/models.py
+++ b/guidedmodules/models.py
@@ -74,14 +74,19 @@ class AppSource(models.Model):
 
     def get_available_apps(self):
         # TODO need to include already loaded apps
-        with self.open() as src:
-            for app in src.list_apps():
-                yield {
-                    "name": app.name,
-                    "new_version_number": app.get_new_version_number(),
-                    "versions_in_catalog": app.get_appversions(),
-                    "hidden_versions": app.get_hidden_appversions(),
-                }
+        try:
+            with self.open() as src:
+                for app in src.list_apps():
+                    yield {
+                        "name": app.name,
+                        "new_version_number": app.get_new_version_number(),
+                        "versions_in_catalog": app.get_appversions(),
+                        "hidden_versions": app.get_hidden_appversions(),
+                    }
+        except:
+            # If we cannot get any apps, return nothing so Admin page will not
+            # try and render widget displaying available apps
+            return
 
     def add_app_to_catalog(self, appname):
         from .app_loading import load_app_into_database


### PR DESCRIPTION
This commit fixes two problems to gracefully handle appsource
field validation errors when updating an appsource and adding
incorrect data.

One error was appsource page trying to render the widget for
for available apps where no available apps existed because
an appsource connection could not be made.

The other error appeared to be failing to render error messages
properly through Django forms (for admin) because we needed to json.dumps
a variable that was an OrderedDict and was previously passed without
dumping to a string formatted as JSON.