### PR TITLE
Improve styling of search box component library and component library detail page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ v999 (March XX, 2021)
 * Update 3-column statement layout's "edit" into a glyphicon pencil pulled all the way right, remove extra lines and other small changes.
 * Update 3-column statement layout to include column headings.
 * Conditionally display remarks in component library using HTML details tag.
+* Style searchbox on component library and component library detail page to use search glyphicon to indicate search and remove glyphicon within search box to clear search results.
 
 New, better install process written in Python.
 Include all required static files pre-collected in `static_root` directory as part of GovReady-Q distribution.

--- a/siteapp/static/css/govready-q.css
+++ b/siteapp/static/css/govready-q.css
@@ -216,6 +216,11 @@ a.glyphicon-home-icon { color: black; margin-right: .25em; text-decoration:none;
 .app-info-height { height: 24px; }
 .app-bottom-spacer { height:40px; }
 
+/* search */
+#searchbox { padding-left:28px; }
+#searchclear { position: absolute; right: 5px; top: 0; bottom: 0; height: 14px; margin: auto; font-size: 14px; cursor: pointer; color: #ccc; text-decoration: none; }
+#searchicon { position: absolute; left: 8px; top: 0; bottom: 0; height: 14px; margin: auto; font-size: 14px; cursor: default; color: #999; text-decoration: none; }
+
 /* project */
 /* leaving display tags within the html to prevent issues */
 

--- a/templates/components/component_library.html
+++ b/templates/components/component_library.html
@@ -33,13 +33,15 @@
 
             <h2 class="">Component Library</h2>
 
-            <form action="{% url 'component_library' %}" method="GET">
+            <form action="{% url 'component_library' %}" method="GET" role="search">
                 <div class="form-inline pull-right create-nav">
-                    <a id="search-reset" href="{% url 'component_library' %}" class="btn btn-danger">Reset</a>
                     <div class="form-group">
                         <div class="input-group">
-                            <div class="input-group-addon">search</div>
-                            <input name="search" value="{{ request.GET.search }}" type="text" placeholder="Search for components">
+                            <input id="searchbox" name="search" value="{{ request.GET.search }}" type="text" placeholder="search components" spellcheck="false" aria-label="Search" aria-describedby="search">
+                            <span id="searchicon" class="glyphicon glyphicon-search" href="{% url 'component_library' %}"></span>
+                            {% if request.GET.search %}
+                                <a id="searchclear" class="glyphicon glyphicon-remove" href="{% url 'component_library' %}"></a>
+                            {% endif %}
                          </div>
                     </div>
                 </div>

--- a/templates/components/element_detail_tabs.html
+++ b/templates/components/element_detail_tabs.html
@@ -166,11 +166,13 @@
             <div id="search-form-container" class="pull-right" style="margin: 12px 12px 0px 0px;">
               <form action="{% url 'component_library_component' element_id=element.id %}" method="GET">
                   <div class="form-inline pull-right create-nav">
-                      <a id="search-reset" href="{% url 'component_library_component' element_id=element.id %}" class="btn btn-danger btn-xs">Reset</a>
                       <div class="form-group">
                           <div class="input-group">
-                              <div class="input-group-addon">search</div>
-                              <input name="search" value="{{ request.GET.search }}" type="text" placeholder="Search by control">
+                              <input id="searchbox" name="search" value="{{ request.GET.search }}" type="text" placeholder="search control">
+                              <span id="searchicon" class="glyphicon glyphicon-search" href="{% url 'component_library' %}"></span>
+                              {% if request.GET.search %}
+                                <a id="searchclear" class="glyphicon glyphicon-remove" href="{% url 'component_library_component' element_id=element.id %}"></a>
+                              {% endif %}
                           </div>
                       </div>
                       <div>


### PR DESCRIPTION
Style search box on component library and component library detail page to use search glyphicon to indicate search and remove glyphicon within search box to clear search results.

<img width="1280" alt="Screen Shot 2021-03-13 at 7 24 49 AM" src="https://user-images.githubusercontent.com/24979/111031471-5145df00-83cd-11eb-85b7-0b82393ce18a.png">
