### PR TITLE
Remove extra bracket so button to publish project artifacts operates correctly

### DIFF
--- a/templates/project.html
+++ b/templates/project.html
@@ -210,7 +210,7 @@ h3.question-group-title {
               <input type="hidden" name="project" value="{{project.id}}"/>
               <input type="hidden" name="question" value="{{q.question.key}}"/>
               <input type="hidden" name="previous" value="project"/>
-              <a class="btn btn-default" class="action-button">
+              <a class="btn btn-default" class="action-button"
                 href="#" onclick="$(this).parent('form').submit(); return false;">
                 {{q.question.spec.title}} &raquo;
               </a>


### PR DESCRIPTION
An extra bracket was added to HTML so publishing artifacts was not able to be accomplished. This PR addresses that issue.

A minor change, but it allows for the button to be clicked.

Prior to change:
![Screen Shot 2020-12-01 at 5 04 22 PM](https://user-images.githubusercontent.com/2460738/101070815-d701f500-3569-11eb-82c9-375379cfb2cc.png)

After change, button works as expected.