### PR TITLE
Move project related modal inclusion to project-base.html

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -89,8 +89,6 @@
     {% include "bootstrap-helpers.html" %}
 
     {% include "portfolios/select-portfolio-modal.html" %}
-    {% include "edit-project-modal.html" %}
-    {% include "move-project-modal.html" %}
 
     <div id="invitation_modal" class="modal" tabindex="-1" role="dialog" aria-labelledby="invitation_modal_title" aria-hidden="true" data-url="{% url "send_invitation" %}">
       <div class="modal-dialog">

--- a/templates/project-base.html
+++ b/templates/project-base.html
@@ -270,6 +270,9 @@
   </div> <!-- /col -->
 </div> <!-- /row -->
 
+{% include "edit-project-modal.html" %}
+{% include "move-project-modal.html" %}
+
 {% block scripts %}
     <script>
         function show_import_project_modal(id, callback) {


### PR DESCRIPTION
Project related modals are only used with pages that extend
the project-base.html template. Keeping the modal templates
on project-base.html reduces updates that need to made to
project.html branded pages which are more likely to change
in branding exercises than project-base.html page.