### PR TITLE
PK changes from 2020-05-03 to ge-wkhtmltopdf-optional

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,10 @@ ARG DOCKERFILE_EXEC_SH=deployment/docker/dockerfile_exec_gunicorn.sh
 # ARG SUPERVISORD_INI=deployment/docker/supervisord_uwsgi.ini
 # ARG DOCKERFILE_EXEC_SH=deployment/docker/dockerfile_exec_uwsgi.sh
 
+# Default to "off"
+ARG GR_PDF_GENERATOR=off
+#ARG GR_PDF_GENERATOR=wkhtmltopdf
+
 # Expose the port that `manage.py runserver` uses by default.
 EXPOSE 8000
 
@@ -41,8 +45,7 @@ RUN \
 
 # install wkhtmltopdf for generating PDFs, thumbnails
 # TAKE CAUTION WITH wkhtmltopdf security issues where crafted content renders server-side information
-RUN \
-   yum -y install xorg-x11-server-Xvfb wkhtmltopdf && rm -rf /var/cache/yum
+RUN if [ "$GR_PDF_GENERATOR" = "wkhtmltopdf" ] ; then (yum -y install xorg-x11-server-Xvfb wkhtmltopdf && yum clean all && rm -rf /var/cache/yum) ; fi
 
 # Copy in the Python module requirements and install them.
 # file because they're not commonly used in development.

--- a/guidedmodules/models.py
+++ b/guidedmodules/models.py
@@ -1205,7 +1205,7 @@ class Task(models.Model):
                 # convert from HTML to something else, writing to a temporary file
                 outfn = os.path.join(tempdir, filename)
                 with subprocess.Popen(
-                    ["/usr/bin/pandoc", "-f", "html", "-t", pandoc_format, "-o", outfn],
+                    ["pandoc", "-f", "html", "-t", pandoc_format, "-o", outfn],
                     stdin=subprocess.PIPE
                     ) as proc:
                     proc.communicate(

--- a/templates/task-finished.html
+++ b/templates/task-finished.html
@@ -229,7 +229,7 @@
   function download_document(document_id) {
     var dom = $("<div><p>Select download format:</p>"
       + "<select class=form-control>"
-      {% if gr_pdf_generator %}+ "<option value=pdf>PDF</option>"{% endif %}
+      {% if gr_pdf_generator == 'wkhtmltopdf' %}+ "<option value=pdf>PDF</option>"{% endif %}
       + "<option value=docx>Word Document</option>"
       + "<option value=odt>OpenOffice Document</option>"
       + "<option value=html>HTML Page</option>"


### PR DESCRIPTION
1. I added a build-arg to the Dockerfile.  If you don't include `--build-arg GR_PDF_GENERATOR=wkhtmltopdf` it builds without wkhtmltopdf.

2. In task-finished.html I think we now need to test for `gr_pdf_generator == 'wkhtmltopdf'`.

3. I now call pandoc as `pandoc` rather than `/usr/bin/pandoc`.