### PR TITLE
Fix OSCAL display feature flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ v.0.9.1.47 (December 01, 2020)
 
 * Significant refactoring of CSS to replace inline styles from as many pages as possible with classes defined in `css/govready-q.css` stylesheet.
 
+**Bug fix**
+
+* Fix system_settings methods enable_experimental_oscal and enable_experimental_opencontrol to work properly.
+
 v0.9.1.46.4 (November 25, 2020)
 -----------------------------
 

--- a/system_settings/models.py
+++ b/system_settings/models.py
@@ -19,4 +19,4 @@ class SystemSettings(models.Model):
 
   @classmethod
   def enable_experimental_oscal(cls):
-    return cls.objects.get(setting="enable_experimental_opencontrol").active
+    return cls.objects.get(setting="enable_experimental_oscal").active

--- a/templates/controls/editor.html
+++ b/templates/controls/editor.html
@@ -142,7 +142,7 @@ Remove contextbar from top of page
       <li role="presentation"><a href="#combined" aria-controls="combined" role="tab" data-toggle="tab"><span class="glyphicon glyphicon-file"></span> Combined Statement </a></li>
       <li role="presentation"><a href="#common_controls" aria-controls="common_controls" role="tab" data-toggle="tab"><span class="glyphicon glyphicon-ok-circle"></span> Common Controls &nbsp;<div id="common-tab-count">{{ common_controls|length }}</div></a></li>
       <li role="presentation"><a href="#component_controls" aria-controls="component_controls" role="tab" data-toggle="tab"><span class="glyphicon glyphicon-wrench"></span> Component Statements  &nbsp;<div id="common-tab-count">{{ impl_smts|length }}</div></a></li>
-      {% if enable_experimental_opencontrol %}
+      {% if enable_experimental_oscal %}
         <li role="presentation"><a href="#oscal" aria-controls="oscal" role="tab" data-toggle="tab"><span class="glyphicon glyphicon-file"></span> OSCAL  &nbsp;<div id="common-tab-count">{{ impl_smts|length }}</div></a></li>
       {% endif %}
     </ul>
@@ -312,8 +312,7 @@ Remove contextbar from top of page
       <!-- Tab panel: combined -->
       {% if enable_experimental_oscal %}
       <div role="tabpanel" class="tab-pane" id="oscal">
-        <div id="combined_smt" class="control-text"><h3>OSCAL (under development)</h3></div>
-        <div>See reference <a href="https://github.com/usnistgov/OSCAL/blob/master/content/ssp-example/json/ssp-example.json">https://github.com/usnistgov/OSCAL/blob/master/content/ssp-example/json/ssp-example.json</a></div>
+        <div id="combined_smt" class="control-text"><h3>OSCAL</h3></div>
         <div style="font-family: monospace; font-size:12px; white-space: pre;">{{ oscal }}</div>
       </div>
       {% endif %}

--- a/templates/systems/element_detail_tabs.html
+++ b/templates/systems/element_detail_tabs.html
@@ -124,7 +124,7 @@
     <ul class="nav nav-tabs" role="tablist">
       <li role="presentation" class="active"><a href="#component" aria-controls="component" role="tab" data-toggle="tab"><span class="glyphicon glyphicon-list-alt"></span> Component</a></li>
       <li role="presentation"><a href="#component_controls" aria-controls="component_controls" role="tab" data-toggle="tab"><span class="glyphicon glyphicon-wrench"></span> Component Statements  &nbsp;<div id="common-tab-count">{{ impl_smts|length }}</div></a></li>
-      {% if enable_experimental_opencontrol %}
+      {% if enable_experimental_oscal %}
         <li role="presentation"><a href="#oscal" aria-controls="oscal" role="tab" data-toggle="tab"><span class="glyphicon glyphicon-file"></span> OSCAL </a></li>
       {% endif %}
       {% if enable_experimental_opencontrol %}
@@ -233,7 +233,7 @@
           <div><h3><button type="submit" class="small btn btn-md btn-success" style="color: white;" onclick="add_smt()">Add component statement</button></h3></div>
       </div>
 
-      <!-- Tab panel: combined -->
+      <!-- Tab panel: oscal -->
       {% if enable_experimental_oscal %}
       <div role="tabpanel" class="tab-pane" id="oscal">
         <p id="oscal_download" class="navbar-text navbar-right">
@@ -244,7 +244,7 @@
             Download ...
           </a>
         </p>
-        <div id="combined_smt" class="control-text"><h3>OSCAL (under development)</h3></div>
+        <div id="combined_smt" class="control-text"><h3>OSCAL</h3></div>
         <div style="font-family: monospace; font-size:12px; white-space: pre;">{{ oscal }}</div>
       </div>
       {% endif %}


### PR DESCRIPTION
Fix enable_experimental_oscal control
    
Model method was set incorrectly requiring both enable_experimental_oscal and enable_experimental_opencontrol had to be enabled for either to show up.
    
This is now fixed.