### PR TITLE
Assign `guidedmodules.view_appsource` perm to new users created via SSO.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ GovReady-Q Release Notes
 v999 (March XX, 2021)
 ----------------------------
 
+**Bug fixes**
+
+* Make sure new users are granted `view app source` permission when user account created via SSO proxy.
 
 v0.9.3.1 (March 23, 2021)
 ----------------------------

--- a/siteapp/middleware.py
+++ b/siteapp/middleware.py
@@ -3,6 +3,7 @@ from django.conf import settings
 from django.shortcuts import render
 
 from django.urls import reverse
+from django.contrib.auth.models import Permission
 import django.contrib.auth.backends
 import django.contrib.auth.middleware
 
@@ -103,6 +104,12 @@ class ProxyHeaderUserAuthenticationBackend(django.contrib.auth.backends.RemoteUs
                 user_portfolio.save()
                 # Grant owner permissions on new portfolio to user
                 user_portfolio.assign_owner_permissions(user)
+
+            # Make sure user has permission to view app sources and thus see available compliance apps
+            # New users may not have permission to view app sources, so add permission if user does not have it
+            if not user.has_perm("guidedmodules.view_appsource"):
+                user.user_permissions.add(Permission.objects.get(codename='view_appsource'))
+                user.save()
 
         # Return.
         return user

--- a/siteapp/views.py
+++ b/siteapp/views.py
@@ -78,6 +78,8 @@ def homepage(request):
     signup_form.fields['username'].widget.attrs.pop("autofocus", None)
     login_form.fields['login'].widget.attrs.pop("autofocus", None)
 
+    # Sign / Register new user here and create account
+    # NOTE: When GovReady-Q is in SSO trusting mode, new users accounts are created in siteapp/middelware.py ProxyHeaderUserAuthenticationBackend
     if SIGNUP in request.path or request.POST.get("action") == SIGNUP:
         signup_form = SignupForm(request.POST)
         portfolio_form = PortfolioSignupForm(request.POST)


### PR DESCRIPTION
Make sure new users are granted `view app source` permission when user account created via SSO proxy.

Previously, new users would be created via SSO proxy but would not have permission to see project templates.