### PR TITLE
Small fixes for controls

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -71,7 +71,7 @@ RUN yum clean all && rm -rf /var/cache/yum
 # Remove unneeded Python libraries
 # Remove `pipenv` and its extra copies of `requests` and `urllib3` that scanners see
 # Safety only needed for preparing requirements files, not operating GovReady
-RUN pip3.6 uninstall -y pipenv safety
+# RUN pip3.6 uninstall -y pipenv safety || true
 
 # Safety only needed for preparing requirements files, not operating GovReady
 ## Run pyup.io's python package vulnerability check.

--- a/controls/data/catalogs/NIST_SP-800-171_rev1_catalog.json
+++ b/controls/data/catalogs/NIST_SP-800-171_rev1_catalog.json
@@ -1,6 +1,6 @@
 {
     "catalog": {
-      "id": "uuid-1xxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+      "id": "uuid-5a1fef9f-e95c-46ee-9c84-0e59c48e9d13",
       "metadata": {
         "title": "NIST Special Publication 800-171 Revision 1: Protecting Controlled Unclassified Information in Nonfederal Systems and Organizations",
         "last-modified": "2018-06-07-04T14:55:16.051-05:00",

--- a/controls/oscal.py
+++ b/controls/oscal.py
@@ -173,7 +173,11 @@ class Catalog (object):
         # Example 'guidance'
         #   python3 -c "import oscal; cg = oscal.Catalog(); print(cg.get_control_prose_as_markdown(cg.get_control_by_id('ac-6'), part_types={'guidance'}))"
 
-        return self.format_part_as_markdown(control_data, filter_name=part_types)
+        text = self.format_part_as_markdown(control_data, filter_name=part_types)
+        parameter_values = {} # Eventually replace with organizational defined parameters when we have them
+        text_params_replaced = self.substitute_parameter_text(control_data, text, parameter_values)
+
+        return text_params_replaced
 
     def format_part_as_markdown(self, part, indentation_level=-1, indentation_string="    ", filter_name=None, hide_first_label=True):
         # Format part, which is either a control or a part, as Markdown.
@@ -248,9 +252,11 @@ class Catalog (object):
         # Fill in parameter_values with control parameter labels for any
         # parameters that are not specified.
         parameter_values = dict(parameter_values) # clone so that we don't modify the caller's dict
+        if "parameters" not in control:
+            return text
         for parameter in control['parameters']:
             if parameter["id"] not in parameter_values:
-                parameter_values[parameter["id"]] = "[" + parameter["label"] + "]"
+                parameter_values[parameter["id"]] = "[" + parameter.get("label", parameter["id"]) + "]"
         for parameter_key, parameter_value in parameter_values.items():
             text = re.sub(r"{{ " + re.escape(parameter_key) + " }}", parameter_value, text)
         return text

--- a/templates/controls/editor.html
+++ b/templates/controls/editor.html
@@ -271,7 +271,7 @@ Remove contextbar from top of page
         // Submits control id for Control look up box
         function show_control_by_id() {
           var control_id = $('#control-lookup').find('input[name="id"]').val();
-          var url = "/systems/{{ system.id }}/controls/catalogs/{{ catalog.catalog_key }}/control/"+control_id+"/editor";
+          var url = "/systems/{{ system.id }}/controls/catalogs/{{ catalog.catalog_key }}/control/"+control_id;
           window.location.href = url;
         }
       </script>


### PR DESCRIPTION
Fix control look up url on editor page.
Incorporate parameter substitution into displayed control text.