### PR TITLE
Upgrade Django to 3.1.7 (3.1 latest)  to remediate web cache poisoning vulnerability

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -24,7 +24,7 @@ jsonschema # MIT License
 filetype # MIT License
 # Common Django Packages
 # Django==2.2.12 # BSD License
-Django==3.1.6 # BSD License
+Django==3.1.7 # BSD License
 django-debug-toolbar # BSD License
 django-allauth # MIT License
 django-bootstrap3 # Apache License 2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -199,9 +199,9 @@ django-simple-history==2.12.0 \
     --hash=sha256:3b7bf6bfbcf973afca123c5786c72b917ed4d92d7bf3b6cb70fe2e3850e763a3 \
     --hash=sha256:e7e830cb7a768dc90d6ba0507f8023f889bcb62fe31a08f18fac102c55eec539
     # via -r requirements.in
-django==3.1.6 \
-    --hash=sha256:169e2e7b4839a7910b393eec127fd7cbae62e80fa55f89c6510426abf673fe5f \
-    --hash=sha256:c6c0462b8b361f8691171af1fb87eceb4442da28477e12200c40420176206ba7
+django==3.1.7 \
+    --hash=sha256:32ce792ee9b6a0cbbec340123e229ac9f765dff8c2a4ae9247a14b2ba3a365a7 \
+    --hash=sha256:baf099db36ad31f970775d0be5587cc58a6256a6771a44eb795b554d45f211b8
     # via
     #   -r requirements.in
     #   django-allauth


### PR DESCRIPTION
  See:

  - https://github.com/GovReady/govready-q/pull/1422#issuecomment-782277399
    - https://app.snyk.io/vuln/SNYK-PYTHON-DJANGO-1076802
      - https://www.djangoproject.com/weblog/2021/feb/19/security-releases/

  - https://docs.djangoproject.com/en/3.1/releases/3.1.7/