### PR TITLE
Improve line break formatting in output docs

### DIFF
--- a/controls/models.py
+++ b/controls/models.py
@@ -545,7 +545,8 @@ class System(auto_prefetch.Model):
             # Poor performance, at least in some instances, appears to being caused by `smt.producer_element.name`
             # parameter in the below statement.
             if smt.producer_element:
-                smts_as_dict[smt.sid]['combined_smt'] += f"<i>{smt.producer_element.name}</i>\n{status_str}\n\n{smt.body}\n\n"
+                smt_formatted = smt.body.replace('\n','<br/>')
+                smts_as_dict[smt.sid]['combined_smt'] += f"<i>{smt.producer_element.name}</i><br/>{status_str}<br/><br/>{smt_formatted}<br/><br/>"
             # When "smt.producer_element.name" the provided as a fixed string (e.g, "smt.producer_element.name")
             # for testing purposes, the loop runs 3x faster
             # The reference `smt.producer_element.name` appears to be calling the database and creating poor performance

--- a/controls/oscal.py
+++ b/controls/oscal.py
@@ -325,6 +325,9 @@ class Catalog(object):
         in the catalog.
         """
         family_id = self.get_group_id_by_control_id(control['id'])
+        description = self.get_control_prose_as_markdown(control, part_types={"statement"},
+                                                        parameter_values=self.parameter_values)
+        description_print = description.replace("\n", "<br/>")
         cl_dict = {
             "id": control['id'],
             "id_display": re.sub(r'^([A-Za-z][A-Za-z]-)([0-9]*)\.([0-9]*)$', r'\1\2 (\3)', control['id']),
@@ -332,8 +335,8 @@ class Catalog(object):
             "family_id": family_id,
             "family_title": self.get_group_title_by_id(family_id),
             "class": control['class'],
-            "description": self.get_control_prose_as_markdown(control, part_types={"statement"},
-                                                              parameter_values=self.parameter_values),
+            "description": description,
+            "description_print": description_print,
             "guidance": self.get_control_prose_as_markdown(control, part_types={"guidance"}),
             "catalog_file": self.catalog_file,
             "catalog_id": self.catalog_id,


### PR DESCRIPTION
Improve line break formatting in output docs,
both HTML and DOCX, by creating versions of string parameters
with line breaks (<br/>) replacing line returns (\n).

The line breaks are respected by HTML and DOCX.

Next up to fix: indententation across HTML and DOCX.