### PR TITLE
[Feature] MCT-159 - Rename Component Description

### DIFF
--- a/controls/tests.py
+++ b/controls/tests.py
@@ -507,13 +507,16 @@ class ElementUnitTests(TestCase):
         """Test renaming an element"""
 
         # Create an element
-        e = Element.objects.create(name="Element A", full_name="Element A FN", element_type="component")
-        self.assertTrue(e.id is not None)
-        self.assertTrue(e.name == "Element A")
+        e = Element.objects.create(name="Element A", full_name="Element A Full Name",description="Element A Description",element_type="component")
+        self.assertIsNotNone(e.id)
+        self.assertEqual(e.name, "Element A")
+        self.assertEqual(e.description, "Element A Description")
         e.save() 
         e.name = "Renamed Element A"
+        e.description = "Renamed Element A Description"
         e.save()
-        self.assertTrue(e.name == "Renamed Element A")
+        self.assertEqual(e.name, "Renamed Element A")
+        self.assertEqual(e.description, "Renamed Element A Description")
 
 
 class SystemUnitTests(TestCase):

--- a/controls/views.py
+++ b/controls/views.py
@@ -217,12 +217,14 @@ def rename_element(request,element_id):
     """
     try:
         new_name = request.POST.get("name", "").strip() or None
+        new_description = request.POST.get("description", "").strip() or None
         element = get_object_or_404(Element, id=element_id)
         element.name = new_name
+        element.description = new_description
         element.save()
         logger.info(
             event="rename_element",
-            element={"id": element.id, "new_name": new_name}
+            element={"id": element.id, "new_name": new_name, "new_description": new_description}
         )
         return JsonResponse({ "status": "ok" }) 
     except:

--- a/templates/base.html
+++ b/templates/base.html
@@ -92,6 +92,7 @@
     {% include "bootstrap-helpers.html" %}
 
     {% include "portfolios/select-portfolio-modal.html" %}
+    {% include "edit-component-modal.html" %}
 
     <div id="invitation_modal" class="modal" tabindex="-1" role="dialog" aria-labelledby="invitation_modal_title" aria-hidden="true" data-url="{% url "send_invitation" %}">
       <div class="modal-dialog">

--- a/templates/components/element_detail_tabs.html
+++ b/templates/components/element_detail_tabs.html
@@ -108,7 +108,7 @@
       <div class="col-sm-2">
         <div id="btn-edit-title" style="text-align: center;">
           {% if is_admin %}
-            <button class="btn btn-default btn-small" id="edit-button" onclick="return rename_component();">Edit</button>
+            <button class="btn btn-default btn-small" id="edit-button" onclick="return edit_component();">Edit</button>
           {% endif %}
         </div>
       </div>
@@ -425,17 +425,17 @@
               }
           }
         }
-        function rename_component() {
-          var new_name = prompt("Rename this component?", "{{element.name|escapejs}}");
-          if (new_name === null || new_name == "{{element.name|escapejs}}") return;
-          ajax_with_indicator({
-            url: '{% url "rename_element" element.id %}',
-            method: "POST",
-            data: {name: new_name},
-            keep_indicator_forever: true,
-            success: function() {
-              window.location.reload();
-            }
+        function edit_component() {
+          show_edit_component_modal("{{element.name}}","{{element.description}}",(newName, newDescription)=>{
+            ajax_with_indicator({
+              url: '{% url "rename_element" element.id %}',
+              method: "POST",
+              data: {name: newName,description: newDescription},
+              keep_indicator_forever: true,
+              success: function() {
+                window.location.reload();
+              }
+            });
           });
         }
       </script>

--- a/templates/edit-component-modal.html
+++ b/templates/edit-component-modal.html
@@ -1,0 +1,40 @@
+<div id="edit-component-modal" class="modal"">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <div class="modal-header">
+          <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+          <h4 class="modal-title" id="invitation_modal_title">Edit Component</h4>
+        </div>
+        <form role="form" method="get">
+           <div class="modal-body">
+            <div class="form-group" data-children-count="1">
+                <label class="control-label" for="id_name">Name</label>
+                <input type="text" name="name" maxlength="250" class="form-control" placeholder="Name" title="Common name or acronym of the element" required="" id="name-input" data-kwimpalastatus="alive" data-kwimpalaid="1609952239310-0">
+                <div class="help-block">Common name or acronym of the element</div>
+            </div>
+            <div class="form-group" data-children-count="1">
+                <label class="control-label" for="id_name">Description</label>
+                <input type="text" name="name" maxlength="250" class="form-control" placeholder="Description" title="Common name or acronym of the element" required="" id="description-input" data-kwimpalastatus="alive" data-kwimpalaid="1609952239310-0">
+                <div class="help-block">Brief description of the Element</div>
+            </div>
+           </div>
+           <div class="modal-footer">
+             <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+             <button id="submit-btn" class="btn btn-success" type="submit">Save</button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+  </div>
+  
+  {% block scripts %}
+  <script>
+    function show_edit_component_modal(name,description,callback) {
+      document.getElementById("name-input").value = name;
+      document.getElementById("description-input").value = description;
+      $('#edit-component-modal').modal();
+      $('#submit-btn').on('click', () => callback(document.getElementById("name-input").value,document.getElementById("description-input").value));
+    }
+  </script>
+  {% endblock %}


### PR DESCRIPTION
# Pull Request

## Description

Added the ability for a GovReady administrator to rename the description of a component with the use of an edit button near the name of a component in the Component Library pages.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Unit Test - Tests updating the description of a component 
- [X] UI Test - Tests the existence of the button on the component page if the user is an admin
Scripts have been implemented to `controls/tests.py` to run it: `python manage.py test controls.tests `

## Checklist:

- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings