### PR TITLE
Make Python 3.6-3.7 compatible  via package dependencies

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -20,7 +20,6 @@ GitPython # BSD License
 Pygments==2.7.3 # BSD License
 termcolor # MIT License
 xxhash # BSD License
-importlib-metadata>=1.7.0,>=0.12 # Apache License
 importlib-resources<2,>=1.0 # Apache License
 pyinstrument==3.2.0 # BSD License
 jsonschema # MIT License
@@ -30,7 +29,9 @@ filetype # MIT License
 Django==3.1.7 # BSD License
 django-debug-toolbar # BSD License
 django-allauth # MIT License
-django-bootstrap3 # Apache License 2.0
+django-bootstrap3 # BSD 3-Clause License
+importlib-metadata>=1.7.0,<2,>=0.12 # Apache License 2.0
+# importlib-metadata>=1.7,<2 for bandit 1.7 / stevedore 3.3, django-bootstrap3 14.2  +  ==any for importlib-resources 1.5, jsonschema 3.2  all Python<3.8
 django-notifications-hq==1.6 # MIT License
 jsonfield # MIT License
 dj_database_url # BSD License
@@ -49,7 +50,9 @@ commonmarkextensions # BSD 3
 # commonmarkextensions>=0.0.6 (e.g., 0.0.6 tested)  for Python 3.9 compatibility:
 #   commonmark <=0.9.1 compatibility:
 #     https://github.com/GovReady/CommonMark-py-Extensions/commit/72992208a2ddcb686e5a5a678dfeb04ee0440585
-structlog # Apache License
+structlog # MIT or Apache License 2.0
+typing-extensions>=3.7.4.3 # Python Software Foundation License
+# typing-extensions for structlog 20.2 Python<3.8
 
 # Only needed in common production deployment configurations
 # uwsgi # GPL2 # Needed only if using uwsgi instead of gunicorn

--- a/requirements.txt
+++ b/requirements.txt
@@ -353,10 +353,15 @@ imagesize==1.2.0 \
     --hash=sha256:6965f19a6a2039c7d48bca7dba2473069ff854c36ae6f19d2cde309d998228a1 \
     --hash=sha256:b1f6b5a4eab1f73479a50fb79fcf729514a900c341d8503d62a62dbc4127a2b1
     # via sphinx
-importlib-metadata==3.4.0 \
-    --hash=sha256:ace61d5fc652dc280e7b6b4ff732a9c2d40db2c0f92bc6cb74e07b73d53a1771 \
-    --hash=sha256:fa5daa4477a7414ae34e95942e4dd07f62adf589143c875c133c1e53c4eff38d
-    # via -r requirements.in
+importlib-metadata==1.7.0 \
+    --hash=sha256:90bb658cdbbf6d1735b6341ce708fc7024a3e14e99ffdc5783edea9f9b077f83 \
+    --hash=sha256:dc15b2969b4ce36305c51eebe62d418ac7791e9a157911d58bfb1f9ccd8e2070
+    # via
+    #   -r requirements.in
+    #   django-bootstrap3
+    #   importlib-resources
+    #   jsonschema
+    #   stevedore
 importlib-resources==1.5.0 \
     --hash=sha256:6f87df66833e1942667108628ec48900e02a4ab4ad850e25fbf07cb17cf734ca \
     --hash=sha256:85dc0b9b325ff78c8bef2e4ff42616094e16b98ebd5e3b50fe7e2f0bbcdcde49
@@ -813,6 +818,13 @@ toml==0.10.2 \
     --hash=sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b \
     --hash=sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f
     # via dparse
+typing-extensions==3.7.4.3 \
+    --hash=sha256:7cb407020f00f7bfc3cb3e7881628838e69d8f3fcab2f64742a5e76b2f841918 \
+    --hash=sha256:99d4073b617d30288f569d3f13d2bd7548c3a7e4c8de87db09a9d29bb3a4a60c \
+    --hash=sha256:dafc7639cde7f1b6e1acc0f457842a83e722ccca8eef5270af2d74792619a89f
+    # via
+    #   -r requirements.in
+    #   structlog
 tzlocal==2.1 \
     --hash=sha256:643c97c5294aedc737780a49d9df30889321cbe1204eac2c2ec6134035a92e44 \
     --hash=sha256:e2cb6c6b5b604af38597403e9852872d7f534962ae2954c7f35efcb1ccacf4a4
@@ -893,7 +905,9 @@ xxhash==2.0.0 \
 zipp==3.4.0 \
     --hash=sha256:102c24ef8f171fd729d46599845e95c7ab894a4cf45f5de11a44cc7444fb1108 \
     --hash=sha256:ed5eee1974372595f9e416cc7bbeeb12335201d8081ca8a0743c954d4446e5cb
-    # via importlib-metadata
+    # via
+    #   importlib-metadata
+    #   importlib-resources
 zope.event==4.5.0 \
     --hash=sha256:2666401939cdaa5f4e0c08cf7f20c9b21423b95e88f4675b1443973bdb080c42 \
     --hash=sha256:5e76517f5b9b119acf37ca8819781db6c16ea433f7e2062c4afc2b6fbedb1330


### PR DESCRIPTION
  - Fix    #1206 #1424  re: Python 3.6-3.7 compatibility
  - Stay   Python 3.8-3.9 compatible
  - Update related dependency license tracking comments