### PR TITLE
Fixed Empty Catch Block Fortify Issues

### DIFF
--- a/discussion/views.py
+++ b/discussion/views.py
@@ -1,3 +1,7 @@
+import logging
+import structlog
+from structlog import get_logger
+
 from django.db import transaction
 from django.shortcuts import render, redirect, get_object_or_404
 from django.http import Http404, HttpResponse, HttpResponseRedirect, HttpResponseForbidden, JsonResponse, HttpResponseNotAllowed
@@ -6,6 +10,9 @@ from django.conf import settings
 from django.utils import timezone
 
 from .models import Discussion, Comment, Attachment
+
+logging.basicConfig()
+logger = get_logger()
 
 @login_required
 @transaction.atomic
@@ -24,7 +31,11 @@ def update_discussion_comment_draft(request):
         try:
             comment = discussion.comments.get(id=request.POST['draft'], user=request.user, draft=True)
         except:
-            pass
+            logger.error(
+                event="update_discussion_comment_draft",
+                object={"object": "comment", "id": request.POST['draft']},
+                user={"id": request.user.id, "username": request.user.username}
+            )
         else:
             comment.text = text
             comment.save()

--- a/guidedmodules/app_loading.py
+++ b/guidedmodules/app_loading.py
@@ -102,7 +102,7 @@ def load_app_into_database(app, update_mode=AppImportUpdateMode.CreateInstance, 
         appinst.catalog_metadata\
             .setdefault("description", {})["long"] = readme
     except fs.errors.ResourceNotFound:
-        logger.error(event="read_from_radme.md", msg="Failed to read README.md")
+        logger.error(event="read_from_readme.md", msg="Failed to read README.md")
 
     # Update appinst. It may have been modified by extract_catalog_metadata
     # and by the loading of a README.md file.

--- a/guidedmodules/app_loading.py
+++ b/guidedmodules/app_loading.py
@@ -5,8 +5,11 @@
 
 import enum
 import json
+import logging
+import structlog
 import sys
 from collections import OrderedDict
+from structlog import get_logger
 
 from django.db import transaction
 from django.db.models.deletion import ProtectedError
@@ -18,6 +21,9 @@ from .models import AppSource, AppVersion, ModuleAsset, \
 from .validate_module_specification import \
     validate_module, \
     ValidationError as ModuleValidationError
+
+logging.basicConfig()
+logger = get_logger()
 
 class AppImportUpdateMode(enum.Enum):
     CreateInstance = 1
@@ -96,7 +102,7 @@ def load_app_into_database(app, update_mode=AppImportUpdateMode.CreateInstance, 
         appinst.catalog_metadata\
             .setdefault("description", {})["long"] = readme
     except fs.errors.ResourceNotFound:
-        pass
+        logger.error(event="read_from_radme.md", msg="Failed to read README.md")
 
     # Update appinst. It may have been modified by extract_catalog_metadata
     # and by the loading of a README.md file.
@@ -163,7 +169,7 @@ def load_module_into_database(app, appinst, module_id, available_modules, proces
             m = Module.objects.get(app=appinst, module_name=spec['id'])
         except Module.DoesNotExist:
             # If it doesn't exist yet in the previous app, we'll just create it.
-            pass
+            logger.info(event="load_module_into_database", msg="module does not exist in database yet")
     if m:
         # What is the difference between the app's module and the module in the database?
         change = is_module_changed(m, app.store.source, spec)

--- a/guidedmodules/models.py
+++ b/guidedmodules/models.py
@@ -1,3 +1,7 @@
+import logging
+import structlog
+from structlog import get_logger
+
 from django.db import models, transaction
 from django.utils import timezone
 from django.conf import settings
@@ -14,6 +18,8 @@ from guardian.shortcuts import (assign_perm, get_objects_for_user,
                                 get_perms_for_model, get_user_perms,
                                 get_users_with_perms, remove_perm)
 
+logging.basicConfig()
+logger = get_logger()
 
 class AppSource(models.Model):
     is_system_source = models.BooleanField(default=False, help_text="This field is set to True for a single AppSource that holds the system modules such as user profiles.")
@@ -1291,7 +1297,7 @@ class Task(models.Model):
                     self.get_app_icon_url = self.get_static_asset_image_data_url(icon_img, 75)
                 except ValueError:
                     # no asset or image error
-                    pass
+                    logger.error(event="get_app_icon_url", msg="No asset or image error")
         return self.get_app_icon_url
 
     def get_subtask(self, question_id):

--- a/siteapp/models.py
+++ b/siteapp/models.py
@@ -1,4 +1,8 @@
 from itertools import chain
+import logging
+import structlog
+from structlog import get_logger
+from structlog.stdlib import LoggerFactory
 from typing import Dict
 
 from django.conf import settings
@@ -15,15 +19,10 @@ from guardian.shortcuts import (assign_perm, get_objects_for_user,
 from controls.models import System, Element
 from jsonfield import JSONField
 
-import logging
 logging.basicConfig()
-import structlog
-from structlog import get_logger
-from structlog.stdlib import LoggerFactory
 structlog.configure(logger_factory=LoggerFactory())
 structlog.configure(processors=[structlog.processors.JSONRenderer()])
 logger = get_logger()
-# logger = logging.getLogger(__name__)
 
 
 class User(AbstractUser):
@@ -214,7 +213,8 @@ class User(AbstractUser):
         try:
             del profile["picture"]["content_dataurl"]
         except:
-            pass
+            logger.warning(event="render_context_dict",
+                msg="Failed to delete profile picture content_dataurl")
 
         # Add username to profile
         profile["username"] = self.username

--- a/siteapp/settings.py
+++ b/siteapp/settings.py
@@ -105,7 +105,7 @@ try:
 	import test_without_migrations
 	INSTALLED_APPS.append('test_without_migrations')
 except ImportError:
-	pass
+	print("WARNING: 'test_without_migrations' could not be imported")
 
 # Add standard middleware.
 MIDDLEWARE = [

--- a/testmocking/web.py
+++ b/testmocking/web.py
@@ -1,4 +1,6 @@
+import logging
 import requests
+import structlog
 import parsel
 from random import sample
 import re
@@ -11,6 +13,9 @@ from siteapp.urls import urlpatterns
 from django.urls.exceptions import Resolver404 as Resolver404
 
 from siteapp.models import *
+
+logging.basicConfig()
+logger = get_logger()
 
 class WebClient():
     session = None
@@ -45,7 +50,7 @@ class WebClient():
                     self._use_page(match.func(req, *match.args, **match.kwargs))
                     return
             except Resolver404:
-                pass
+                logger.error(event="_resolve_path", msg="404: Failed to resolve url request path")
         raise Exception("{} not resolved".format(req.path))
 
     def load(self, path):


### PR DESCRIPTION
## Description

This PR fixes the Poor Error Handling: Empty Catch Block findings in Fortify (#1110)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Ran local tests as follows:

**NOTE:** Due to issues with certain pip dependencies and the hash option, this was tested without the `--require-hashes` option for reading the `requirements.txt` file. (See #1206)

```
python3 -m venv env
source env/bin/activate
./quickstart.sh. # requirements.txt replaced with a non-hash requirements file due to #1206 
python3 manage.py test
```


**Test Configuration**:
* Version, or branch, tested:  ma-empty_catch_block_fix-20201118
* Python version: 3.6.9

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation if applicable
- [x] My changes generate no new warnings in pylint
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have corrected any misspellings
- [x] I do not introduce security vulnerabilities in this change