### PR TITLE
Fix updating prototype components

### DIFF
--- a/controls/views.py
+++ b/controls/views.py
@@ -1151,10 +1151,12 @@ def update_smt_prototype(request):
         # needs self.body == self.prototype.body
 
         try:
-            statement.prototype.body = statement.body
-            statement.prototype.save()
+            proto_statement = Statement.objects.get(pk=statement.prototype_id)
+            proto_statement.prototype.body = statement.body
+
+            proto_statement.prototype.save()
             statement_status = "ok"
-            statement_msg = "Update to statement prototype succeeded."
+            statement_msg = f"Update to statement prototype {proto_statement.prototype_id} succeeded."
         except Exception as e:
             statement_status = "error"
             statement_msg = "Update to statement prototype failed. Error reported {}".format(e)

--- a/controls/views.py
+++ b/controls/views.py
@@ -1153,7 +1153,6 @@ def update_smt_prototype(request):
         try:
             proto_statement = Statement.objects.get(pk=statement.prototype_id)
             proto_statement.prototype.body = statement.body
-
             proto_statement.prototype.save()
             statement_status = "ok"
             statement_msg = f"Update to statement prototype {proto_statement.prototype_id} succeeded."


### PR DESCRIPTION
Get the prototype as well to update the prototype. Updating from just the prototype attribute grabs the latest implementation so the prototype is actually pointing from the last implementation.