### PR TITLE
Restore Select2 selection box for adding component to system's selected components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,10 @@ Properly generate JSON, YAML questionnaire output documents from a JSON (or YAML
 * Make statement synchronization status lable/alert clickable to reveal certified statement and diff between local and certified.
 * Add buttons for copying certified statement into local statement and for admin to update certified statement from local statement.
 * Add autocompletes to make it easy to add a new component to a system and the component's respective certified controls.
+* Use Select2 box to add component to system's selected component.
+* Add route `add_system_component` and related view to add a component to a system's selected component.
 * Replace the url pattern routing in v0.9.1.46.4 for directing accounts login to home page with custom templates to override default aullauth templates.
+* Use Django messaging when adding a component to system's selected component to provide user with better feedback.
 
 **Data changes**
 
@@ -56,7 +59,12 @@ Properly generate JSON, YAML questionnaire output documents from a JSON (or YAML
 * Modified controls.Statement model to link `control_implementation` statements to
   `control_implementation_prototype` statements. See commit 5083af.
 * Add methods for diff'ing (e.g., comparing) a `control_implementation` statement against its prototype statement using Google diff-match-patch.
-* The work for a componet library and certified controls was performed across three branches that were eventually synchronized (approximately commit 18934669) and merged into the master branch:
+* Avoid duplicative adding of a component to a system causing duplicate statements.
+* Avoiding adding a component with no control implementation statements to a system.
+* Avoid adding duplicate control implementation instance statements to a system by checking in the statement model that we are not creating an instance statement when such and statement from prototype already exists.
+* Use Django messaging when adding a component to system's selected component to provide user with better feedback.
+* Delete already commented-out contol id look up from system's selected components page.
+* The work for a component library and certified controls was performed across three branches that were eventually synchronized (approximately commit 18934669) and merged into the master branch:
     * `autocomplete_statements_#1066`
     * `ge/reuse-0903`
     * `automated-tests-statements`

--- a/controls/models.py
+++ b/controls/models.py
@@ -87,12 +87,22 @@ class Statement(models.Model):
         return self.prototype
 
     def create_instance_from_prototype(self, consumer_element_id):
-        """Creates a control_implementation statement instance for root_element of a system from an existing control implementation prototype statement"""
+        """Creates a control_implementation statement instance for a system's root_element from an existing control implementation prototype statement"""
 
-        # if self.prototype is not None:
-        #     # Prototype already exists for statement
-        #     return self.prototype
+        # TODO: Check statement is a prototype
+
+        # System already has instance of the prototype statement
+        # TODO: write check for this logic
+        # Get all statements for consumer element
+        smts_existing = Statement.objects.filter(consumer_element__id = consumer_element_id)
+        # Get prototype ids for all consumer element statements
+        smts_existing_prototype_id = [smt.prototype.id for smt in smts_existing]
+        if self.id is smts_existing_prototype_id:
+            return self.prototype
+
+        #     # TODO:
         #     # check if prototype content is the same, report error if not, or overwrite if permission approved
+
         instance = deepcopy(self)
         instance.statement_type="control_implementation"
         instance.consumer_element_id = consumer_element_id

--- a/controls/urls.py
+++ b/controls/urls.py
@@ -24,7 +24,8 @@ urlpatterns = [
     url(r'^(?P<system_id>.*)/controls/catalogs/(?P<catalog_key>.*)/control/(?P<cl_id>.*)$', views.editor, name="control_editor"),
     url(r'^editor_autocomplete/', views.EditorAutocomplete.as_view(), name="search_system_component"),
     url(r'^related_system_components/', views.RelatedComponentStatements.as_view(), name="related_system_components"),
-    url(r'^(?P<system_id>.*)/components/editor_autocomplete$',  views.EditorAutocomplete.as_view(), name="add_system_component"),
+    url(r'^(?P<system_id>.*)/components/add_system_component$', views.add_system_component, name="add_system_component"),
+    url(r'^(?P<system_id>.*)/components/editor_autocomplete$',  views.EditorAutocomplete.as_view(), name="editor_autocomplete"),
 
     url(r'^smt/_save/$', views.save_smt),
     url(r'^smt/_delete/$', views.delete_smt),

--- a/controls/views.py
+++ b/controls/views.py
@@ -888,8 +888,6 @@ def editor(request, system_id, catalog_key, cl_id):
         # User does not have permission to this system
         raise Http404
 
-
-
 def editor_compare(request, system_id, catalog_key, cl_id):
     """System Control detail view"""
 
@@ -1116,7 +1114,6 @@ def save_smt(request):
         {"status": "success", "message": statement_msg + " " + producer_element_msg + " " + statement_element_msg,
          "statement": serialized_obj})
 
-
 def update_smt_prototype(request):
     """Update a certified statement"""
 
@@ -1256,6 +1253,81 @@ def delete_smt(request):
 
 # Components
 
+def add_system_component(request, system_id):
+    """Add an existing element and its statements to a system"""
+
+    if request.method != "POST":
+        return HttpResponseNotAllowed(["POST"])
+
+    form_dict = dict(request.POST)
+    form_values = {}
+    for key in form_dict.keys():
+        form_values[key] = form_dict[key][0]
+
+    # Does user have permission to add element?
+    # Check user permissions
+    system = System.objects.get(pk=system_id)
+    if not request.user.has_perm('change_system', system):
+        # User does not have write permissions
+        # Log permission to save answer denied
+        logger.info(
+            event="change_system permission_denied",
+            object={"object": "element", "producer_element_name": form_values['producer_element_name']},
+            user={"id": request.user.id, "username": request.user.username}
+        )
+        return HttpResponseForbidden("Permission denied. {} does not have change privileges to system and/or project.".format(request.user.username))
+
+    # DEBUG
+    # print(f"Atempting to add {producer_element.name} (id:{producer_element.id}) to system_id {system_id}")
+
+    # Get system's existing components selected
+    elements_selected = system.producer_elements
+    elements_selected_ids = [e.id for e in elements_selected]
+
+    # Get system's selected controls because we only want to add statements for selected controls
+    selected_controls = system.root_element.controls.all()
+    selected_controls_ids = set([f"{sc.oscal_ctl_id} {sc.oscal_catalog_key}" for sc in selected_controls])
+    # TODO: Refactor above line selected_controls into a system model function if not already existing
+
+    # Add element to system's selected components
+    # Look up the element rto add
+    producer_element = Element.objects.get(pk=form_values['producer_element_id'])
+
+    # TODO: various use cases
+        # - component previously added but element has statements not yet added to system
+        #   this issue may be best addressed elsewhere.
+
+    # Component already added to system. Do not add the component (element) to the system again.
+    if producer_element.id in elements_selected_ids:
+        messages.add_message(request, messages.ERROR,
+                            f'Component "{producer_element.name}" already exists in selected components.')
+        # Redirect to selected element page
+        return HttpResponseRedirect("/systems/{}/components/selected".format(system_id))
+
+    smts = Statement.objects.filter(producer_element_id = producer_element.id, statement_type="control_implementation_prototype")
+
+    # Component does not have any statements of type control_implementation_prototype to
+    # add to system. So we cannot add the component (element) to the system.
+    if len(smts) == 0:
+        # print(f"The component {producer_element.name} does not have any control implementation statements.")
+        messages.add_message(request, messages.ERROR,
+                            f'I could\'t add the Component "{producer_element.name}" to the system because the component does not currently have any control implementation statements to add.')
+        # Redirect to selected element page
+        return HttpResponseRedirect("/systems/{}/components/selected".format(system_id))
+
+    # Loop through element's prototype statements and add to control implementation statements
+    messages.add_message(request, messages.INFO,
+                         f'OK. I\'ve the control implementation statements for component "{producer_element.name}" to the system.')
+    for smt in Statement.objects.filter(producer_element_id = producer_element.id, statement_type="control_implementation_prototype"):
+        # Only add statements for controls selected for system
+        if "{} {}".format(smt.sid, smt.sid_class) in selected_controls_ids:
+            # print("smt", smt)
+            smt.create_instance_from_prototype(system.root_element.id)
+        else:
+            print("not adding smt not selected controls for system", smt)
+
+    # Redirect to selected element page
+    return HttpResponseRedirect("/systems/{}/components/selected".format(system_id))
 
 def search_system_component(request):
     """Add an existing element and its statements to a system"""

--- a/templates/systems/components_selected.html
+++ b/templates/systems/components_selected.html
@@ -28,13 +28,6 @@
             <a href="{{ project.get_absolute_url }}" class="systems-link">{{ system.root_element.name }}</a> > Selected Components
           </h2>
       </div>
-      <!-- Control Lookup-->
-      <div class="systems-control-lookup">
-          <!-- <form id="control-lookup" method="get" action="/controls/" onsubmit="show_control_by_id(); return false;">
-            <input type="text" name="id" placeholder="Enter control id" value="{% if control %}{{ control.id_display|upper }}{% endif %}">
-                <button type="submit" class="btn btn-success">Look up</button>
-          </form> -->
-      </div>
     </div>
   </div><!--/row-->
     <p>&nbsp;</p>
@@ -62,7 +55,9 @@
               <label for="compoment">Add component</label>&nbsp;&nbsp;
                 <select class="producer_element_id" id="producer_element_id" name="producer_element_id" style="width:340px;">
                   {% for component in elements %}
-                  <option value="{{ component.id }}">{{ component.name }}</option>
+                    {% if component not in system.producer_elements %}
+                      <option value="{{ component.id }}">{{ component.name }}</option>
+                    {% endif %}
                   {% endfor %}
                 </select>
           </div>

--- a/templates/systems/components_selected.html
+++ b/templates/systems/components_selected.html
@@ -57,16 +57,19 @@
     <div id="tab-content" class="row row-control" style="">
       <form class="form-inline" method="post" action="/systems/{{ system.id }}/components/add_system_component">
         {% csrf_token %}
-        <div id="" class="col-xs-8 col-sm-8 col-md-8 col-lg-8 col-xl-8">
-        <div class="form-group">
-            <label for="compoment">Add component</label>&nbsp;&nbsp;
-              <select class="producer_element_id" id="producer_element_id" name="producer_element_id" style="width:340px;">
-                {% for component in elements %}
-                <option value="{{ component.id }}">{{ component.name }}</option>
-                {% endfor %}
-              </select>
+        <div id="" class="col-xs-7 col-sm-7 col-md-7 col-lg-7 col-xl-7">
+          <div class="form-group">
+              <label for="compoment">Add component</label>&nbsp;&nbsp;
+                <select class="producer_element_id" id="producer_element_id" name="producer_element_id" style="width:340px;">
+                  {% for component in elements %}
+                  <option value="{{ component.id }}">{{ component.name }}</option>
+                  {% endfor %}
+                </select>
+          </div>
         </div>
-          &nbsp;&nbsp;<button type="submit" class="small btn btn-sm btn-success" style="color: white;" onclick="add_smt()">Add</button>
+        <div class="col-xs-2 col-sm-2 col-md-2 col-lg-2 col-xl-2">
+          <button type="submit" class="btn btn-xs btn-success" style="color: white;" onclick="add_smt()">Add</button>
+        </div>
       </div>
     </div>
       </form>
@@ -81,5 +84,11 @@
 {% block scripts %}
 <script src="{% static "vendor/js/select2.min.js" %}"></script>
 <link href="{% static "vendor/css/select2.min.css" %}" rel="stylesheet" />
+<script>
+  // Convert select field for Add Component to jQuery Select2 box
+  $(document).ready(function() {
+      $('.producer_element_id').select2();
+  });
+</script>
 
 {% endblock %}


### PR DESCRIPTION
Restore Select2 box to add component to system's selected component

Restore route `add_system_component` and related view from branch `ge/reuse-0903` for adding
a component to a system's selected component. Route and view were modified for the
component autocomplete functionality to add a component to a control while in selected controls.

Fix jQuery Select2 autocomplete selection box in system's selected component page
to make adding a component from a list easier.

Add Django messaging to Adding component to system's selected component to
provide user with better feedback.

Avoid duplicative adding of a component to a system causing duplicate statements.

Avoiding adding a component with no control implementation statements to a system.

Filter components when creating list of components to not include components already
selected for a system.

Delete already commented-out contol id look up from system's selected components page.

Avoid adding duplicate control implementation instance statements to a system
When creating a control implementation statement instance from a prototype statement.
Avoid this by checking in the statement model that we are not creating an instance
when such and instance already exists.

Update CHANGELOG.
