### PR TITLE
Copy Components on Import

### DIFF
--- a/controls/tests.py
+++ b/controls/tests.py
@@ -235,6 +235,10 @@ class ComponentUITests(OrganizationSiteFunctionalTests):
         file_input = self.find_selected_option('input#id_file')
         self.filepath_conversion(file_input, oscal_json_path, "sendkeys")
 
+        element_count_before_import = Element.objects.filter(element_type="system_element").count()
+        statement_count_before_import = Statement.objects.filter(
+            statement_type="control_implementation_prototype").count()
+
         # Verify that the contents got copied correctly from the file to the textfield
         try:
             # Load contents from file
@@ -252,19 +256,19 @@ class ComponentUITests(OrganizationSiteFunctionalTests):
 
         self.click_element('input#import_component_submit')
 
-        element_count = Element.objects.filter(uuid='123456a7-b890-1234-cd56-e789fa012bcd').count()
-        self.assertEqual(element_count, 0)
+        element_count_after_import = Element.objects.filter(element_type="system_element").count()
+        self.assertEqual(element_count_before_import, element_count_after_import)
 
-        statement1_count = Statement.objects.filter(uuid='1ab2c345-67d8-9e0f-1234-5a6bcd789efa').count()
-        self.assertEqual(statement1_count, 0)
-
-        statement2_count = Statement.objects.filter(uuid='2bc3d456-78e9-0f1a-2345-6b7cde890fab').count()
-        self.assertEqual(statement2_count, 0)
+        statement_count_after_import = Statement.objects.filter(statement_type="control_implementation_prototype").count()
+        self.assertEqual(statement_count_before_import, statement_count_after_import)
 
     def test_component_import_oscal_json(self):
         self._login()
         url = self.url(f"/controls/components")
         self.browser.get(url)
+
+        element_count_before_import = Element.objects.filter(element_type="system_element").count()
+        statement_count_before_import = Statement.objects.filter(statement_type="control_implementation_prototype").count()
 
         # Test initial import of Component(s) and Statement(s)
         self.click_element('a#component-import-oscal')
@@ -275,23 +279,22 @@ class ComponentUITests(OrganizationSiteFunctionalTests):
 
         self.click_element('input#import_component_submit')
 
-        element_count = Element.objects.filter(element_type="system_element").count()
-        self.assertEqual(element_count, 2)
+        var_sleep(3) # Wait for OSCAL to be imported
 
-        statement_count = Statement.objects.filter(statement_type="control_implementation_prototype").count()
-        self.assertEqual(statement_count, 4)
+        element_count_after_import = Element.objects.filter(element_type="system_element").count()
+        self.assertEqual(element_count_before_import + 2, element_count_after_import)
 
-        # Verify that statements without a proper Catalog don't get entered
-        bad_catalog_statement_count = Statement.objects.filter(uuid='1bb0b252-90d3-4d2c-9785-0c4efb254dfc').count()
-        self.assertEqual(bad_catalog_statement_count, 0)
+        statement_count_after_import = Statement.objects.filter(statement_type="control_implementation_prototype").count()
+        self.assertEqual(statement_count_before_import + 4, statement_count_after_import)
+        # Test file contains 6 Statements, but only 4 get imported
+        # because one has an improper Catalog
+        # and another has an improper Control
+        # but we can't test individual statements because the UUIDs are randomly generated and not consistent
+        # with the OSCAL JSON file. So we simply do a count.
 
-        # Verify that statements without a proper Control don't get entered
-        bad_control_id_statement_count = Statement.objects.filter(uuid='3bb0b252-90d3-4d2c-9785-0c4efb254dfc').count()
-        self.assertEqual(bad_control_id_statement_count, 0)
+        var_sleep(3) # Needed to allow page to refresh and messages to render
 
-        var_sleep(1) # Needed to allow page to refresh and messages to render
-
-        # Test that duplicate Components and Statements are not re-imported
+        # Test that duplicate Components are re-imported with a different name and that Statements get reimported
         self.click_element('a#component-import-oscal')
         file_input = self.find_selected_option('input#id_file')
         # Using converted keys from above
@@ -299,11 +302,21 @@ class ComponentUITests(OrganizationSiteFunctionalTests):
 
         self.click_element('input#import_component_submit')
 
-        element_count = Element.objects.filter(element_type="system_element").count()
-        self.assertEqual(element_count, 2)
+        var_sleep(3) # Wait for OSCAL to be imported
 
-        statement_count = Statement.objects.filter(statement_type="control_implementation_prototype").count()
-        self.assertEqual(statement_count, 4)
+        element_count_after_duplicate_import = Element.objects.filter(element_type="system_element").count()
+        self.assertEqual(element_count_after_import + 2, element_count_after_duplicate_import)
+
+        original_import_element_count = Element.objects.filter(name='Test OSCAL Component1').count()
+        self.assertEqual(original_import_element_count, 1)
+
+        duplicate_import_element_count = Element.objects.filter(name='Test OSCAL Component1 (1)').count()
+        self.assertEqual(duplicate_import_element_count, 1)
+
+        statement_count_after_duplicate_import = Statement.objects.filter(
+            statement_type="control_implementation_prototype").count()
+        self.assertEqual(statement_count_after_import + 4, statement_count_after_duplicate_import)
+
 
     def test_import_tracker(self):
         """Tests that imports are tracked correctly."""

--- a/controls/utilities.py
+++ b/controls/utilities.py
@@ -91,3 +91,14 @@ def get_control_statement_part(control_stmnt_id):
     # Portion after the '_smt.' is the part
     split_stmnt = control_stmnt_id.split("_smt.")
     return split_stmnt[1] if len(split_stmnt) > 1 else ""
+
+
+def increment_component_name(component_name):
+    """Increments a Component Name by adding (1)"""
+
+    if re.search("\((\d+)\)$", component_name):
+        new_component_name = re.sub("\((\d+)\)$", lambda m: " (" + str(int(m.groups()[0])+1) + ")", component_name)
+    else:
+        new_component_name = component_name + " (1)"
+
+    return new_component_name


### PR DESCRIPTION
For now, while we aren't sure of the behavior for using UUIDs in Component and Statement imports, I have removed the UUID checks from the Component Importer. Instead, we're only checking for conflicts of the Component Name. If there is a conflict, the name gets incremented, so the Component still gets imported and the statements still get created. The only situation where a Statement won't get created now is if the catalog/profile does not contain the control in question.