### PR TITLE
Updated import to use OSCAL statements property.

### DIFF
--- a/controls/data/test_data/test_oscal_component.json
+++ b/controls/data/test_data/test_oscal_component.json
@@ -1,18 +1,18 @@
 {
   "component-definition": {
     "metadata": {
-      "title": "AWS IAMS Component-to-Control Narratives",
+      "title": "Sample OSCAL for Testing",
       "published": "2020-12-01T20:38:51+00:00",
       "last-modified": "2020-12-01T20:25:29+00:00",
       "version": "string",
       "oscal-version": "1.0.0-milestone2"
     },
     "components": {
-      "998040f9-a453-4854-ad88-f093bb683dab": {
-        "name": "Test OSCAL Component",
+      "098040f9-a453-4854-ad88-f093bb683dab": {
+        "name": "Test OSCAL Component1",
         "component-type": "software",
         "title": "",
-        "description": "",
+        "description": "This is a sample OSCAL component.",
         "control-implementations": [
           {
             "uuid": "0ab0b252-90d3-4d2c-9785-0c4efb254dfc",
@@ -22,62 +22,111 @@
               {
                 "uuid": "1ab0b252-90d3-4d2c-9785-0c4efb254dfc",
                 "control-id": "ac-7",
-                "description": "Allow a user 5 login attempts before locking them out.",
+                "description": "Default statement description",
                 "remarks": "",
+                "statements" : {
+                  "ac-7_smt.a": {
+                    "uuid": "2ab0b252-90d3-4d2c-9785-0c4efb254dfc",
+                    "description": "Part a description"
+                  },
+                  "ac-7_smt.b": {
+                    "uuid": "3ab0b252-90d3-4d2c-9785-0c4efb254dfc",
+                    "description": "Part b description"
+                  }
+                },
                 "properties": [
                   {
-                  "name": "label",
-                  "value": "a"
+                  "name": "n/a",
+                  "value": "test"
                   }
                 ]
               },
               {
-                "uuid": "2ab0b252-90d3-4d2c-9785-0c4efb254dfc",
-                "control-id": "ac-7",
-                "description": "Disable user account for 5 minutes after lockout.",
+                "uuid": "4ab0b252-90d3-4d2c-9785-0c4efb254dfc",
+                "control-id": "ac-17(9)",
+                "description": "Sample extended control",
                 "remarks": "",
-                "properties": [
-                  {
-                  "name": "label",
-                  "value": "b"
+                "statements" : {
+                  "ac-17(9)_smt.c": {
+                    "uuid": "5ab0b252-90d3-4d2c-9785-0c4efb254dfc",
+                    "description": "Part c of a sample control extension."
                   }
-                ]
+                }
               }
             ]
           },
           {
-            "uuid": "3ab0b252-90d3-4d2c-9785-0c4efb254dfc",
+            "uuid": "6ab0b252-90d3-4d2c-9785-0c4efb254dfc",
+            "source": "NIST_SP-800-53_rev5",
+            "description": "Valid Catalog, Partial implementation of NIST_SP-800-53_rev5",
+            "implemented-requirements": [
+              {
+                "uuid": "7ab0b252-90d3-4d2c-9785-0c4efb254dfc",
+                "control-id": "ac-7",
+                "description": "Default statement description",
+                "remarks": "",
+                "statements" : {
+                  "ac-7_smt.d": {
+                    "uuid": "8ab0b252-90d3-4d2c-9785-0c4efb254dfc",
+                    "description": "Part d description"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "198040f9-a453-4854-ad88-f093bb683dab": {
+        "name": "Test OSCAL Component2",
+        "component-type": "software",
+        "title": "",
+        "description": "Sample Component #2 with invalid statements",
+        "control-implementations": [
+          {
+            "uuid": "9ab0b252-90d3-4d2c-9785-0c4efb254dfc",
             "source": "SMPL_SP-800-53_rev20",
             "description": "Invalid Catalog",
             "implemented-requirements": [
               {
-                "uuid": "4ab0b252-90d3-4d2c-9785-0c4efb254dfc",
+                "uuid": "0bb0b252-90d3-4d2c-9785-0c4efb254dfc",
                 "control-id": "ac-5",
                 "description": "Allow a user 5 login attempts before locking them out.",
                 "remarks": "",
+                "statements" : {
+                  "ac-5_smt.d": {
+                    "uuid": "1bb0b252-90d3-4d2c-9785-0c4efb254dfc",
+                    "description": "Part d description"
+                  }
+                },
                 "properties": [
                   {
-                  "name": "label",
-                  "value": "c"
+                  "name": "unused",
+                  "value": "x"
                   }
                 ]
               }
             ]
           },
           {
-            "uuid": "5ab0b252-90d3-4d2c-9785-0c4efb254dfc",
+            "uuid": "2bb0b252-90d3-4d2c-9785-0c4efb254dfc",
             "source": "NIST_SP-800-53_rev4",
             "description": "Valid Catalog, Partial implementation of NIST_SP-800-53_rev4",
             "implemented-requirements": [
               {
-                "uuid": "6ab0b252-90d3-4d2c-9785-0c4efb254dfc",
+                "uuid": "3bb0b252-90d3-4d2c-9785-0c4efb254dfc",
                 "control-id": "xz-0",
                 "description": "Invalid Control ID",
                 "remarks": "",
+                "statements" : {
+                  "xz-0_smt.d": {
+                    "uuid": "4bb0b252-90d3-4d2c-9785-0c4efb254dfc",
+                    "description": "Part d description"
+                  }
+                },
                 "properties": [
                   {
-                  "name": "label",
-                  "value": "d"
+                  "name": "unused",
+                  "value": "x"
                   }
                 ]
               }

--- a/controls/tests.py
+++ b/controls/tests.py
@@ -303,22 +303,19 @@ class ComponentUITests(OrganizationSiteFunctionalTests):
 
         self.click_element('input#import_component_submit')
 
-        element_count = Element.objects.filter(name='Test OSCAL Component').count()
-        self.assertEqual(element_count, 1)
+        element_count = Element.objects.filter(element_type="system_element").count()
+        self.assertEqual(element_count, 2)
 
-        statement1_count = Statement.objects.filter(uuid='1ab0b252-90d3-4d2c-9785-0c4efb254dfc').count()
-        self.assertEqual(statement1_count, 1)
-
-        statement2_count = Statement.objects.filter(uuid='2ab0b252-90d3-4d2c-9785-0c4efb254dfc').count()
-        self.assertEqual(statement2_count, 1)
+        statement_count = Statement.objects.filter(statement_type="control_implementation_prototype").count()
+        self.assertEqual(statement_count, 4)
 
         # Verify that statements without a proper Catalog don't get entered
-        statement3_count = Statement.objects.filter(uuid='4ab0b252-90d3-4d2c-9785-0c4efb254dfc').count()
-        self.assertEqual(statement3_count, 0)
+        bad_catalog_statement_count = Statement.objects.filter(uuid='1bb0b252-90d3-4d2c-9785-0c4efb254dfc').count()
+        self.assertEqual(bad_catalog_statement_count, 0)
 
         # Verify that statements without a proper Control don't get entered
-        statement4_count = Statement.objects.filter(uuid='6ab0b252-90d3-4d2c-9785-0c4efb254dfc').count()
-        self.assertEqual(statement4_count, 0)
+        bad_control_id_statement_count = Statement.objects.filter(uuid='3bb0b252-90d3-4d2c-9785-0c4efb254dfc').count()
+        self.assertEqual(bad_control_id_statement_count, 0)
 
         var_sleep(1) # Needed to allow page to refresh and messages to render
 
@@ -330,11 +327,11 @@ class ComponentUITests(OrganizationSiteFunctionalTests):
 
         self.click_element('input#import_component_submit')
 
-        element_count = Element.objects.filter(name='Test OSCAL Component').count()
-        self.assertEqual(element_count, 1)
+        element_count = Element.objects.filter(element_type="system_element").count()
+        self.assertEqual(element_count, 2)
 
-        statement1_count = Statement.objects.filter(uuid='1ab0b252-90d3-4d2c-9785-0c4efb254dfc').count()
-        self.assertEqual(statement1_count, 1)
+        statement_count = Statement.objects.filter(statement_type="control_implementation_prototype").count()
+        self.assertEqual(statement_count, 4)
 
 
 class StatementUnitTests(TestCase):

--- a/controls/utilities.py
+++ b/controls/utilities.py
@@ -79,6 +79,7 @@ def oscalize_catalog_key(catalogkey):
 
     return catalogkey
 
+
 def get_control_statement_part(control_stmnt_id):
     """ Parses part from control statement id
     ra-5_smt.a --> a
@@ -87,11 +88,6 @@ def get_control_statement_part(control_stmnt_id):
     if "." not in control_stmnt_id and "_" not in control_stmnt_id:
         return control_stmnt_id
 
-    # Portion after the '.' is the part
-    split_stmnt = control_stmnt_id.split(".")
-    if len(split_stmnt) > 1:
-        return split_stmnt[1]
-    else:
-        # No part, get control id
-        split_stmnt = control_stmnt_id.split("_")
-        return split_stmnt[0]
+    # Portion after the '_smt.' is the part
+    split_stmnt = control_stmnt_id.split("_smt.")
+    return split_stmnt[1] if len(split_stmnt) > 1 else ""

--- a/controls/utilities.py
+++ b/controls/utilities.py
@@ -78,3 +78,20 @@ def oscalize_catalog_key(catalogkey):
         catalogkey = split_key_list[0] + "-800-" + split_key_list[1]
 
     return catalogkey
+
+def get_control_statement_part(control_stmnt_id):
+    """ Parses part from control statement id
+    ra-5_smt.a --> a
+    """
+
+    if "." not in control_stmnt_id and "_" not in control_stmnt_id:
+        return control_stmnt_id
+
+    # Portion after the '.' is the part
+    split_stmnt = control_stmnt_id.split(".")
+    if len(split_stmnt) > 1:
+        return split_stmnt[1]
+    else:
+        # No part, get control id
+        split_stmnt = control_stmnt_id.split("_")
+        return split_stmnt[0]

--- a/controls/views.py
+++ b/controls/views.py
@@ -351,7 +351,9 @@ class ComponentImporter(object):
             return False
         if self.validate_oscal_json(oscal_json):
             # Returns list of created components
-            return self.create_components(oscal_json, request)
+            created_components = self.create_components(oscal_json, request)
+            messages.add_message(request, messages.INFO, f"Created {len(created_components)} components.")
+            return created_components
         else:
             messages.add_message(request, messages.ERROR, f"Invalid OSCAL. Component(s) not created.")
             return False
@@ -393,10 +395,10 @@ class ComponentImporter(object):
         try:
             existing_element_uuids = Element.objects.filter(uuid=component_uuid).count()
         except ValidationError:
-            messages.add_message(request, messages.ERROR, f"Invalid Component UUID ({component_uuid}). Skipping Component...")
+            logger.info(f"Invalid Component UUID ({component_uuid}). Skipping Component...")
             return None
         if existing_element_uuids > 0:
-            messages.add_message(request, messages.ERROR, f"Component already exists with UUID {component_uuid}. Skipping Component...")
+            logger.info(f"Component already exists with UUID {component_uuid}. Skipping Component...")
             return None
         try:
             new_component = Element.objects.create(
@@ -408,24 +410,24 @@ class ComponentImporter(object):
                 uuid=component_uuid
             )
             new_component.save()
-            messages.add_message(request, messages.INFO, f"Component {component_json['name']} created.")
+            logger.info(f"Component {component_json['name']} created.")
             control_implementation_statements = component_json['control-implementations']
             for control_element in control_implementation_statements:
-                catalog = control_element['source'] if 'source' in control_element else None
-                implementation_statements = control_element['implemented-requirements'] if 'implemented-requirements' in control_element else []
-                self.create_control_implementation_statements(catalog, implementation_statements, new_component, request)
+                catalog = oscalize_catalog_key(control_element['source']) if 'source' in control_element else None
+                implemented_reqs = control_element['implemented-requirements'] if 'implemented-requirements' in control_element else []
+                created_statements = self.create_control_implementation_statements(catalog, implemented_reqs, new_component, request)
             return new_component
         except IntegrityError:
-            messages.add_message(request, messages.ERROR, f"Component with name {component_json['name']} already exists. Skipping Component...")
+            logger.info(f"Component with name {component_json['name']} already exists. Skipping Component...")
             return None
 
-    def create_control_implementation_statements(self, catalog_key, implementation_statements, parent_component, request):
+    def create_control_implementation_statements(self, catalog_key, implemented_reqs, parent_component, request):
         """Creates a Statement from a JSON dictimplemented-requirements
 
         @type catalog_key: str
         @param catalog_key: Catalog of the control statements
-        @type implementation_statements: list
-        @param implementation_statements: Implementation statements
+        @type implemented_reqs: list
+        @param implemented_reqs: Implemented controls
         @type parent_component: str
         @param parent_component: UUID of parent component
         @rtype: dict
@@ -434,41 +436,63 @@ class ComponentImporter(object):
 
         new_statements = []
 
-        for impl_stmnt in implementation_statements:
+        for implemented_control in implemented_reqs:
 
-            control_id = impl_stmnt['control-id'] if 'control-id' in impl_stmnt else ''
-            stmnt_uuid = impl_stmnt['uuid'] if 'uuid' in impl_stmnt else ''
+            control_id = oscalize_control_id(implemented_control['control-id']) if 'control-id' in implemented_control else ''
+            statements = implemented_control['statements'] if 'statements' in implemented_control else ''
 
-            try:
-                existing_statement_uuids = Statement.objects.filter(uuid=stmnt_uuid).count()
-            except ValidationError:
-                messages.add_message(request, messages.ERROR, f"Statement UUID {stmnt_uuid} is invalid. Skipping Statement...")
-                continue
+            for stmnt_id in statements:
+                statement = statements[stmnt_id]
 
-            if existing_statement_uuids > 0:
-                messages.add_message(request, messages.ERROR, f"Statement with UUID {stmnt_uuid} already exists. Skipping Statement...")
-                continue
+                # If the UUID already exists or is invalid, skip this statement
+                if 'uuid' in statement:
+                    stmnt_uuid = statement['uuid']
+                    try:
+                        existing_statement_uuids = Statement.objects.filter(uuid=stmnt_uuid).count()
+                    except ValidationError:
+                        logger.info(f"Statement UUID {stmnt_uuid} is invalid. Skipping Statement...")
+                        continue
+                    if existing_statement_uuids > 0:
+                        logger.info(f"Statement with UUID {stmnt_uuid} already exists. Skipping Statement...")
+                        continue
 
-            if self.control_exists_in_catalog(catalog_key, control_id):
-                try:
-                    new_statement = Statement.objects.create(
-                        sid=control_id,
-                        sid_class=catalog_key,
-                        pid=impl_stmnt['properties'][0]['value'] if 'properties' in impl_stmnt and 'value' in impl_stmnt['properties'][0] else None,
-                        body=impl_stmnt['description'] if 'description' in impl_stmnt else None,
-                        statement_type="control_implementation_prototype",
-                        remarks=impl_stmnt['remarks'] if 'remarks' in impl_stmnt else None,
-                        status=impl_stmnt['status'] if 'status' in impl_stmnt else None,
-                        producer_element=parent_component,
-                        uuid=stmnt_uuid,
-                    )
-                    new_statement.save()
-                    messages.add_message(request, messages.INFO, f"New statement with UUID {stmnt_uuid} created.")
-                    new_statements.append(new_statement)
-                except IntegrityError:
-                    messages.add_message(request, messages.ERROR, f"Statement with UUID {stmnt_uuid} already exists. Skipping Statement...")
-            else:
-                messages.add_message(request, messages.ERROR, f"Control {control_id} doesn't exist in this Catalog. Skipping Statement with UUID {stmnt_uuid}...")
+                part = get_control_statement_part(stmnt_id)
+                if 'description' in statement:
+                    description = statement['description']
+                elif 'description' in implemented_control:
+                    description = implemented_control['description']
+                else:
+                    description = ''
+
+                if 'remarks' in statement:
+                    remarks = statement['remarks']
+                elif 'remarks' in implemented_control:
+                    remarks = implemented_control['remarks']
+                else:
+                    remarks = ''
+
+                if self.control_exists_in_catalog(catalog_key, control_id):
+                    try:
+                        new_statement = Statement.objects.create(
+                            sid=control_id,
+                            sid_class=catalog_key,
+                            pid=part,
+                            body=description,
+                            statement_type="control_implementation_prototype",
+                            remarks=remarks,
+                            status=implemented_control['status'] if 'status' in implemented_control else None,
+                            producer_element=parent_component,
+                            uuid=stmnt_uuid,
+                        )
+                        new_statement.save()
+                        logger.info(f"New statement with UUID {stmnt_uuid} created.")
+                        new_statements.append(new_statement)
+                    except IntegrityError:
+                        logger.info(f"Statement with UUID {stmnt_uuid} already exists. Skipping Statement...")
+                        continue
+                else:
+                    logger.info(f"Control {control_id} doesn't exist in this Catalog. Skipping Statement with UUID {stmnt_uuid}...")
+                    continue
 
         return new_statements
 


### PR DESCRIPTION
Supercedes: https://github.com/GovReady/govready-q/pull/1218

Updates the component import to create statements based on the "statements" OSCAL JSON property.
Updates the tests to be more robust and test more edge cases (including invalid components and control extensions).
Moved some messages to logs, to reduce UX messages displayed.