### PR TITLE
Update local-examples for venv, 0.9.3

### DIFF
--- a/local-examples/local-ubuntu-postgres-nginx-gunicorn-supervisor-http/gunicorn.conf.py
+++ b/local-examples/local-ubuntu-postgres-nginx-gunicorn-supervisor-http/gunicorn.conf.py
@@ -1,7 +1,8 @@
 import multiprocessing
 command = 'gunicorn'
-pythonpath = '/home/govready-q/govready-q'
-timeout = 240
+pythonpath = '/home/govready-q/govready-q/venv/bin'
+# Extend time out to 10 min to import large project, OSCAL files
+timeout = 500
 # serve GovReady-Q locally on server to use nginx as a reverse proxy
 bind = 'localhost:8000'
 # Only set workers higher than 1 if `secret-key` is defined in local/environment.json

--- a/local-examples/local-ubuntu-postgres-nginx-gunicorn-supervisor-http/install-os-packages.sh
+++ b/local-examples/local-ubuntu-postgres-nginx-gunicorn-supervisor-http/install-os-packages.sh
@@ -17,12 +17,18 @@ apt-get update
 DEBIAN_FRONTEND=noninteractive \
 apt-get install -y \
 unzip git curl jq \
-python3 python3-pip \
+python3 python3-pip python3-venv \
 python3-yaml \
 graphviz pandoc \
+gunicorn \
 language-pack-en-base language-pack-en
 
-# Upgrade pip to version 20.1+
-echo "Upgrading Python pip..."
-python3 -m pip install --upgrade pip
+# Upgrade to pandoc to version 2.9 or higher
+wget https://github.com/jgm/pandoc/releases/download/2.13/pandoc-2.13-linux-amd64.tar.gz
+tar xvzf pandoc-2.13-linux-amd64.tar.gz
+mv pandoc-2.13/bin/* /usr/local/bin
+rm -Rf pandpandoc-2.13
+rm pandoc-2.13-linux-amd64.tar.gz
 
+# Optionally install supervisord for monitoring and restarting GovReady-q; and NGINX as a reverse proxy
+apt-get install -y supervisor nginx

--- a/local-examples/local-ubuntu-postgres-nginx-gunicorn-supervisor-http/supervisor-govready-q.conf
+++ b/local-examples/local-ubuntu-postgres-nginx-gunicorn-supervisor-http/supervisor-govready-q.conf
@@ -1,12 +1,13 @@
 [program:govready-q]
 user = govready-q
-command = gunicorn3 --config /home/govready-q/govready-q/local/gunicorn.conf.py siteapp.wsgi
+command = /home/govready-q/govready-q/venv/bin/gunicorn --config /home/govready-q/govready-q/local/gunicorn.conf.py siteapp.wsgi
 directory = /home/govready-q/govready-q
 stderr_logfile = /var/log/govready-q-stderr.log
 stdout_logfile = /var/log/govready-q-stdout.log
 
 [program:notificationemails]
-command = python3.6 manage.py send_notification_emails forever
+user = govready-q
+command = /home/govready-q/govready-q/venv/bin/python manage.py send_notification_emails forever
 directory = /home/govready-q/govready-q
 stderr_logfile = /var/log/notificationemails-stderr.log
 stdout_logfile = /var/log/notificationemails-stdout.log


### PR DESCRIPTION
Tweak local-examples Ubuntu files for installing with venv and using v0.9.3.x

This update is paired with https://github.com/GovReady/govready-q-docs/pull/38