### PR TITLE
Fix `requirements.txt` < `requirements_txt_updater.sh`  to prevent install error  re: setuptools not pinned

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -888,6 +888,13 @@ zipp==3.4.0 \
     --hash=sha256:ed5eee1974372595f9e416cc7bbeeb12335201d8081ca8a0743c954d4446e5cb
     # via importlib-metadata
 
-# WARNING: The following packages were not pinned, but pip requires them to be
-# pinned when the requirements file includes hashes. Consider using the --allow-unsafe flag.
-# setuptools
+# The following packages are considered to be unsafe in a requirements file:
+setuptools==53.0.0 \
+    --hash=sha256:0e86620d658c5ca87a71a283bd308fcaeb4c33e17792ef6f081aec17c171347f \
+    --hash=sha256:1b18ef17d74ba97ac9c0e4b4265f123f07a8ae85d9cd093949fa056d3eeeead5
+    # via
+    #   fs
+    #   gunicorn
+    #   jsonschema
+    #   safety
+    #   sphinx

--- a/requirements_txt_checker.sh
+++ b/requirements_txt_checker.sh
@@ -20,7 +20,9 @@ function run_checks() {
 	# a temporary file.
 	FN=$(mktemp)
 	echo "Flattening transitive dependencies of '$FILE_BASE.txt' to a temporary file '$FN'"
-	pip-compile --generate-hashes --output-file $FN --no-header --no-annotate ${FILE_BASE}.in > /dev/null
+	pip-compile --generate-hashes --allow-unsafe  --upgrade --output-file $FN --no-header --no-annotate ${FILE_BASE}.in > /dev/null
+        # like requirements_txt_updater.sh
+        #   except added --no-annotate (see below)
 
 	# The reverse-dependency metadata doesn't seem to be entirely
 	# accurate and changes nondeterministically? We omit it above

--- a/requirements_txt_checker.sh
+++ b/requirements_txt_checker.sh
@@ -21,8 +21,8 @@ function run_checks() {
 	FN=$(mktemp)
 	echo "Flattening transitive dependencies of '$FILE_BASE.txt' to a temporary file '$FN'"
 	pip-compile --generate-hashes --allow-unsafe  --upgrade --output-file $FN --no-header --no-annotate ${FILE_BASE}.in > /dev/null
-        # like requirements_txt_updater.sh
-        #   except added --no-annotate (see below)
+	# like requirements_txt_updater.sh
+	#   except added --no-annotate (see below)
 
 	# The reverse-dependency metadata doesn't seem to be entirely
 	# accurate and changes nondeterministically? We omit it above
@@ -31,8 +31,37 @@ function run_checks() {
 	FN2=$(mktemp)
 	echo "Clean up of temporary requirements file for comparisons"
 	cat ${FILE_BASE}.txt \
-		| python3 -c "import sys, re; print(re.sub(r'[\s\\\\]+# via .*', '', sys.stdin.read()));" \
+		| python3 -c "import sys, re; print(re.sub(r'\n[ \t]+\# .*', '', sys.stdin.read()));" \
 		> $FN2
+	# e.g.,
+	#   Reduce
+	#
+	#   > zipp==3.4.0 \
+	#   >     --hash=sha256:102c24ef8f171fd729d46599845e95c7ab894a4cf45f5de11a44cc7444fb1108 \
+	#   >     --hash=sha256:ed5eee1974372595f9e416cc7bbeeb12335201d8081ca8a0743c954d4446e5cb
+	#   >     # via
+	#   >     #   importlib-metadata
+	#   >     #   importlib-resources
+	#   >
+	#   > # The following packages are considered to be unsafe in a requirements file:
+	#   > setuptools==53.0.0 \
+	#   >     --hash=sha256:0e86620d658c5ca87a71a283bd308fcaeb4c33e17792ef6f081aec17c171347f \
+	#   >     --hash=sha256:1b18ef17d74ba97ac9c0e4b4265f123f07a8ae85d9cd093949fa056d3eeeead5
+	#   >     # via
+	#   >     #   fs
+	#
+	#   to
+	#
+	#   > zipp==3.4.0 \
+	#   >     --hash=sha256:102c24ef8f171fd729d46599845e95c7ab894a4cf45f5de11a44cc7444fb1108 \
+	#   >     --hash=sha256:ed5eee1974372595f9e416cc7bbeeb12335201d8081ca8a0743c954d4446e5cb
+	#   >
+	#   > # The following packages are considered to be unsafe in a requirements file:
+	#   > setuptools==53.0.0 \
+	#   >     --hash=sha256:0e86620d658c5ca87a71a283bd308fcaeb4c33e17792ef6f081aec17c171347f \
+	#   >     --hash=sha256:1b18ef17d74ba97ac9c0e4b4265f123f07a8ae85d9cd093949fa056d3eeeead5
+
+	# Note:  sys.stdin.read() appends a '\n',  but leaving since ignoring whitespace below
 
 	# Compare the requirements.txt in the repository to the one found by
 	# generating it from requirements.in.

--- a/requirements_txt_updater.sh
+++ b/requirements_txt_updater.sh
@@ -29,7 +29,11 @@ function run_update() {
 	# generate a requirements.txt file from scratch, and any unpinned
 	# packages will be pinned to the latest upstream version, and if we
 	# don't do the same here, the files won't match and the check will fail.)
-	pip-compile --generate-hashes --upgrade --output-file ${FILE_BASE}.txt --no-header ${FILE_BASE}.in
+	pip-compile --generate-hashes --allow-unsafe  --upgrade --output-file ${FILE_BASE}.txt --no-header ${FILE_BASE}.in
+	# --allow-unsafe
+	#   prevents errors during `pip3 install -r requirements.txt`
+	#     by enabling pinning setuptools etc. dependencies
+	#                   e.g., via --generate-hashes
 
 	# Check packages for known vulnerabilities.
 	safety check -r ${FILE_BASE}.txt


### PR DESCRIPTION
  when  `install-govready-q.sh`  /  `pip3 install -r requirements.txt`

  > In --require-hashes mode, all requirements must have their versions pinned with ==. These do not:
  >     setuptools from

---

Fix `requirements_txt_checker.sh`  to prevent false "not in sync" failure

  when  `requirements.txt` contains  either of the following:
  - multiline annotations  via  `pip-compile --generate-hashes` or `--annotate`
  - comments               via  `pip-compile --allow-unsafe`

  > 'requirements.txt' is not in sync with 'requirements.in'. Some packages may have updates available. Run requirements_txt_updater.sh.