### PR TITLE
Addressing gevent being pinned twice in requirements.in

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -68,6 +68,3 @@ markupsafe==1.1.1 # BSD 3
 
 # Excel exports
 openpyxl # MIT License
-
-# pin gevent to working version; we're getting Docker build errors with gevent==20.5.0
-gevent==1.4.0


### PR DESCRIPTION
## Purpose ##
Small PR to address `gevent` being mentioned twice in `requirements.in`.

## Further work that could be done ##
- Modify issue description with proper GovReady PR template
- Modify `requirements_txt_checker.sh` to add ability to check for duplicates
- Update `gevent` version based on conversation with fellow engineers
- Update with `requirements.txt` if gevent version 1.5 is approved to improve compatibility with py3.9