### PR TITLE
temp solution for the navbar being too wide before collapsing to a hamburger.

### DIFF
--- a/siteapp/static/css/govready-q.css
+++ b/siteapp/static/css/govready-q.css
@@ -33,6 +33,8 @@ body, blockquote {
   color: black;
 }
 
+
+
 .glyphicon-globe { color: #888; }
 
 
@@ -418,3 +420,44 @@ form #id_appsource_compapp { width: 100%; overflow: auto !important; }
 
 #component-detail-content { background:#ffffff; }
 .row-control { background:#ffffff;}
+
+
+
+/* this is a temporary solution for the navbar being too wide before collapsing to a hamburger. Now it will collapse at 1102px instead of 768px. */
+@media (max-width: 1102px) {
+    .navbar-header {
+        float: none;
+    }
+    .navbar-toggle {
+        display: block;
+    }
+    .navbar-collapse {
+        border-top: 1px solid transparent;
+        box-shadow: inset 0 1px 0 rgba(255,255,255,0.1);
+    }
+    .navbar-collapse.collapse {
+        display: none!important;
+    }
+    .navbar-nav {
+        float: none!important;
+        margin: 7.5px -15px;
+    }
+    .navbar-nav>li {
+        float: none;
+    }
+    .navbar-nav>li>a {
+        padding-top: 10px;
+        padding-bottom: 10px;
+    }
+    .navbar-text {
+        float: none;
+        margin: 15px 0;
+    }
+    /* since 3.1.0 */
+    .navbar-collapse.collapse.in {
+        display: block!important;
+    }
+    .collapsing {
+        overflow: hidden!important;
+    }
+}

--- a/siteapp/static/css/govready-q.css
+++ b/siteapp/static/css/govready-q.css
@@ -421,8 +421,6 @@ form #id_appsource_compapp { width: 100%; overflow: auto !important; }
 #component-detail-content { background:#ffffff; }
 .row-control { background:#ffffff;}
 
-
-
 /* this is a temporary solution for the navbar being too wide before collapsing to a hamburger. Now it will collapse at 1102px instead of 768px. */
 @media (max-width: 1102px) {
     .navbar-header {

--- a/templates/home-user.html
+++ b/templates/home-user.html
@@ -99,7 +99,7 @@ Your Compliance Projects
 {% block contextbar %}{% endblock %}
 
 {% block body %}
-
+<body class="splash-bg">
 <div class="projects-top">
 
 <div class="container">

--- a/templates/home-user.html
+++ b/templates/home-user.html
@@ -99,7 +99,6 @@ Your Compliance Projects
 {% block contextbar %}{% endblock %}
 
 {% block body %}
-<body class="splash-bg">
 <div class="projects-top">
 
 <div class="container">


### PR DESCRIPTION
Navbar will collapse at 1102px instead of 768px. This keeps the navbar divs from stacking causing occlusion of the context bar between 768px and 1102px screen widths. / removed bg code from home-user