### PR TITLE
Simplify task-finished page layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,22 @@ GovReady-Q Release Notes
 
 v999 (April XX, 2021)
 ---------------------
+
 **Feature changes**
+
 * Added support for Remote Interpreter on IDEs for the local Docker deployment.
 
+**UI changes**
+
+* Simplify task-finished page layout. Move navigation buttons to top.
+* Replace "...and we're done" language with "Module Summary".
+* Replace questions progress sidebar's project links with more obvious project buttons.
+
 **Bug fixes**
+
 * User now has the ability to edit uploaded files via the admin panel.
 * File names now updated properly for all Asset models in the event of an update.
- 
+
 
 v0.9.3.2 (April 1st, 2021)
 --------------------------

--- a/discussion/tests.py
+++ b/discussion/tests.py
@@ -188,7 +188,7 @@ class DiscussionTests(SeleniumTest):
         wait_for_sleep_after(lambda: self._start_task())# wait for page to reload
 
         # Move past the introduction screen.
-        self.assertRegex(self.browser.title, "Next Question: Introduction")
+        self.assertRegex(self.browser.title, "Next Question: Module Introduction")
         self.click_element("#save-button")
         var_sleep(.8) # wait for page to reload
 

--- a/guidedmodules/validate_module_specification.py
+++ b/guidedmodules/validate_module_specification.py
@@ -39,7 +39,7 @@ def validate_module(spec, app, is_authoring_tool=False):
     if "introduction" in spec and spec.get("type") != "project":
         q = {
             "id": "_introduction",
-            "title": "Introduction",
+            "title": "Module Introduction",
             "type": "interstitial",
             "prompt": spec["introduction"]["template"],
         }
@@ -151,7 +151,7 @@ def validate_question(mspec, spec):
     # Jinaj2 identifiers. http://jinja.pocoo.org/docs/2.9/api/#notes-on-identifiers
     if not re.match("^[a-zA-Z_][a-zA-Z0-9_]*$", spec["id"]):
         invalid("The question ID may only contain ASCII letters, numbers, and underscores, and the first character must be a letter or underscore.")
-        
+
     # Perform type conversions, validation, and fill in some defaults in the YAML
     # schema so that the values are ready to use in the database.
     if spec.get("type") == "multiple-choice":
@@ -209,7 +209,7 @@ def validate_question(mspec, spec):
 
     if not isinstance(spec.get("title"), str):
         invalid("Question title is missing or has an invalid data type (must be a string).")
-    
+
     if spec.get("prompt") is None:
         # Prompts are optional in project and system modules but required elsewhere.
         if mspec.get("type") not in ("project", "system-project"):
@@ -266,7 +266,7 @@ def validate_question(mspec, spec):
                 env.from_string(rule["value"])
             except Exception as e:
                 invalid_rule("Impute condition value %s is an invalid Jinja2 template: %s." % (repr(rule["value"]), str(e)))
-    
+
     return spec
 
 

--- a/siteapp/static/css/govready-q.css
+++ b/siteapp/static/css/govready-q.css
@@ -131,7 +131,7 @@ div.question-answer[data-reviewed] a { text-decoration: underline; }
 .btn-sm { width:95%; max-width:200px;  } /* this makes the action buttons all the same width.
 
 /* misc templates */
