### PR TITLE
Handle Name Collisions when Editing a Component Name

### DIFF
--- a/controls/views.py
+++ b/controls/views.py
@@ -220,18 +220,22 @@ def rename_element(request,element_id):
     try:
         new_name = request.POST.get("name", "").strip() or None
         new_description = request.POST.get("description", "").strip() or None
-        element = get_object_or_404(Element, id=element_id)
-        element.name = new_name
-        element.description = new_description
-        element.save()
-        logger.info(
-            event="rename_element",
-            element={"id": element.id, "new_name": new_name, "new_description": new_description}
-        )
-        return JsonResponse({ "status": "ok" }) 
+        try:
+            e = Element.objects.get(name=new_name)
+            return JsonResponse({ "status": "err", "message": "Name already in use"})  
+        except:
+            element = get_object_or_404(Element, id=element_id)
+            element.name = new_name
+            element.description = new_description
+            element.save()
+            logger.info(
+                event="rename_element",
+                element={"id": element.id, "new_name": new_name, "new_description": new_description}
+            )
+            return JsonResponse({ "status": "ok" }) 
     except:
         import sys
-        return JsonResponse({ "status": "error", "message": sys.exc_info() })
+        return JsonResponse({ "status": "err", "message": sys.exc_info() })
 
 
 def components_selected(request, system_id):

--- a/controls/views.py
+++ b/controls/views.py
@@ -220,19 +220,20 @@ def rename_element(request,element_id):
     try:
         new_name = request.POST.get("name", "").strip() or None
         new_description = request.POST.get("description", "").strip() or None
-        try:
-            e = Element.objects.get(name=new_name)
-            return JsonResponse({ "status": "err", "message": "Name already in use"})  
-        except:
-            element = get_object_or_404(Element, id=element_id)
-            element.name = new_name
-            element.description = new_description
-            element.save()
-            logger.info(
-                event="rename_element",
-                element={"id": element.id, "new_name": new_name, "new_description": new_description}
-            )
-            return JsonResponse({ "status": "ok" }) 
+
+        if Element.objects.filter(name=new_name).exists() is True:
+            return JsonResponse({ "status": "err", "message": "Name already in use"})
+            
+        element = get_object_or_404(Element, id=element_id)
+        element.name = new_name
+        element.description = new_description
+        element.save()
+        logger.info(
+            event="rename_element",
+            element={"id": element.id, "new_name": new_name, "new_description": new_description}
+        )
+        return JsonResponse({ "status": "ok" }) 
+           
     except:
         import sys
         return JsonResponse({ "status": "err", "message": sys.exc_info() })

--- a/templates/components/element_detail_tabs.html
+++ b/templates/components/element_detail_tabs.html
@@ -424,8 +424,14 @@
               method: "POST",
               data: {name: newName,description: newDescription},
               keep_indicator_forever: true,
-              success: function() {
-                window.location.reload();
+              success: function(res) {
+                if(res["status"]=="ok"){
+                  hide_edit_component_modal();
+                  window.location.reload();
+                }
+                if(res["status"]=="err"){
+                  show_edit_component_modal_error(res["message"])
+                }
               }
             });
           });

--- a/templates/edit-component-modal.html
+++ b/templates/edit-component-modal.html
@@ -17,6 +17,8 @@
                 <input type="text" name="name" maxlength="250" class="form-control" placeholder="Description" title="Common name or acronym of the element" required="" id="description-input" data-kwimpalastatus="alive" data-kwimpalaid="1609952239310-0">
                 <div class="help-block">Brief description of the Element</div>
             </div>
+            <div class="alert alert-danger" role="alert" id="error-alert">
+            </div>
            </div>
            <div class="modal-footer">
              <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
@@ -33,8 +35,19 @@
     function show_edit_component_modal(name,description,callback) {
       document.getElementById("name-input").value = name;
       document.getElementById("description-input").value = description;
+      $('#error-alert').hide();
       $('#edit-component-modal').modal();
-      $('#submit-btn').on('click', () => callback(document.getElementById("name-input").value,document.getElementById("description-input").value));
+      $('#submit-btn').on('click', (e) =>{
+        e.preventDefault();
+        callback(document.getElementById("name-input").value,document.getElementById("description-input").value);
+      });
+    }
+    function hide_edit_component_modal(){
+      $('#edit-component-modal').modal('hide');
+    }
+    function show_edit_component_modal_error(errorMessage){
+      $("#error-alert").html(errorMessage); 
+      $('#error-alert').fadeIn();
     }
   </script>
   {% endblock %}


### PR DESCRIPTION
# Pull Request

## Description

Added the ability for a GovReady administrator to rename the description of a component with the use of an edit button near the name of a component in the Component Library pages.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings