### PR TITLE
PK docs fix 2020-05-06

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -18,8 +18,8 @@ The code is open source, and [available on GitHub](https://github.com/GovReady/g
    :glob:
    :caption: Contents:
 
-introduction
-   Deploy.rst
+   introduction
+   Deploy
    Environment
    Permissions
    Authoring

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -8,7 +8,8 @@ The GovReady-Q Compliance Server is an open source GRC platform for highly autom
 
 GovReady-Q solves the painful compliance bottleneck of needing months to authorize applications that deploy and redeploy in minutes.
 
-The code is open source, and [available on GitHub](https://github.com/GovReady/govready-q).
+The code is open source, and `available on GitHub
+<https://github.com/GovReady/govready-q/>`_.
 
 .. ATTENTION::
    GovReady-Q is in Beta. Suggested for DevSecOps early adopters needing Compliance-as-Code.


### PR DESCRIPTION
This fixes the Contents section on the index page of the docs, the main problem being the indentation of "introduction".

It also fixes the github link towards the top of the index page.

Tested with sphinx==2.4.4, because sphinx==3.0.3 (latest) was giving me this or similar error: [TypeError: add\_source\_parser\(\) positional arguments error in Sphinx v3\.0\.0 · Issue \#7420 · sphinx\-doc/sphinx](https://github.com/sphinx-doc/sphinx/issues/7420).