-.task-progress-project-truncate { margin: 12px 0 12px 6px; text-align: left;  }
+.task-progress-project-truncate { margin: 12px auto 12px auto; text-align: center; }
 .task-progress-project-url { color:#444; }
 .task-progress-project-group { margin: 0 0 6px 0; padding: 2px; font-size: 1.0em;text-align:left; }
 .task-progress-project-question { font-size: 10px; line-height: 120%; padding-left: 2em; color: #222; }

--- a/siteapp/tests.py
+++ b/siteapp/tests.py
@@ -1400,7 +1400,7 @@ class ProjectTests(TestCaseWithFixtureData):
         """
 
         self.assertEqual(self.project.title, 'I want to answer some questions on Q.')
-        self.assertEqual(self.project.version, None)
+        self.assertEqual(self.project.version, "1.0")
         self.assertEqual(self.project.version_comment, None)
 
         proj_id = self.project.id

--- a/siteapp/tests.py
+++ b/siteapp/tests.py
@@ -508,7 +508,7 @@ class GeneralTests(OrganizationSiteFunctionalTests):
         # Answer the questions.
 
         # Introduction screen.
-        wait_for_sleep_after(lambda: self.assertRegex(self.browser.title, "Next Question: Introduction"))
+        wait_for_sleep_after(lambda: self.assertRegex(self.browser.title, "Next Question: Module Introduction"))
         var_sleep(.5)
         wait_for_sleep_after(lambda: self.click_element("#save-button"))
 
@@ -596,7 +596,7 @@ class GeneralTests(OrganizationSiteFunctionalTests):
 
         self.assertRegex(self.browser.title, "I want to answer some questions on Q") # user is on the project page
         wait_for_sleep_after(lambda: self.click_element('#question-simple_module') )# go to the task page
-        wait_for_sleep_after(lambda: self.assertRegex(self.browser.title, "Next Question: Introduction") )# user is on the task page
+        wait_for_sleep_after(lambda: self.assertRegex(self.browser.title, "Next Question: Module Introduction") )# user is on the task page
 
         # reset_login()
 
@@ -644,7 +644,7 @@ class GeneralTests(OrganizationSiteFunctionalTests):
         # self._start_task()
 
         # # Move past the introduction screen.
-        # self.assertRegex(self.browser.title, "Next Question: Introduction")
+        # self.assertRegex(self.browser.title, "Next Question: Module Introduction")
         # self.click_element("#save-button")
         # var_sleep(.8) # wait for page to reload
 
@@ -913,7 +913,7 @@ class QuestionsTests(OrganizationSiteFunctionalTests):
         wait_for_sleep_after(lambda: self.click_element('#question-question_types_text'))
 
         # Introduction screen.
-        self.assertRegex(self.browser.title, "Next Question: Introduction")
+        self.assertRegex(self.browser.title, "Next Question: Module Introduction")
         self.click_element("#save-button")
         var_sleep(.5)
 
@@ -1022,7 +1022,7 @@ class QuestionsTests(OrganizationSiteFunctionalTests):
         self.click_element('#question-question_types_choice')
 
         # Introduction screen.
-        self.assertRegex(self.browser.title, "Next Question: Introduction")
+        self.assertRegex(self.browser.title, "Next Question: Module Introduction")
         wait_for_sleep_after(lambda: self.click_element("#save-button"))
         var_sleep(.5)
 
@@ -1076,7 +1076,7 @@ class QuestionsTests(OrganizationSiteFunctionalTests):
 
         # Introduction screen.
         var_sleep(0.75)
-        self.assertRegex(self.browser.title, "Next Question: Introduction")
+        self.assertRegex(self.browser.title, "Next Question: Module Introduction")
         self.click_element("#save-button")
         var_sleep(.5)
 
@@ -1227,7 +1227,7 @@ class QuestionsTests(OrganizationSiteFunctionalTests):
         self.click_element('#question-question_types_media')
 
         # Introduction screen.
-        self.assertRegex(self.browser.title, "Next Question: Introduction")
+        self.assertRegex(self.browser.title, "Next Question: Module Introduction")
         self.click_element("#save-button")
         var_sleep(.5)
 
@@ -1266,7 +1266,7 @@ class QuestionsTests(OrganizationSiteFunctionalTests):
         var_sleep(1.5)
 
         # Introduction screen.
-        self.assertRegex(self.browser.title, "Next Question: Introduction")
+        self.assertRegex(self.browser.title, "Next Question: Module Introduction")
         self.click_element("#save-button")
         var_sleep(.75)
 

--- a/templates/task-finished.html
+++ b/templates/task-finished.html
@@ -53,7 +53,7 @@
 
 <div class="row">
   <div id="focus-area-wrapper" class="col-xs-12 col-sm-12 col-md-9 col-lg-8">
-    <h1 class="task-done">...and we&rsquo;re done</h1>
+    <h1 class="task-done">Module Summary</h1>
     {% if top_of_page_output %}
       <div class="task-bottom-margin">
         {{top_of_page_output.html|safe}}
@@ -63,10 +63,86 @@
         {% if previous_page_type == "project" %}
           <p>This module was last updated on {{task.updated|date}}.</p>
         {% elif previous_page_type == "nquestion" %}
-          <p>You have completed the module.</p>
+          <p>You've reached the end of the {{ task.title}} module.</p>
         {% endif %}
       </div>
     {% endif %}
+
+
+      {% with answers_question=task.is_answer_to_unique %}
+        {% if answers_question and answers_question.task.editor == request.user %}
+          {% if task.project.is_account_project %}
+            {# there is nothing else in the account settings project #}
+            <p><a id="return-to-projects" href="/projects" class="btn btn-success">
+              Return to Projects &raquo;
+            </a></p>
+          {% else %}
+            {% if answers_question.task == answers_question.task.project.root_task %}
+              {# return to project #}
+              <p>
+                {# Show this form when we successfully determine next question #}
+                {% if next_module_spec %}
+                  {# Start a task directly using the module type in the specification. #}
+                  {% if not next_module_spec.protocol %}
+                  <form class="start-task" method="post" action="/tasks/start"
+                        onclick="$(this).submit();" style="cursor: pointer">
+                        {% csrf_token %}
+                        <input type="hidden" name="project" value="{{task.project.id}}"/>
+                        <input type="hidden" name="question" value="{{next_module_spec.id}}"/>
+                        <input type="hidden" name="previous" value="project"/>
+                    {% else %}
+                      {# Go to the Apps Catalog to select an app that implements the protocol specified on the question. #}
+                      <form method="get" action="{% url 'store' %}"
+                        onclick="$(this).submit();" style="cursor: pointer">
+                        <input type="hidden" name="q" value="{{task.project.root_task.id}}/{{next_module_spec.id}}">
+                    {% endif %}
+                    <div class="btn btn-success">Continue to {{next_module_spec.title}} &raquo;</div>
+
+                    {# Other options #}
+                    {# Include default link to the project page #}
+                    <a id="return-to-project" href="{{task.project.get_absolute_url}}#tab={{answers_question.question.spec.tab|slugify}}/{{answers_question.question.spec.group|slugify}}/{{answers_question.question.key|slugify}}/{{task.id}}" class="btn btn-default">
+                      Return to project
+                    </a>
+                    {# Reviewer's approval page #}
+                    {% if can_review %}
+                      <a id="btn-review-answers" href="{{task.project.get_absolute_url}}/list#task-{{task.id}}" class="btn btn-default">Review and approve answers</a>
+                    {% endif %}
+
+
+                  </form>
+                  <br>
+                {% endif %}
+
+              </p>
+            {% else %}
+              {# return to non-project parent task #}
+              <p><a id="return-to-supertask" href="{{answers_question.task.get_absolute_url}}" class="btn btn-success">
+                Continue Answering {{answers_question.task.title}} &raquo;
+              </a></p>
+            {% endif %}
+            {# TODO: Does module-set work correctly? #}
+            {% if answers_question.question.spec.type == "module-set" %}
+              <form method="post" action="/tasks/start" style="display:inline;">
+                {% csrf_token %}
+                <input type="hidden" name="project" value="{{task.project.id}}"/>
+                <input type="hidden" name="question" value="{{answers_question.question.key}}"/>
+                <input type="hidden" name="previous" value="task"/>
+                <a href="#" onclick="$(this).parent('form').submit(); return false;" class="btn btn-success" title="Add Another {{answers_question.question.answer_type_module.title}} to {{answers_question.question.spec.title}}.">
+                  Start New {{answers_question.question.answer_type_module.title}} &raquo;
+                </a>
+              </form>
+            {% endif %}
+          {% endif %}
+        {% else %}
+          {# every task, except projects, are now subtasks of other tasks, so this only occurs if a task is a subtask to multiple super-tasks #}
+          <p><a href="{{task.project.get_absolute_url}}" class="btn btn-success">
+           {# we used to say 'with other modules in {{task.project.title}}' but there may not be any other modules #}
+            Continue &raquo;
+          </a></p>
+        {% endif %}
+      {% endwith %}
+
+
 
     <div id="accordion" class="panel-group" role="tablist" aria-multiselectable="true">
       {# output documents #}
@@ -105,8 +181,7 @@
                           {% elif document.format == "xml" %}
                             <a href="{{task.get_absolute_url}}/download/document/{{document.id | urlencode }}/xml">OSCAL (xml)</a>&nbsp;&nbsp;
                           {% else %}
-                            <a href="{{task.get_absolute_url}}/download/document/{{document.id | urlencode }}/docx">Word (docx)</a><button id="projectAssetWordConfigButton" type="button" class="btn-xs btn-primary glyphicon glyphicon-cog" data-toggle="modal" data-target="#projectAssetWordConfig"
-                                                                                                                                           aria-label="Word (docx) Settings" tooltip="Word (docx) Settings" style="text-align: center; margin-right:10px; margin-left:5px;"></button>
+                            <a href="{{task.get_absolute_url}}/download/document/{{document.id | urlencode }}/docx">Word (docx)</a><button id="projectAssetWordConfigButton" type="button" class="btn-xs btn-primary glyphicon glyphicon-cog" data-toggle="modal" data-target="#projectAssetWordConfig" aria-label="Word (docx) Settings" tooltip="Word (docx) Settings" style="text-align: center; margin-right:10px; margin-left:5px;"></button>
                             {% if gr_pdf_generator == 'wkhtmltopdf' %}<a href="{{task.get_absolute_url}}/download/document/{{document.id | urlencode }}/pdf">PDF</a>&nbsp;&nbsp;{% endif %}
                             <!-- <a href="{{task.get_absolute_url}}/download/document/{{document.id | urlencode }}/odt">Open Office (odt)</a>&nbsp;&nbsp; -->
                             <a href="{{task.get_absolute_url}}/download/document/{{document.id | urlencode }}/html">HTML</a>&nbsp;&nbsp;
@@ -128,7 +203,7 @@
           <div class="panel-heading" rol="tab" id="your-answers-title">
             <h4 class="panel-title">
               <a role="button" data-toggle="collapse" data-parent="#accordion" href="#your-answers-body" aria-expanded="true" aria-controls="your-answers-body">
-                Your Answers
+                {{ task.title }} Module Summary
               </a>
             </h4>
           </div>
@@ -179,76 +254,6 @@
 
     </div> <!-- /accordion -->
     <div id="continue-nav" class="task-answers">
-      {% with answers_question=task.is_answer_to_unique %}
-        {% if answers_question and answers_question.task.editor == request.user %}
-          {% if task.project.is_account_project %}
-            {# there is nothing else in the account settings project #}
-            <p><a id="return-to-projects" href="/projects" class="btn btn-success">
-              Return to Projects &raquo;
-            </a></p>
-          {% else %}
-            {% if answers_question.task == answers_question.task.project.root_task %}
-              {# return to project #}
-              <p>
-                {# Show this form when we successfully determine next question #}
-                {% if next_module_spec %}
-                  {# Start a task directly using the module type in the specification. #}
-                  {% if not next_module_spec.protocol %}
-                  <form class="start-task" method="post" action="/tasks/start"
-                        onclick="$(this).submit();" style="cursor: pointer">
-                        {% csrf_token %}
-                        <input type="hidden" name="project" value="{{task.project.id}}"/>
-                        <input type="hidden" name="question" value="{{next_module_spec.id}}"/>
-                        <input type="hidden" name="previous" value="project"/>
-                    {% else %}
-                      {# Go to the Apps Catalog to select an app that implements the protocol specified on the question. #}
-                      <form method="get" action="{% url 'store' %}"
-                        onclick="$(this).submit();" style="cursor: pointer">
-                        <input type="hidden" name="q" value="{{task.project.root_task.id}}/{{next_module_spec.id}}">
-                    {% endif %}
-                    <div class="btn btn-success">Continue to {{next_module_spec.title}} &raquo;</div>
-                  </form>
-                  <br>
-                {% endif %}
-                {# Include default link to the project page #}
-                <a id="return-to-project" href="{{task.project.get_absolute_url}}#tab={{answers_question.question.spec.tab|slugify}}/{{answers_question.question.spec.group|slugify}}/{{answers_question.question.key|slugify}}/{{task.id}}" class="btn btn-default">
-                  Return to project
-                </a>
-              </p>
-            {% else %}
-              {# return to non-project parent task #}
-              <p><a id="return-to-supertask" href="{{answers_question.task.get_absolute_url}}" class="btn btn-success">
-                Continue Answering {{answers_question.task.title}} &raquo;
-              </a></p>
-            {% endif %}
-            {# TODO: Does module-set work correctly? #}
-            {% if answers_question.question.spec.type == "module-set" %}
-              <form method="post" action="/tasks/start" style="display:inline;">
-                {% csrf_token %}
-                <input type="hidden" name="project" value="{{task.project.id}}"/>
-                <input type="hidden" name="question" value="{{answers_question.question.key}}"/>
-                <input type="hidden" name="previous" value="task"/>
-                <a href="#" onclick="$(this).parent('form').submit(); return false;" class="btn btn-success" title="Add Another {{answers_question.question.answer_type_module.title}} to {{answers_question.question.spec.title}}.">
-                  Start New {{answers_question.question.answer_type_module.title}} &raquo;
-                </a>
-              </form>
-            {% endif %}
-          {% endif %}
-        {% else %}
-          {# every task, except projects, are now subtasks of other tasks, so this only occurs if a task is a subtask to multiple super-tasks #}
-          <p><a href="{{task.project.get_absolute_url}}" class="btn btn-success">
-           {# we used to say 'with other modules in {{task.project.title}}' but there may not be any other modules #}
-            Continue &raquo;
-          </a></p>
-        {% endif %}
-      {% endwith %}
-
-      {% if can_review %}
-        <p><a id="btn-review-answers" href="{{task.project.get_absolute_url}}/list#task-{{task.id}}" class="btn btn-default">
-          <em class="glyphicon glyphicon-list"></em>
-          Review &raquo;
-        </a></p>
-      {% endif %}
     </div> <!-- / continue panel -->
   </div> <!-- focus-area-wrapper -->
 

--- a/templates/task-finished.html
+++ b/templates/task-finished.html
@@ -97,18 +97,6 @@
                         <input type="hidden" name="q" value="{{task.project.root_task.id}}/{{next_module_spec.id}}">
                     {% endif %}
                     <div class="btn btn-success">Continue to {{next_module_spec.title}} &raquo;</div>
-
-                    {# Other options #}
-                    {# Include default link to the project page #}
-                    <a id="return-to-project" href="{{task.project.get_absolute_url}}#tab={{answers_question.question.spec.tab|slugify}}/{{answers_question.question.spec.group|slugify}}/{{answers_question.question.key|slugify}}/{{task.id}}" class="btn btn-default">
-                      Return to project
-                    </a>
-                    {# Reviewer's approval page #}
-                    {% if can_review %}
-                      <a id="btn-review-answers" href="{{task.project.get_absolute_url}}/list#task-{{task.id}}" class="btn btn-default">Review and approve answers</a>
-                    {% endif %}
-
-
                   </form>
                   <br>
                 {% endif %}
@@ -205,7 +193,15 @@
               <a role="button" data-toggle="collapse" data-parent="#accordion" href="#your-answers-body" aria-expanded="true" aria-controls="your-answers-body">
                 {{ task.title }} Module Summary
               </a>
+
+              <span class="pull-right">
+                {# Reviewer's approval page #}
+                {% if can_review %}
+                  <a id="btn-review-answers" class="btn-link" href="{{task.project.get_absolute_url}}/list#task-{{task.id}}" class="btn btn-default">Review and approve answers</a>
+                {% endif %}
+              </span>
             </h4>
+
           </div>
           <div id="your-answers-body" class="panel-collapse collapse in" role="tabpanel" aria-labelledby="your-answers-title">
             <div class="panel-body output-document">

--- a/templates/task-finished.html
+++ b/templates/task-finished.html
@@ -68,7 +68,6 @@
       </div>
     {% endif %}
 
-
       {% with answers_question=task.is_answer_to_unique %}
         {% if answers_question and answers_question.task.editor == request.user %}
           {% if task.project.is_account_project %}
@@ -100,7 +99,6 @@
                   </form>
                   <br>
                 {% endif %}
-
               </p>
             {% else %}
               {# return to non-project parent task #}
@@ -129,8 +127,6 @@
           </a></p>
         {% endif %}
       {% endwith %}
-
-
 
     <div id="accordion" class="panel-group" role="tablist" aria-multiselectable="true">
       {# output documents #}
@@ -247,7 +243,6 @@
           </div>
         </div>
       {% endif %}
-
     </div> <!-- /accordion -->
     <div id="continue-nav" class="task-answers">
     </div> <!-- / continue panel -->
@@ -257,9 +252,10 @@
     &nbsp;
   </div>
 
-  <div id="progress-project-area-wrapper" class="col-xs-6 col-sm-6 col-md-3 col-lg-3 task-progress-project">
+  <div id="progress-project-area-wrapper" class="col-xs-8 col-sm-6 col-md-3 col-lg-3 col-xl-2 question-progress-project">
     {% include "task-progress-project-list.html" with previous="question" %}
   </div>
+
 </div>
 
 <div class="modal fade" id="projectAssetWordConfig" tabindex="-1" aria-labelledby="projectAssetWordConfig" aria-hidden="true">
@@ -369,50 +365,6 @@
       window.location = "{{task.get_absolute_url|escapejs}}/download/document/" + encodeURIComponent(document_id) + "/" + format;
     });
   }
-
-  //$(function() {
-  //  // Poll for changes to the answers in the project, which would mean
-  //  // this document may be out of date.
-  //  var initial_timestamp = {{task.project.root_task.updated.timestamp|json}};
-  //  var interval = setInterval(check_for_update, 2500);
-  //  var is_checking_for_update = false;
-  //  function check_for_update() {
-  //    if (is_checking_for_update) return;
-  //    is_checking_for_update = true;
-  //    $.ajax({
-  //      method: 'POST',
-  //      url: '/tasks/_get_task_timetamp',
-  //      data: {
-  //        id: {{task.project.root_task.id}},
-  //        get_changes_since: initial_timestamp
-  //      },
-  //      success: function(res) {
-  //        // Do nothing if the timestamp matches the timestamp
-  //        // when the page was generated.
-  //        if (res.timestamp == initial_timestamp)
-  //          return;
-
-  //        // Don't poll for any further changes.
-  //        clearInterval(interval);
-
-  //        // Show a desktop notification.
-  //        Push.create("Project Information Changed", {
-  //          body: res.changes,
-  //          timeout: 5000
-  //        });
-
-  //        // Dim the page and reload.
-  //        var modal = $('<div style="display: none; position: fixed; left: 0; top: 0; width: 100%; height: 100%; z-index: 100000; text-align: center; background-color: rgba(255,255,255,.75)"><div style="margin: 20% auto"><div><span class="fas fa-spinner fa-pulse"></span></div><div class="message">Loading...</div></div></div>');
-  //        $('body').append(modal);
-  //        modal.fadeIn();
-  //        window.location.reload();
-  //      },
-  //      complete: function() {
-  //        is_checking_for_update = false;
-  //      }
-  //    })
-  //  }
-  //});
 
   function refresh_output_doc(app_id) {
       if (upgrade_app_option_confirm

--- a/templates/task-progress-project-list.html
+++ b/templates/task-progress-project-list.html
@@ -1,12 +1,10 @@
 <div class="truncate task-progress-project-truncate">
-    PROJECT:&nbsp; <a href="{{task.project.get_absolute_url}}" class="task-progress-project-url">
-      {{task.project.title}}
-    </a>
-    {% if current_group %}
-    <br>
-    SECTION:&nbsp; <a href="{{task.project.get_absolute_url}}#{{current_group}}" class="task-progress-project-url">{{current_group}}
-    </a>
-    {% endif %}
+  <button id="btn-controls" class="btn btn-sm btn-default text-center" onclick="window.location = '{{task.project.get_absolute_url}}';">
+    <em class="glyphicon glyphicon-home"></em> Project Home</a>
+  </button>{% if current_group %}<br><button id="btn-controls" class="btn btn-sm btn-default text-center" onclick="window.location = '{{task.project.get_absolute_url}}#{{current_group}}';">
+      Section: {{current_group}}</a>
+  </button>
+  {% endif %}
 </div>
 
 <div>
@@ -25,7 +23,7 @@
             <li>&nbsp;</li>
             </div>
             <li>
-              <a href="{{task.get_absolute_url}}/finished">...and we&rsquo;re done</a>
+              <a href="{{task.get_absolute_url}}/finished">Module summary</a>
             </li>
           {% endif %}
           </ul>


### PR DESCRIPTION
Simplify task-finished page layout. Move navigation buttons to top.
Replace "...and we're done" language with "Module Summary".
Replace questions progress sidebar's project links with more obvious project buttons.

Remove deprecated polling Javascript from task-finished page.

<img width="1303" alt="Screen Shot 2021-04-11 at 6 27 24 AM" src="https://user-images.githubusercontent.com/24979/114300580-06cc8680-9a8f-11eb-91c1-3d4a8367927c.png">

<img width="1253" alt="Screen Shot 2021-04-11 at 6 12 14 AM" src="https://user-images.githubusercontent.com/24979/114300227-295da000-9a8d-11eb-892d-06e480fcbe00.png">

