### PR TITLE
Oscal app inputs simple

### DIFF
--- a/controls/views.py
+++ b/controls/views.py
@@ -444,7 +444,7 @@ class OpenControlComponentSerializer(ComponentSerializer):
 
 class ComponentImporter(object):
 
-    def import_components_as_json(self, import_name, json_object, request):
+    def import_components_as_json(self, import_name, json_object, request=None):
         """Imports Components from a JSON object
 
         @type import_name: str
@@ -459,16 +459,22 @@ class ComponentImporter(object):
         try:
             oscal_json = json.loads(json_object)
         except ValueError:
-            messages.add_message(request, messages.ERROR, f"Invalid JSON. Component(s) not created.")
+            if request is not None:
+                messages.add_message(request, messages.ERROR, f"Invalid JSON. Component(s) not created.")
+            logger.info(f"Invalid JSON. Component(s) not created.")
             return False
         if self.validate_oscal_json(oscal_json):
             # Returns list of created components
-            created_components = self.create_components(oscal_json, request)
-            messages.add_message(request, messages.INFO, f"Created {len(created_components)} components.")
+            created_components = self.create_components(oscal_json)
+            if request is not None:
+                messages.add_message(request, messages.INFO, f"Created {len(created_components)} components.")
+            logger.info(f"Created {len(created_components)} components.")
             new_import_record = self.create_import_record(import_name, created_components)
             return new_import_record
         else:
-            messages.add_message(request, messages.ERROR, f"Invalid OSCAL. Component(s) not created.")
+            if request is not None:
+                messages.add_message(request, messages.ERROR, f"Invalid OSCAL. Component(s) not created.")
+            logger.info(f"Invalid JSON. Component(s) not created.")
             return False
 
     def create_import_record(self, import_name, components):
@@ -508,19 +514,19 @@ class ComponentImporter(object):
             logger.info(e)
             return False
 
-    def create_components(self, oscal_json, request):
+    def create_components(self, oscal_json):
         """Creates Elements (Components) from valid OSCAL JSON"""
 
         components_created = []
         components = oscal_json['component-definition']['components']
         for component in components:
-            new_component = self.create_component(components[component], request)
+            new_component = self.create_component(components[component])
             if new_component is not None:
                 components_created.append(new_component)
 
         return components_created
 
-    def create_component(self, component_json, request):
+    def create_component(self, component_json):
         """Creates a component from a JSON dict
 
         @type component_json: dict
@@ -546,11 +552,10 @@ class ComponentImporter(object):
         for control_element in control_implementation_statements:
             catalog = oscalize_catalog_key(control_element['source']) if 'source' in control_element else None
             implemented_reqs = control_element['implemented-requirements'] if 'implemented-requirements' in control_element else []
-            created_statements = self.create_control_implementation_statements(catalog, implemented_reqs,
-                                                                               new_component, request)
+            created_statements = self.create_control_implementation_statements(catalog, implemented_reqs, new_component)
         return new_component
 
-    def create_control_implementation_statements(self, catalog_key, implemented_reqs, parent_component, request):
+    def create_control_implementation_statements(self, catalog_key, implemented_reqs, parent_component):
         """Creates a Statement from a JSON dictimplemented-requirements
 
         @type catalog_key: str

--- a/guidedmodules/app_source_connections.py
+++ b/guidedmodules/app_source_connections.py
@@ -68,6 +68,8 @@ class App(object):
     def __repr__(self):
         return "<App {name} in {store}>".format(name=self.name, store=self.store)
 
+    def get_inputs(self):
+        raise Exception("Not implemented!")
     def get_modules(self):
         raise Exception("Not implemented!")
     def get_assets(self):
@@ -253,6 +255,15 @@ class PyFsApp(App):
     def __init__(self, store, name, fs):
         super().__init__(store, name)
         self.fs = fs
+
+    def get_fs(self):
+        return self.fs
+
+    def get_inputs(self):
+
+        app = read_yaml_file(self.read_file("app.yaml"))
+        input_list = app["input"]
+        return input_list
 
     def get_modules(self):
         # Return a generator over parsed YAML data for modules.


### PR DESCRIPTION
**Compare against:** https://github.com/GovReady/govready-q/pull/1335
**ONLY MERGE ONE**

This is a simple approach to supporting OSCAL JSON components with Compliance App sources.
Iterates through inputs in the app.yaml file.

Input format in the app.yaml file is expected as:
```
input:
- id: oscal_components
  name: OSCAL Components
  type: oscal
  path: data/oscal_components.json
  group: OSCAL
```