### PR TITLE
Add/edit implementation statements on system component detail page

### DIFF
--- a/templates/controls/editor.html
+++ b/templates/controls/editor.html
@@ -286,6 +286,7 @@ Remove contextbar from top of page
 
             {% endfor %}
           </div><!--/smt-list-->
+          <!-- Add component button -->
           <div><h3><button type="submit" class="small btn btn-md btn-success" style="color: white;" onclick="add_smt()">Add component statement</button></h3></div>
 
       </div>
@@ -293,10 +294,10 @@ Remove contextbar from top of page
     </div>
   </div>
 
-      {{ block.super }}
-      {% endblock %}
+  {{ block.super }}
+  {% endblock %}
 
-      {% block scripts %}
+  {% block scripts %}
       <script>
         // Submits control id for Control look up box
         function show_control_by_id() {
@@ -360,7 +361,6 @@ Remove contextbar from top of page
                   <textarea class="form-control" id="remarks_panel_num" name="remarks" placeholder="Add remarks for team"  rows="4" cols="50"></textarea>
                 </div>
 
-                <input type="hidden" id="control_id_panel_num" name="control_id" value="{{ control.id }}">
                 <input type="hidden" id="system_id_panel_num" name="system_id" value="{{ system.id }}">
                 <input type="hidden" id="sid_panel_num" name="sid" value="{{ control.id }}">
                 <input type="hidden" id="sid_class_panel_num" name="sid_class" value="{{ catalog.catalog_key }}">
@@ -415,7 +415,9 @@ Remove contextbar from top of page
                 $( '#'+smt_panel_num+' input[name=producer_element_id]' ).val(smt_saved[0]['fields']['producer_element']);
                 $('#success-msg-'+smt_panel_num).fadeIn().text('Saved');
                 // Update combined statement
-                update_combined_smt();
+                if (typeof update_combined_smt === "function") {
+                  update_combined_smt();
+                }
               } else {
                 $('#success-msg-'+smt_panel_num).fadeIn().text('Error '+res['message']);
               }
@@ -475,4 +477,4 @@ Remove contextbar from top of page
 
       </script>
 
-      {% endblock %}
+  {% endblock %}

--- a/templates/systems/element_detail_tabs.html
+++ b/templates/systems/element_detail_tabs.html
@@ -165,7 +165,8 @@
               <div class="panel-heading" role="tab" id="document-{{ forloop.counter }}-title">
                 <h4 id="panel-{{ forloop.counter }}-title" class="panel-title">
                   <a role="button" data-toggle="collapse" data-parent="#accordion" href="#document-{{ forloop.counter }}-body" aria-expanded="false" aria-controls="document-{{ forloop.counter }}-body">
-                    <span id="producer_element-panel_num-title">{{ smt.producer_element.name }}</span>&nbsp;
+                    <span id="producer_element-panel_num-control">{{ smt.sid|upper }}</span>&nbsp;
+                    <!--<span id="producer_element-panel_num-title">{{ smt.producer_element.name }}</span>&nbsp;-->
                     <div class="panel-heading-smt">{{ smt.body }}</div>
                   </a>
                 </h4>
@@ -189,6 +190,17 @@
                     <input type="hidden" id="smt_id" name="smt_id" value="{{ smt.id }}">
                     <label for="statement">Statement</label>
                     <textarea style="min-height:130px;overflow-y: scroll;" class="form-control" id="body_{{ forloop.counter }}" name="body" placeholder="How component contributes to control"  cols="50">{{ smt.body }}</textarea>
+                  </div>
+                  <div class="form-group">
+                    <label for="status">Status</label>
+                    <select class=form-control id="status_{{ forloop.counter }}" name="status" style="width:180px;">
+                    <option value='' {% if '' == smt.status %}selected="selected"{% endif %}></option>
+                    <option value='Not Implemented' {% if 'Not Implemented' == smt.status %}selected="selected"{% endif %}>Not Implemented</option>
+                    <option value='Planned' {% if 'Planned' == smt.status %}selected="selected"{% endif %}>Planned</option>
+                    <option value='Partially Implemented' {% if 'Partially Implemented' == smt.status %}selected="selected"{% endif %}>Partially Implemented</option>
+                    <option value='Implemented' {% if 'Implemented' == smt.status %}selected="selected"{% endif %}>Implemented</option>
+                    <option value='Unknown' {% if 'Unknown' == smt.status %}selected="selected"{% endif %}>Unknown</option>
+                    </select>
                   </div>
                   <div class="form-group">
                     <label for="remarks">Remarks</label>
@@ -217,7 +229,7 @@
 
             {% endfor %}
           </div><!--/smt-list-->
-          <!-- <div><h3><button type="submit" class="small btn btn-md btn-success" style="color: white;" onclick="add_smt()">Add component statement</button></h3></div> -->
+          <div><h3><button type="submit" class="small btn btn-md btn-success" style="color: white;" onclick="add_smt()">Add component statement</button></h3></div>
       </div>
 
       <!-- Tab panel: combined -->
@@ -247,4 +259,179 @@
 {% endblock %}
 
 {% block scripts %}
+      <script>
+        // View combined implementation statement
+
+        // Adds statement form to page
+        function add_smt() {
+          var panel_num = $('.panel').length + 1
+          var smt_form = `
+            <div id="panel-panel_num" class="panel panel-default">
+            <div class="panel-heading" role="tabx" id="document-panel_num-title">
+              <h4 id="panel-panel_num-title" class="panel-title">
+                <a role="button" data-toggle="collapse" data-parent="#accordion" href="#document-panel_num-body" aria-expanded="{% if forloop.first %}true{% endif %}" aria-controls="document-panel_num-body">
+                  <span id="producer_element-panel_num-title">{{ element.name }}</span>
+                  <div class="panel-heading-smt"></div>
+                </a>
+              </h4>
+            </div>
+            <div id="document-panel_num-body" class="panel-collapse collapse {% if forloop.first %}in{% endif %} output-document" role="tabpanel" aria-labelledby="document-panel_num-title">
+              <div class="panel-body output-document">
+
+            <div>
+              <form id="smt_panel_num" class="smt_form">
+                <div class="form-group">
+                  <input type="hidden" id="producer_element_id" name="producer_element_id" value="{{ element.id }}">
+                  <label for="compoment"><a href="/systems/{{ system.id }}/component/{{ element.id }}" style="color: black;">{{ element.name }}</a></label>
+                  <!-- <label for="compoment">Producer Component</label> -->
+                  <input type="hidden" class="form-control" id="producer_element_name" name="producer_element_name" placeholder="Name of component"
+                    onchange="$('#producer_element-panel_num-title').text($(this).val());" value="{{ element.name }}">
+                </div>
+
+                <div class="form-group">
+
+                  <label for="compoment">Control</label>
+                  <select class=form-control id="sid_panel_num" name="sid" style="">
+                    {% for ctl in catalog_controls %}
+                      <option value='{{ ctl.id }}'>{{ ctl.id|upper }} - {{ ctl.title }}</option>
+                    {% endfor %}
+                  </select>
+                  <input type="hidden" id="sid_class_panel_num" name="sid_class" prompt="Enter catalog_key" value="{{ catalog_key }}">
+                </div>
+
+
+                <div class="form-group">
+                  <input type="hidden" id="smt_id" name="smt_id" value="">
+                  <label for="statement">Statement</label>
+                  <textarea class="form-control" id="body_panel_num" name="body" placeholder="How component contributes to control" rows="5" cols="50"></textarea>
+                </div>
+                <div class="form-group">
+                  <label for="status">Status</label>
+                    <select class=form-control id="status_{{ forloop.counter }}" name="status" style="width:180px;">
+                      <option value=''></option>
+                      <option value='Not Implemented'>Not Implemented</option>
+                      <option value='Planned'>Planned</option>
+                      <option value='Partially Implemented'>Partially Implemented</option>
+                      <option value='Implemented'>Implemented</option>
+                      <option value='Unknown'>Unknown</option>
+                    </select>
+                </div>
+                <div class="form-group">
+                  <label for="remarks">Remarks</label>
+                  <textarea class="form-control" id="remarks_panel_num" name="remarks" placeholder="Add remarks for team"  rows="4" cols="50"></textarea>
+                </div>
+
+                <input type="hidden" id="system_id_panel_num" name="system_id" value="{{ system.id }}">
+                <input type="hidden" id="statement_type_panel_num" name="statement_type" value="control_implementation">
+
+              <div class="modal-footer">
+                <div id="success-msg-smt_panel_num" style="display: inline; margin-right: 20px; color: gray;"></div>
+                <button type="button" name="delete" value="delete" class="btn btn-xs btn-danger" onclick="delete_smt('smt_panel_num');return false;">Delete</button>
+                <button type="button" name="save" value="save" class="btn btn-xs btn-success" onclick="save_smt('smt_panel_num');return false;">Save</button>
+              </div>
+
+              </form>
+            </div>
+
+              </div>
+            </div>
+          </div>`.replace(/panel_num/g, panel_num);
+          $( "#smt-list" ).append(smt_form);
+        }
+
+        function save_smt(smt_panel_num) {
+          // Save a statement
+          // serialize data from the identified statement form
+          var data = $( '#'+smt_panel_num ).serialize();
+
+          // send data via ajax to be saved
+          ajax_with_indicator({
+            url: "/controls/smt/_save/",
+            method: "POST",
+            data: data,
+            indicator_parent: $('#page-content'),
+            keep_indicator_forever: false, // keep the ajax indicator up forever --- it'll go away when we issue the redirect
+            success: function(res) {
+              console.log('success');
+              console.log(res);
+              if (res['status'] == "success") {
+                // Update field values from saved
+                // Initially update a few fields
+                smt_saved = JSON.parse(res['statement']);
+                console.log("printing smt_saved");
+                console.log(smt_saved);
+                $( '#'+smt_panel_num+' input[name=smt_id]' ).val(smt_saved[0]['pk']);
+
+                // If saving first time remove producer_element_name input field
+                if ($( '#'+smt_panel_num+' input[name=producer_element_id]' ).val().length == 0) {
+                  $( '#'+smt_panel_num+' input[name=producer_element_id]' ).val(smt_saved[0]['fields']['producer_element']);
+                }
+
+                // Update panel statement
+                $( '#'+smt_panel_num.replace("smt_","panel-")+' .panel-heading-smt' ).html(smt_saved[0]['fields']['body']);
+
+                $( '#'+smt_panel_num+' input[name=producer_element_id]' ).val(smt_saved[0]['fields']['producer_element']);
+                $('#success-msg-'+smt_panel_num).fadeIn().text('Saved');
+                // Update combined statement
+                if (typeof update_combined_smt === "function") { 
+                  update_combined_smt();
+                }
+              } else {
+                $('#success-msg-'+smt_panel_num).fadeIn().text('Error '+res['message']);
+              }
+              setTimeout(function() {
+                $('#success-msg-'+smt_panel_num).fadeOut("fast");
+              }, 1000 );
+            }
+          });
+
+          // Stop <form> submit
+          return false;
+
+        }; // /save_smt
+
+        function delete_smt(smt_panel_num) {
+          console.log("Deleting statement button pressed "+smt_panel_num);
+          // Confirm deletion
+          var result = confirm("Delete statement?");
+          if (result) {
+              // Delete statement object in database if it exists
+              if ($( '#'+smt_panel_num+' input[name=producer_element_id]' ).val().length > 0) {
+                // console.log("deleting db object")
+                // serialize data from the identified statement form
+                var data = $( '#'+smt_panel_num ).serialize()
+                // send data via ajax to delete object
+                ajax_with_indicator({
+                  url: "/controls/smt/_delete/",
+                  method: "POST",
+                  data: data,
+                  indicator_parent: $('#page-content'),
+                  keep_indicator_forever: false, // keep the ajax indicator up forever --- it'll go away when we issue the redirect
+                  success: function(res) {
+                    console.log('success');
+                    console.log(res);
+                    if (res['status'] == "success") {
+                      // Update field values from saved
+                      // Initially update a few fields
+                      console.log("smt_deleted");
+                    }
+                    // Remove statement accordian from page
+                    console.log("removing from page "+'#panel-'+smt_panel_num)
+                    $( '#panel-'+smt_panel_num.replace("smt_","") ).remove()
+                  }
+                });
+              } else {
+                // Remove statement accordian from page
+                console.log("removing from page "+'#panel-'+smt_panel_num)
+                $( '#panel-'+smt_panel_num.replace("smt_","") ).remove()
+              }
+          }
+        }
+      </script>
+      <script>
+        $( document ).ready(function() {
+            //console.log("document ready");
+        });
+
+      </script>
 {% endblock %}


### PR DESCRIPTION
Include the ability to edit implementation statements and add new
implementation statements for a system component on the system
component view. This is nice because you manage the content
associated with a component on the component page for a system.