### PR TITLE
Re-generated secret key for case of missing env file (#1242)

### DIFF
--- a/siteapp/settings.py
+++ b/siteapp/settings.py
@@ -46,9 +46,8 @@ else:
 	# Show the defaults.
 	print("\nCouldn't find `local/environment.json` file. Generating default environment params.")
 	print("Please create a '%s' file containing something like this:" % local("environment.json"))
-	environment["secret-key"] = make_secret_key() # Generate a new key
+	environment["secret-key"] = make_secret_key() # Generate a new key since the initial one was printed for the user for edification
 	print(json.dumps(environment, sort_keys=True, indent=2))
-	print()
 
 # Load pre-specified admin users
 # Example: "govready_admins":[{"username": "username", "email":"first.last@example.com", "password": "REPLACEME"}]

--- a/siteapp/settings.py
+++ b/siteapp/settings.py
@@ -46,6 +46,7 @@ else:
 	# Show the defaults.
 	print("\nCouldn't find `local/environment.json` file. Generating default environment params.")
 	print("Please create a '%s' file containing something like this:" % local("environment.json"))
+	environment["secret-key"] = make_secret_key() # Generate a new key
 	print(json.dumps(environment, sort_keys=True, indent=2))
 	print()
 


### PR DESCRIPTION
## Description

This PR fixes a `System Information Leak` identified by Fortify. The secret key used for the environment is printed to stdout in the event that the `environment.json` file is missing.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Ran local tests as follows:

**NOTE:** Due to issues with certain pip dependencies and the hash option, this was tested without the `--require-hashes` option for reading the `requirements.txt` file (See #1206)

```
python3 -m venv env
source env/bin/activate
./quickstart.sh
python3 manage.py test
```

Unrelated test fails:
 None, all tests should pass

**Test Configuration**:
* Version, or branch, tested: ma-fix-env-leak-20201230
* Python version: 3.6.9

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation if applicable
- [x] My changes generate no new warnings in pylint
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have corrected any misspellings
- [x] I do not introduce security vulnerabilities in this change