### PR TITLE
Add link to Compliance App Library without adding app to portfolio.

### DIFF
--- a/siteapp/views.py
+++ b/siteapp/views.py
@@ -364,10 +364,7 @@ def apps_catalog(request):
     if "q" in request.GET: forward_qsargs["q"] = request.GET["q"]
 
     # Add the portfolio id the user is creating the project from to the args
-    if "portfolio" not in request.GET:
-        messages.add_message(request, messages.ERROR, "Please select 'Start a project' to continue.")
-        return redirect('projects')
-    else:
+    if "portfolio" in request.GET:
         forward_qsargs["portfolio"] = request.GET["portfolio"]
 
     # Get the app catalog. If the user is answering a question, then filter to

--- a/templates/app-store-item.html
+++ b/templates/app-store-item.html
@@ -145,14 +145,9 @@
             </select>
           </div>
         {% endif %}
-        <button id="start-project" type="submit" class="btn btn-success app-button-width">
-          {% if not request.GET.q %}
-          Add
-          {% else %}
-          Add
-          {% endif %}
-          ►
-        </button>
+        {% if portfolio %}
+          <button id="start-project" type="submit" class="btn btn-success app-button-width">Add ►</button>
+        {% endif %}
       </form>
       <button id="start-project" type="submit" class="btn btn-link btn-start-project">
           {% if portfolio %}

--- a/templates/app-store.html
+++ b/templates/app-store.html
@@ -205,9 +205,9 @@ Compliance Apps
                       {% with app.organizations|first as first_org %}
                           <input type="hidden" id="{{ app.key }}/organization_{{ forloop.counter }}" name="organization" value="{{ first_org.slug }}">
                       {% endwith %}
-                      <button type="submit" class="btn btn-success btn-sm start-app">
-                          Add ►
-                      </button>&nbsp;
+                      {% if 'portfolio' in forward_qsargs %}
+                        <button type="submit" class="btn btn-success btn-sm start-app">Add ►</button>&nbsp;
+                      {% endif %}
                   </form>
               {% endif %}
             <a href="/store/{{app.key|urlencode}}{{forward_qsargs}}" class="btn btn-default btn-sm view-app">Info</a>

--- a/templates/navbar.html
+++ b/templates/navbar.html
@@ -18,10 +18,10 @@
       <ul class="nav navbar-nav navbar-left">
         {% if request.user.is_authenticated and not request.user.is_anonymous %}
           <li><a href="/projects" id="menu-projects">Projects</a></li>
-          <li>&nbsp;&nbsp;&nbsp;&nbsp;</li>
           <li><a href="/portfolios" id="menu-portfolios">Portfolios</a></li>
           <li><a href="/controls" id="menu-controls">Controls</a></li>
           <li><a href="/controls/components" id="menu-controls">Component Library</a></li>
+          <li><a href="{% url 'store' %}">App Library</a></li>
         {% endif %}
       </ul>
 


### PR DESCRIPTION
I've had trouble accessing the list of Compliance Apps without specifying a portfolio, but there should be a way to view available Compliance Apps without adding them to a project or portfolio. I created a simple workflow that removes the "Add" button from the Compliance Apps page if a portfolio is not specified. This should improve the workflow without requiring users to enter a specific URL.