### PR TITLE
 Allow migrations to be ran backwards

### DIFF
--- a/controls/migrations/0023_auto_20200802_0119.py
+++ b/controls/migrations/0023_auto_20200802_0119.py
@@ -21,19 +21,24 @@ class Migration(migrations.Migration):
             obj.save()
 
     operations = [
-        migrations.RemoveField(
-            model_name='poam',
-            name='uuid',
-        ),
+        migrations.RemoveField(model_name='poam', name='uuid'),
         migrations.AddField(
             model_name='element',
             name='uuid',
-            field=models.UUIDField(default=uuid.uuid4, editable=True, help_text='A UUID (a unique identifier) for this Element.'),
+            field=models.UUIDField(
+                default=uuid.uuid4,
+                editable=True,
+                help_text='A UUID (a unique identifier) for this Element.',
+            ),
         ),
         migrations.AddField(
             model_name='statement',
             name='uuid',
-            field=models.UUIDField(default=uuid.uuid4, editable=True, help_text='A UUID (a unique identifier) for this Statement.'),
+            field=models.UUIDField(
+                default=uuid.uuid4,
+                editable=True,
+                help_text='A UUID (a unique identifier) for this Statement.',
+            ),
         ),
-        migrations.RunPython(create_uuids),
+        migrations.RunPython(create_uuids, migrations.RunPython.noop),
     ]

--- a/controls/migrations/0028_elementcontrol_uuid.py
+++ b/controls/migrations/0028_elementcontrol_uuid.py
@@ -20,7 +20,10 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='elementcontrol',
             name='uuid',
-            field=models.UUIDField(default=uuid.uuid4, help_text='A UUID (a unique identifier) for this ElementControl.'),
+            field=models.UUIDField(
+                default=uuid.uuid4,
+                help_text='A UUID (a unique identifier) for this ElementControl.',
+            ),
         ),
-        migrations.RunPython(create_uuids),
+        migrations.RunPython(create_uuids, migrations.RunPython.noop),
     ]

--- a/discussion/models.py
+++ b/discussion/models.py
@@ -251,12 +251,7 @@ class Comment(models.Model):
     replies_to = models.ForeignKey('self', blank=True, null=True, related_name="replies", on_delete=models.CASCADE, help_text="If this is a reply to a Comment, the Comment that this is in reply to.")
     user = models.ForeignKey(User, on_delete=models.PROTECT, help_text="The user making a comment.")
 
-    emojis = models.CharField(
-        max_length=256,
-        blank=True,
-        default="",
-        help_text="A comma-separated list of emoji names that the user is reacting with.",
-    )
+    emojis = models.CharField(max_length=256, blank=True, null=True, help_text="A comma-separated list of emoji names that the user is reacting with.")
     text = models.TextField(blank=True, help_text="The text of the user's comment.")
     proposed_answer = JSONField(blank=True, null=True, help_text="A proposed answer to the question that this discussion is about.")
     draft = models.BooleanField(default=False, help_text="Set to true if the comment is a draft.")

--- a/discussion/models.py
+++ b/discussion/models.py
@@ -251,7 +251,12 @@ class Comment(models.Model):
     replies_to = models.ForeignKey('self', blank=True, null=True, related_name="replies", on_delete=models.CASCADE, help_text="If this is a reply to a Comment, the Comment that this is in reply to.")
     user = models.ForeignKey(User, on_delete=models.PROTECT, help_text="The user making a comment.")
 
-    emojis = models.CharField(max_length=256, blank=True, null=True, help_text="A comma-separated list of emoji names that the user is reacting with.")
+    emojis = models.CharField(
+        max_length=256,
+        blank=True,
+        default="",
+        help_text="A comma-separated list of emoji names that the user is reacting with.",
+    )
     text = models.TextField(blank=True, help_text="The text of the user's comment.")
     proposed_answer = JSONField(blank=True, null=True, help_text="A proposed answer to the question that this discussion is about.")
     draft = models.BooleanField(default=False, help_text="Set to true if the comment is a draft.")

--- a/guidedmodules/migrations/0011_modulequestion_answer_type_module.py
+++ b/guidedmodules/migrations/0011_modulequestion_answer_type_module.py
@@ -27,7 +27,17 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='modulequestion',
             name='answer_type_module',
-            field=models.ForeignKey(blank=True, help_text='For module and module-set typed questions, this is the Module that Tasks that answer this question must be for.', null=True, on_delete=django.db.models.deletion.PROTECT, related_name='is_type_of_answer_to', to='guidedmodules.Module'),
+            field=models.ForeignKey(
+                blank=True,
+                help_text=(
+                    'For module and module-set typed questions, this is the Module that'
+                    ' Tasks that answer this question must be for.'
+                ),
+                null=True,
+                on_delete=django.db.models.deletion.PROTECT,
+                related_name='is_type_of_answer_to',
+                to='guidedmodules.Module',
+            ),
         ),
-        migrations.RunPython(forwards_func),
+        migrations.RunPython(forwards_func, migrations.RunPython.noop),
     ]

--- a/guidedmodules/migrations/0037_appsource_is_system_source.py
+++ b/guidedmodules/migrations/0037_appsource_is_system_source.py
@@ -19,8 +19,13 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='appsource',
             name='is_system_source',
-            field=models.BooleanField(default=False, help_text='This field is set to True for a single AppSource that holds the system modules such as user profiles.'),
+            field=models.BooleanField(
+                default=False,
+                help_text=(
+                    'This field is set to True for a single AppSource that holds the system'
+                    ' modules such as user profiles.'
+                ),
+            ),
         ),
-
-        migrations.RunPython(mark_system_source),
+        migrations.RunPython(mark_system_source, migrations.RunPython.noop),
     ]

--- a/guidedmodules/migrations/0039_appsource_approved_apps.py
+++ b/guidedmodules/migrations/0039_appsource_approved_apps.py
@@ -24,7 +24,13 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='appsource',
             name='approved_apps',
-            field=jsonfield.fields.JSONField(blank=True, help_text='Information about apps whitelisted or blacklisted for display in the catalog from this source.'),
+            field=jsonfield.fields.JSONField(
+                blank=True,
+                help_text=(
+                    'Information about apps whitelisted or blacklisted for display in the'
+                    ' catalog from this source.'
+                ),
+            ),
         ),
-        migrations.RunPython(add_default_value),
+        migrations.RunPython(add_default_value, migrations.RunPython.noop),
     ]

--- a/system_settings/migrations/0002_auto_20190808_1947.py
+++ b/system_settings/migrations/0002_auto_20190808_1947.py
@@ -14,6 +14,4 @@ class Migration(migrations.Migration):
         ('system_settings', '0001_initial'),
     ]
 
-    operations = [
-        migrations.RunPython(hide_registration),
-    ]
+    operations = [migrations.RunPython(hide_registration, migrations.RunPython.noop)]

--- a/system_settings/migrations/0003_auto_20200623_1539.py
+++ b/system_settings/migrations/0003_auto_20200623_1539.py
@@ -20,6 +20,6 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunPython(enable_experimental_opencontrol),
-        migrations.RunPython(enable_experimental_oscal),
+        migrations.RunPython(enable_experimental_opencontrol, migrations.RunPython.noop),
+        migrations.RunPython(enable_experimental_oscal, migrations.RunPython.noop),
     ]


### PR DESCRIPTION
currently django would raise exception if we tried to reverse the migrations because the data migration has no backwards. This avoids that problem [read more](https://django.doctor/advice/C8001)

I made this PR via the "auto fix" tab on https://django.doctor/GovReady/govready-q