### PR TITLE
project export fails because uuids are not json serializable

### DIFF
--- a/controls/views.py
+++ b/controls/views.py
@@ -2850,7 +2850,7 @@ def project_export(request, project_id):
                     "remarks": smt.remarks,
                     "version": smt.remarks,
                     "status": smt.status,
-                    "uuid": smt.uuid,
+                    "uuid": str(smt.uuid),
                 }
             }
             # Add json version as an element in the poams list

--- a/controls/views.py
+++ b/controls/views.py
@@ -2784,11 +2784,9 @@ def project_import(request, project_id):
                     body= poamsmt_data.get('body'),
                     remarks= poam.get('remarks'),
                     version= poam.get('version'),
-                    created= poam.get('created'),
-                    updated= poam.get('updated'),
                     statement_type="POAM",
                     status= poamsmt_data.get('status', "New"),
-                    uuid= poam.get('uuid'),
+                    uuid= str(uuid4()),
                     consumer_element= system_root_element
                 )
                 # Create Poam with statement and imported data


### PR DESCRIPTION
Error occurs when exporting a project with poams.  Poams have a uuid field in their statements and the uuid needs to be typecasted into a string since uuids are not json serializable.