### PR TITLE
Gracefully render blank datagrid in output templates

### DIFF
--- a/guidedmodules/module_logic.py
+++ b/guidedmodules/module_logic.py
@@ -711,7 +711,18 @@ class HtmlAnswerRenderer:
             # Assuming that RenderedAnswer gives us string version of the stored datagrid object
             # that is an Array of Dictionaries
             import ast
-            datagrid_rows = ast.literal_eval(value)
+            try:
+                # Get datagrid data if datgrid question has been answered with information
+                datagrid_rows = ast.literal_eval(value)
+            except:
+                if value == "<nothing chosen>":
+                    # Datagrid question has been visited and instantiated but no answer given
+                    # No data was entered into data grid
+                    datagrid_rows = []
+                else:
+                    # Datagrid question has not been visited and not yet instantiated
+                    # `value` is set to "<Software Inventory (datagrid)>"
+                    datagrid_rows = []
 
             # Build a table to display datagrid information
             value = "<table class=\"table\">\n"

--- a/guidedmodules/module_logic.py
+++ b/guidedmodules/module_logic.py
@@ -712,7 +712,7 @@ class HtmlAnswerRenderer:
             # that is an Array of Dictionaries
             import ast
             try:
-                # Get datagrid data if datgrid question has been answered with information
+                # Get datagrid data if datagrid question has been answered with information
                 datagrid_rows = ast.literal_eval(value)
             except:
                 if value == "<nothing chosen>":

--- a/siteapp/views.py
+++ b/siteapp/views.py
@@ -898,7 +898,7 @@ def project_api(request, project):
             if q.spec["type"] == "choice": add_filter_field(q, "html", "Human-readable value")
             if q.spec["type"] == "yesno": add_filter_field(q, "html", "Human-readable value ('Yes' or 'No')")
             if q.spec["type"] == "multiple-choice": add_filter_field(q, "html", "Comma-separated human-readable value")
-            # if q.spec["type"] == "datagrid": add_filter_field(q, "html", "Comma-separated human-readable value")
+            if q.spec["type"] == "datagrid": add_filter_field(q, "html", "Array of dictionaries for Datagrid")
 
         # Document the fields of the sub-modules together.
         for q, a in items:


### PR DESCRIPTION
When a datagrid question is not answered we still need to be able to render the output template referencing datagrid question without crashing.