### PR TITLE
Properly populate previously blank "Start project" modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ Include all required static files pre-collected in `static_root` directory as pa
 * Replace shell script install script `install-govready-q.sh` with better Python install script `install.py`.
 * Now including all static files pre-collected as part of distribution.
 
+**Bug fixes**
+
+* Properly populate previously blank "Start project" modal that appeared on component library, component library detail, and some other pages.
+
 v0.9.2.2 (March 10, 2021)
 -------------------------
 
@@ -101,7 +105,7 @@ Project page displays mini-dashboard of compliance stats.
 
 **UI changes**
 
-* Improve page load times for listings with pagination and ordering for project listing and selected component listing. 
+* Improve page load times for listings with pagination and ordering for project listing and selected component listing.
 * Display projects in pages of 10 and selected components by 5.
 * Project page displays mini-dashboard of compliance stats.
     * Number of controls implemented out of count of controls.
@@ -485,7 +489,7 @@ v.0.9.1.47 (December 01, 2020)
 * Fix system_settings methods enable_experimental_oscal and enable_experimental_opencontrol to work properly.
 
 v0.9.1.46.4 (November 25, 2020)
------------------------------	
+-----------------------------
 
 **UI changes**
 

--- a/controls/views.py
+++ b/controls/views.py
@@ -34,6 +34,7 @@ from system_settings.models import SystemSettings
 from .forms import ImportOSCALComponentForm, SystemAssessmentResultForm
 from .forms import StatementPoamForm, PoamForm, ElementForm, DeploymentForm
 from .forms import ElementEditForm
+from siteapp.forms import PortfolioForm, ProjectForm
 from .models import *
 from .utilities import *
 from simple_history.utils import update_change_reason
@@ -308,7 +309,8 @@ def component_library(request):
     context = {
         "page_obj": page_obj,
         "import_form": ImportOSCALComponentForm(),
-        "total_comps": Element.objects.exclude(element_type='system').count()
+        "total_comps": Element.objects.exclude(element_type='system').count(),
+        "project_form": ProjectForm(request.user, initial={'portfolio': request.user.portfolio_list().first().id}),
     }
 
     return render(request, "components/component_library.html", context)
@@ -324,6 +326,7 @@ def import_records(request):
 
     context = {
         "import_components": import_components,
+        "project_form": ProjectForm(request.user, initial={'portfolio': request.user.portfolio_list().first().id}),
     }
 
     return render(request, "components/import_records.html", context)
@@ -337,6 +340,7 @@ def import_record_details(request, import_record_id):
     context = {
         "import_record": import_record,
         "component_statements": component_statements,
+        "project_form": ProjectForm(request.user, initial={'portfolio': request.user.portfolio_list().first().id}),
     }
     return render(request, "components/import_record_details.html", context)
 
@@ -811,6 +815,7 @@ def component_library_component(request, element_id):
             "impl_smts": impl_smts,
             "is_admin": request.user.is_superuser,
             "enable_experimental_opencontrol": SystemSettings.enable_experimental_opencontrol,
+            "project_form": ProjectForm(request.user, initial={'portfolio': request.user.portfolio_list().first().id}),
         }
         return render(request, "components/element_detail_tabs.html", context)
 
@@ -858,7 +863,7 @@ def component_library_component(request, element_id):
         "enable_experimental_opencontrol": SystemSettings.enable_experimental_opencontrol,
         "enable_experimental_oscal": SystemSettings.enable_experimental_oscal,
         "opencontrol": opencontrol_string,
-        # "project_form": ProjectForm(request.user),
+        "project_form": ProjectForm(request.user, initial={'portfolio': request.user.portfolio_list().first().id}),
     }
     return render(request, "components/element_detail_tabs.html", context)
 


### PR DESCRIPTION
Component library, component library detail, and some other pages
    were not properly populating the "Start project' modal. The modal
    appeared blank b/c we were not passing current user session
    portfolios into the list. This is corrected by adding
    `"project_form": ProjectForm(request.user, initial={'portfolio': request.user.portfolio_list().first().id}),`
    to the page context.
    
Why the "Start project" modal appears...

![Screen Shot 2021-03-15 at 4 18 00 AM](https://user-images.githubusercontent.com/24979/111131608-6a25d000-8546-11eb-9247-1aa728630028.png)

What was broken...

![Screen Shot 2021-03-15 at 4 17 54 AM](https://user-images.githubusercontent.com/24979/111131782-96415100-8546-11eb-8015-b96d900e4cbf.png)

What this looks like after `"project_form": ProjectForm(request.user, initial={'portfolio': request.user.portfolio_list().first().id}),` is passed into the page `context`...

![Screen Shot 2021-03-15 at 4 17 23 AM](https://user-images.githubusercontent.com/24979/111131681-7dd13680-8546-11eb-9278-591cf9f29e4a.png)
