### PR TITLE
Separate user home[start] page from /project page

### DIFF
--- a/siteapp/urls.py
+++ b/siteapp/urls.py
@@ -12,7 +12,8 @@ from .good_settings_helpers import signup_wrapper
 from .settings import *
 
 urlpatterns = [
-    url(r"^(?![\s\S]|login)$", views.homepage, name="homepage"),
+    url(r"^(?![\s\S])$", views.home_user, name="home_user"),
+    url(r"^login$", views.homepage, name="homepage"),
     url(r"^(privacy|terms-of-service|love-assessments)$", views.shared_static_pages, name="privacy_terms_love"),
 
     url(r'^api/v1/projects/(?P<project_id>\d+)/answers$', views_landing.project_api),

--- a/siteapp/views.py
+++ b/siteapp/views.py
@@ -67,7 +67,6 @@ def homepage(request):
 
     if request.user.is_authenticated:
         return HttpResponseRedirect("/projects")
-    print("LOGIN2 PAGE HOMEPAGE")
     from allauth.account.forms import SignupForm, LoginForm
 
     portfolio_form = PortfolioSignupForm()

--- a/siteapp/views_landing.py
+++ b/siteapp/views_landing.py
@@ -29,91 +29,6 @@ logger = get_logger()
 LOGIN = "login"
 SIGNUP = "signup"
 
-def homepage(request):
-    # Main landing page.
-
-    from allauth.account.forms import SignupForm, LoginForm
-
-    portfolio_form = PortfolioSignupForm()
-    signup_form = SignupForm()
-    login_form = LoginForm()
-
-    # The allauth forms have 'autofocus' set on their widgets that draw the
-    # focus in a way that doesn't make sense here.
-    signup_form.fields['username'].widget.attrs.pop("autofocus", None)
-    login_form.fields['login'].widget.attrs.pop("autofocus", None)
-
-    if SIGNUP in request.path or request.POST.get("action") == SIGNUP:
-        signup_form = SignupForm(request.POST)
-        portfolio_form = PortfolioSignupForm(request.POST)
-        if (request.user.is_authenticated or signup_form.is_valid()) and portfolio_form.is_valid():
-            # Perform signup and new org creation, then redirect to main page
-            with transaction.atomic():
-                if not request.user.is_authenticated:
-                    # Create account.
-                    new_user = signup_form.save(request)
-                    # Add default permission, view AppSource
-                    new_user.user_permissions.add(Permission.objects.get(codename='view_appsource'))
-                    new_user.save()
-
-                    # Log them in.
-                    from django.contrib.auth import authenticate, login
-                    user = authenticate(request, username=signup_form.cleaned_data['username'], password=signup_form.cleaned_data['password1'])
-                    if user is not None:
-                        login(request, user, 'django.contrib.auth.backends.ModelBackend')
-                    else:
-                        print("[ERROR] new_user '{}' did not authenticate after during account creation.".format(new_user.username))
-                        messages.error(request, "[ERROR] new_user '{}' did not authenticate during account creation. Account not created. Report error to System Administrator. {}".format(new_user.username, vars(new_user)))
-                        return HttpResponseRedirect("/")
-                else:
-                    user = request.user
-                if portfolio_form.is_valid():
-                    portfolio = portfolio_form.save()
-                    portfolio.assign_owner_permissions(request.user)
-                    logger.info(
-                        event="new_portfolio",
-                        object={"object": "portfolio", "id": portfolio.id, "title":portfolio.title},
-                        user={"id": request.user.id, "username": request.user.username}
-                    )
-                    logger.info(
-                        event="new_portfolio assign_owner_permissions",
-                        object={"object": "portfolio", "id": portfolio.id, "title":portfolio.title},
-                        receiving_user={"id": request.user.id, "username": request.user.username},
-                        user={"id": request.user.id, "username": request.user.username}
-                    )
-                # Send a message to site administrators.
-                from django.core.mail import mail_admins
-                def subvars(s):
-                    return s.format(
-                        portfolio=portfolio.title,
-                        username=user.username,
-                        email=user.email,
-                    )
-                mail_admins(
-                    subvars("New portfolio: {portfolio} (created by {email})"),
-                    subvars("A new portfolio has been registered!\n\nPortfolio\n------------\nName: {portfolio}\nRegistering User\n----------------\nUsername: {username}\nEmail: {email}"))
-
-                return HttpResponseRedirect("/projects")
-
-    elif LOGIN in request.path or request.POST.get("action") == LOGIN:
-        login_form = LoginForm(request.POST, request=request)
-        if login_form.is_valid():
-            login_form.login(request)
-            return HttpResponseRedirect('/') # reload
-
-    elif request.POST.get("action") == "logout" and request.user.is_authenticated:
-        from django.contrib.auth import logout
-        logout(request)
-        return HttpResponseRedirect('/') # reload
-
-    return render(request, "index.html", {
-        "hide_registration": SystemSettings.hide_registration,
-        "signup_form": signup_form,
-        "portfolio_form": portfolio_form,
-        "login_form": login_form,
-        "member_of_orgs": Organization.get_all_readable_by(request.user) if request.user.is_authenticated else None,
-    })
-
 def org_group_projects(request, org_slug):
     """Get projects belonging to group"""
     org = get_object_or_404(Organization, slug=org_slug)
@@ -232,7 +147,7 @@ def project_api(request, project_id):
 
     from django.db.models import Q
     from .models import User, Project
-    
+
     try:
         user = User.objects.get(Q(api_key_rw=api_key)|Q(api_key_ro=api_key)|Q(api_key_wo=api_key))
     except User.DoesNotExist:
@@ -357,7 +272,7 @@ def project_api(request, project_id):
                         log.append(key + " updated")
                     else:
                         log.append(key + " unchanged")
-                
+
                 except ValueError as e:
                     log.append(key + ": " + str(e))
                     ok = False

--- a/templates/home-user.html
+++ b/templates/home-user.html
@@ -108,68 +108,65 @@ Your Compliance Projects
   <a id="new-project" onclick="show_select_portfolio_modal(); return false;" href="#" class=" btn btn-success">Start a project</a>
 </div>
 
-<h2 class="">Projects</h2>
+<h2>Welcome to GovReady-Q</h2>
 
-{% if projects_access|length < 1 %}
-<p>You do not currently have access to any projects.</p>
-{% else %}
-<p>You have access to {{ projects_access|length }} project{{ projects_access|pluralize }}</p>
+<p>Assess, test, and authorize together</p>
 
-<div class="container">
-<div class="row">
-  <div class="col-xs-10 col-md-5"><strong>Project</strong></div>
-  <div class="col-xs-6 col-sm-1"><strong>ID</strong></div>
-  <div class="col-xs-6 col-sm-2"><strong>Portfolio</strong></div>
-  <div class="col-xs-6 col-sm-2"><strong>Role</strong></div>
-  <div class="col-xs-12 col-md-2"><strong>Updated</strong></div>
-</div>
-{% endif %}
-
-{% for project in projects %}
-<div class="row projects-row">
-  <div class="col-xs-10 col-md-5">
-    {% if project.root_task.get_app_icon_url %}
-      <span class="project-image">
-        <img src="{{project.root_task.get_app_icon_url}}" class="img-responsive" alt="App Icon">
-      </span>
-      &nbsp;&nbsp;&nbsp;
-    {% else %}
-    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-    {% endif %}
-    <a href="{{project.get_absolute_url}}" class="projects-link">{{project.title}}</a>
-  </div>
-
-  <div class="col-xs-6 col-sm-1">{{project.id}}</div>
-  <div class="col-xs-6 col-sm-2">{{project.portfolio.title}}</div>
-
-  {% get_obj_perms request.user for project as "perms" %}
-  {% get_obj_perms request.user for project.portfolio as "portfolio_perms" %}
-  {% if "delete_project" in perms %}
-  <div class="col-xs-6 col-sm-2">Owner</div>
-  {% elif "change_project" in perms%}
-  <div class="col-xs-6 col-sm-2">Project Member</div>
-  {% elif "portfolio_perms"%}
-  <div class="col-xs-6 col-sm-2">Portfolio Member</div>
-  {% endif %}
-
-  <div class="col-xs-12 col-md-2 left-text">
-      <!-- App version: {{project.root_task.module.spec.catalog.version|force_escape}} -->
-      {{project.root_task.updated|naturaltime}}
-      <!-- Started: {{project.created|naturaltime}} -->
-  </div>
-</div>
-
-{% endfor %}
-
-
-{% include 'components/paginate_comp.html' with projects=page_obj %}
-
-
-{% if projects|length < 1 %}
 <!-- Display grid of options -->
-  <div class="row" style="height: 600px;">
-    &nbsp;
-  </div>
-{% endif %}
+  <div class="row">
+
+    <div class="col-sm-6">
+      <div class="luna-box">
+        <div class="col-md-3">
+          <div class="glyphicon glyphicon glyphicon-list-alt"></div>
+        </div>
+        <div class="col-md-9">
+
+          <h3><a id="new-project" href="/projects">You have access to {{ projects_access|length }} project{{ projects_access|pluralize }}</a></h3>
+          <p>Projects are your organization's questionnaires, assessments and guides needed for authorizations.
+          </p>
+        </div>
+      </div>
+    </div>
+
+    <div class="col-sm-6">
+      <div class="luna-box">
+        <div class="col-md-3">
+          <div class="glyphicon glyphicon glyphicon-folder-open"></div>
+        </div>
+        <div class="col-md-9">
+          <h3><a href="/portfolios">You have access to {{ portfolios|length }} portfolio{{ portfolios|pluralize }}</a></h3>
+          <p>Portfolios are a way to organize and manage related projects.</p>
+          <p><a href={% url 'new_portfolio' %}>Create a Portfolio</a></p>
+        </div>
+      </div>
+    </div>
+
+    <div class="col-sm-6">
+      <div class="luna-box">
+        <div class="col-md-3">
+          <div class="glyphicon glyphicon-heart-empty"></div>
+        </div>
+        <div class="col-md-9">
+          <h3><a href="love-assessments">Fall in love with assessments</a></h3>
+          <p>Assessing, learning, and improving is one of the most powerful things about being  human.
+          </p>
+        </div>
+      </div>
+    </div>
+
+    <div class="col-sm-6">
+      <div class="luna-box">
+        <div class="col-md-3">
+          <div class="glyphicon glyphicon-duplicate"></div>
+        </div>
+        <div class="col-md-9">
+          <h3><a href="https://govready-q.readthedocs.org">Learn more about GovReady-Q</a></h3>
+          <p>Checkout our documentation to learn how to take full advantage of GovReady-Q.
+          </p>
+        </div>
+      </div>
+    </div>
+</div>
 
 {% endblock %}

--- a/templates/portfolios/detail.html
+++ b/templates/portfolios/detail.html
@@ -1,4 +1,4 @@
-{% extends "project-base.html" %}
+{% extends "base.html" %}
 {% load humanize %}
 {% load guardian_tags %}
 {% load static %}


### PR DESCRIPTION
Improve the user start page experience.

- Change sign-in/sign up form to url /login.
- Direct authenticated user to / url and display a basic
  report about count of projects and portfolios using the
  quad boxes previously shown on an empty project page.
- Change /projects to just say user does not have access
  to any projects when projects are zero.

Also fix action buttons showing up on projects page because
projects.html was extending project-base.html when it should
have extended project.html.

This change creates a smoother first use experience where
the user is not dropped into a list of projects.