### PR TITLE
Properly convert \n to <br> in 3 column layout

### DIFF
--- a/controls/views.py
+++ b/controls/views.py
@@ -305,7 +305,6 @@ def component_library(request):
     except EmptyPage:
         page_obj = ele_paginator.page(ele_paginator.num_pages)
 
-
     context = {
         "page_obj": page_obj,
         "import_form": ImportOSCALComponentForm(),
@@ -836,8 +835,20 @@ def component_library_component(request, element_id):
     # using the natsort package from pypi: https://pypi.org/project/natsort/
     impl_smts = natsorted(impl_smts, key=lambda x: x.sid)
 
+    # Pagination
+    obj_paginator = Paginator(impl_smts, 10)
+    page_number = request.GET.get('page')
+
+    try:
+        page_obj = obj_paginator.page(page_number)
+    except PageNotAnInteger:
+        page_obj = obj_paginator.page(1)
+    except EmptyPage:
+        page_obj = obj_paginator.page(obj_paginator.num_pages)
+
     # Return the system's element information
     context = {
+        "page_obj": page_obj,
         "element": element,
         "impl_smts": impl_smts,
         "catalog_controls": catalog_controls,

--- a/templates/components/element_detail_tabs.html
+++ b/templates/components/element_detail_tabs.html
@@ -144,7 +144,12 @@
       {% if enable_experimental_opencontrol %}
       <li id="opencontrol-tab" role="presentation"><a href="#opencontrol" aria-controls="opencontrol" role="tab" data-toggle="tab"><span class="glyphicon glyphicon-file"></span> OpenControl </a></li>
       {% endif %}
+      <div style="margin: 0px 12px 0px 0px;">
+        <a id="copy_component" class="btn btn btn-default pull-right" href={% url 'component_library_component_copy' element_id=element.id %} role="button" style="color: black;">Clone component</a>
+      </div>
     </ul>
+
+
 
     <!-- Tab panels -->
     <div id="component-detail-content" class="tab-content">
@@ -161,8 +166,6 @@
             {% endif %}
           </div>
           <div class="col-xs-4 col-sm-4 col-md-4 col-lg-4 col-xl-4">
-            <div style="margin: 0px 12px 0px 0px;">
-              <h3><a id="copy_component" class="btn btn-sm btn-success pull-right" href={% url 'component_library_component_copy' element_id=element.id %} role="button" style="color: white;">Copy component</a></h3></div>
 
             <!-- Search/Filter form -->
             <div id="search-form-container" class="pull-right" style="margin: 12px 12px 0px 0px;">
@@ -175,18 +178,31 @@
                               <input name="search" value="{{ request.GET.search }}" type="text" placeholder="Search by control">
                           </div>
                       </div>
+                      <div>
+                        {% include 'components/paginate_comp.html' %}
+                      </div>
                   </div>
               </form>
             </div>
-
           </div>
         </div>
 
-        <div id="control-description" class="control-text"><h3>Control Implementation Statements</h3></div>
+        <div class="row">
+          <div class="col-xs-9 col-sm-9 col-md-9 col-lg-9 col-xl-9 description-text">
+            <div id="" class="">
+              <h3>Control Implementation Statements</h3>
+            </div>
+          </div>
+          <div class="col-xs-3 col-sm-3 col-md-3 col-lg-3 col-xl-3">
+            <div style="margin: 0px 12px 0px 0px;">
+              &nbsp;
+            </div>
+          </div>
+        </div>
 
           <div id="smt-list" class="" style="width: 100%">
             <!-- Loop through existing component-control statements -->
-            {% for smt in impl_smts %}
+            {% for smt in page_obj %}
             <div id="panel-{{ forloop.counter }}" class="">
               <div class="panel-heading" role="tab" id="document-{{ forloop.counter }}-title">
 
@@ -290,7 +306,7 @@
 
         <!-- Tab panel: combined -->
       <div role="tabpanel" class="tab-pane" id="oscal">
-        <p id="oscal_download" class="navbar-text navbar-right">
+        <p id="oscal_download" class="pull-right" style="margin: 12px 12px 0px 0px;">
           <a id="oscal_download_json_link"
              class="navbar-link"
              href={% url 'system_element_download_oscal_json' system_id=system.id element_id=element.id %}>
@@ -298,7 +314,7 @@
             Download ...
           </a>
         </p>
-        <div id="combined_smt" class="control-text"><h3>OSCAL (under development)</h3></div>
+        <div id="combined_smt" class="control-text"><h3>OSCAL</h3></div>
         <div style="font-family: monospace; font-size:12px; white-space: pre;">{{ oscal }}</div>
       </div>
 

--- a/templates/components/element_detail_tabs.html
+++ b/templates/components/element_detail_tabs.html
@@ -90,6 +90,13 @@
     white-space: pre-line;
   }
 
+  .statement-edit-text-block {
+    border-left: 1px solid #ccc;
+    background-color: rgb(253, 253, 253);
+    padding-bottom: 8px;
+    margin-top: -20px;
+  }
+
   .control-id-text { font-weight: bold; }
 
   #component-detail-content {
@@ -233,7 +240,7 @@
                       <div class="col-xs-3 col-sm-3 col-md-3 col-lg-3 col-xl-3">
                         &nbsp;
                       </div>
-                      <div class="col-xs-6 col-sm-6 col-md-6 col-lg-6 col-xl-6 statement-text-block"><div> 
+                      <div class="col-xs-6 col-sm-6 col-md-6 col-lg-6 col-xl-6 statement-edit-text-block"><div>
 
                         <form id="smt_{{ forloop.counter }}" class="smt_form">
                           <!-- Never change name of the producer element already associated with a statement -->
@@ -379,7 +386,7 @@
                       <div class="col-xs-3 col-sm-3 col-md-3 col-lg-3 col-xl-3">
                         &nbsp;
                       </div>
-                      <div class="col-xs-6 col-sm-6 col-md-6 col-lg-6 col-xl-6 statement-text-block">
+                      <div class="col-xs-6 col-sm-6 col-md-6 col-lg-6 col-xl-6 statement-edit-text-block">
 
                     <form id="smt_panel_num" class="smt_form">
                       <div class="form-group">

--- a/templates/components/element_detail_tabs.html
+++ b/templates/components/element_detail_tabs.html
@@ -85,7 +85,10 @@
 
   .statement-text, .description-text { font-size: 0.8em; }
 
-  .statement-text-block { border-left: 1px solid #ccc; }
+  .statement-text-block, .remark-text-block {
+    border-left: 1px solid #ccc;
+    white-space: pre-line;
+  }
 
   .control-id-text { font-weight: bold; }
 
@@ -194,7 +197,7 @@
                   <div class="col-xs-6 col-sm-6 col-md-6 col-lg-6 col-xl-6 statement-text-block">
                     {{ smt.body }}
                   </div>
-                  <div class="col-xs-3 col-sm-3 col-md-3 col-lg-3 col-xl-3">
+                  <div class="col-xs-3 col-sm-3 col-md-3 col-lg-3 col-xl-3 remark-text-block">
                     <a role="button" class="" data-toggle="collapse" data-parent="#accordion" href="#document-{{ forloop.counter }}-body" aria-expanded="false" aria-controls="document-{{ forloop.counter }}-body">edit</a>
                     <br />
                     {{ smt.remarks }}

--- a/templates/controls/editor.html
+++ b/templates/controls/editor.html
@@ -85,7 +85,10 @@
 
         .statement-text, .description-text { font-size: 0.8em; }
 
-        .statement-text-block { border-left: 1px solid #ccc; }
+        .statement-text-block, .remark-text-block {
+            border-left: 1px solid #ccc;
+            white-space: pre-line;
+        }
 
         .control-id-text { font-weight: bold; }
 
@@ -182,7 +185,7 @@
                                         {% endif %}
                                         {{ smt.body }}
                                       </div>
-                                      <div id="smt-edit-{{ forloop.counter }}" class="col-xs-3 col-sm-3 col-md-3 col-lg-3 col-xl-3">
+                                      <div id="smt-edit-{{ forloop.counter }}" class="col-xs-3 col-sm-3 col-md-3 col-lg-3 col-xl-3 remark-text-block">
                                         <a role="button" class="" data-toggle="collapse" data-parent="#accordion" href="#document-{{ forloop.counter }}-body" aria-expanded="false" aria-controls="document-{{ forloop.counter }}-body">edit</a>
                                         &nbsp;&nbsp; &nbsp;
                                         Status: {% if smt.status != "" and smt.status is not None %}{{ smt.status }}{% else %}TBD{% endif %}

--- a/templates/systems/element_detail_tabs.html
+++ b/templates/systems/element_detail_tabs.html
@@ -86,7 +86,10 @@
 
   .statement-text, .description-text { font-size: 0.8em; }
 
-  .statement-text-block { border-left: 1px solid #ccc; }
+  .statement-text-block, .remark-text-block {
+    border-left: 1px solid #ccc;
+    white-space: pre-line;
+  }
 
   .control-id-text { font-weight: bold; }
 
@@ -161,7 +164,7 @@
                                   <div class="col-xs-6 col-sm-6 col-md-6 col-lg-6 col-xl-6 statement-text-block">
                                     {{ smt.body }}
                                   </div>
-                                  <div class="col-xs-3 col-sm-3 col-md-3 col-lg-3 col-xl-3">
+                                  <div class="col-xs-3 col-sm-3 col-md-3 col-lg-3 col-xl-3 remark-text-block">
                                     <a role="button" class="" data-toggle="collapse" data-parent="#accordion" href="#document-{{ forloop.counter }}-body" aria-expanded="false" aria-controls="document-{{ forloop.counter }}-body">edit</a>
                                     <br />
                                     {{ smt.remarks }}


### PR DESCRIPTION
Use proper stylesheets to convert \n to <br>
in the 3 column layouts for statement and remark text.