### PR TITLE
Improve first_run script with better tests for pre-existing content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,14 @@ v999 (April XX, 2021)
 * User now has the ability to edit uploaded files via the admin panel.
 * File names now updated properly for all Asset models in the event of an update.
 
+**Install fixes**
+
+* Create portfolios for admins when passing in ADMIN setting for automated admin creation during install first-run.
+* Create default org 'main' if none exists earlier in the first-run process.
+* Fix adding admin user to Help Squad and Reviewers list.
+* Install default AppSources and compliance apps only if no AppSources installed.
+
+
 v0.9.3.2 (April 1st, 2021)
 --------------------------
 

--- a/siteapp/management/commands/first_run.py
+++ b/siteapp/management/commands/first_run.py
@@ -159,8 +159,8 @@ class Command(BaseCommand):
                 print("[INFO] Admin added to Help Squad and Reviewers")
 
         else:
-            # One or more superusers already exist
-            print("\n[INFO] Superuser(s) already exist, not creating default admin superuser. Did you specify 'govready_admins' in 'local/environment.json'? Are you connecting to a persistent database?\n")
+            # One or more superusers already exists
+            print("\n[INFO] Superuser(s) already exists, not creating default admin superuser. Did you specify 'govready_admins' in 'local/environment.json'? Are you connecting to a persistent database?\n")
 
         # Provide feedback to user
         print("GovReady-Q configuration complete.")

--- a/siteapp/management/commands/first_run.py
+++ b/siteapp/management/commands/first_run.py
@@ -34,37 +34,60 @@ class Command(BaseCommand):
             print("The database is not initialized yet.")
             sys.exit(1)
 
-        # Create AppSources that we want.
-        if os.path.exists("/mnt/q-files-host"):
-            # For our docker image.
-            AppSource.objects.get_or_create(
-                slug="host",
-                defaults={
-                    "spec": { "type": "local", "path": "/mnt/q-files-host" }
-                }
-            )
-        # Second, for 0.9.x startpack
-        # We can use forward slashes because we are storing the path in the database
-        # and the path will be applied correctly to the operating OS.
-        qfiles_path = 'q-files/vendors/govready/govready-q-files-startpack/q-files'
-        if os.path.exists(qfiles_path):
-            # For 0.9.x+.
-            AppSource.objects.get_or_create(
-                slug="govready-q-files-startpack",
-                defaults={
-                    "spec": { "type": "local", "path": qfiles_path }
-                }
-            )
-            # Load the AppSource's assessments (apps) we want
-            # We will do some hard-coding here temporarily
-            created_appsource = AppSource.objects.get(slug="govready-q-files-startpack")
-            for appname in ["speedyssp", "System-Description-Demo",
-                            "PTA-Demo", "rules-of-behavior", "lightweight-ato", "lightweight-ato-800-171"]:
-                print("Adding appname '{}' from AppSource '{}' to catalog.".format(appname, created_appsource))
-                try:
-                    appver = created_appsource.add_app_to_catalog(appname)
-                except Exception as e:
-                    raise
+        # Create the default organization.
+        if not Organization.objects.all().exists() and not Organization.objects.filter(name="main").exists():
+            org, result = Organization.objects.get_or_create(name="main", slug="main")
+
+        # Install default AppSources and compliance apps if no AppSources installed
+        if len(AppSource.objects.all()) == 0:
+            # Create AppSources that we want.
+            if os.path.exists("/mnt/q-files-host"):
+                # For our docker image.
+                AppSource.objects.get_or_create(
+                    slug="host",
+                    defaults={
+                        "spec": { "type": "local", "path": "/mnt/q-files-host" }
+                    }
+                )
+            # Second, for 0.9.x startpack
+            # We can use forward slashes because we are storing the path in the database
+            # and the path will be applied correctly to the operating OS.
+            qfiles_path = 'q-files/vendors/govready/govready-q-files-startpack/q-files'
+            if os.path.exists(qfiles_path):
+                # For 0.9.x+.
+                AppSource.objects.get_or_create(
+                    slug="govready-q-files-startpack",
+                    defaults={
+                        "spec": { "type": "local", "path": qfiles_path }
+                    }
+                )
+                # Load the AppSource's assessments (apps) we want
+                # We will do some hard-coding here temporarily
+                created_appsource = AppSource.objects.get(slug="govready-q-files-startpack")
+                for appname in ["speedyssp", "System-Description-Demo",
+                                "PTA-Demo", "rules-of-behavior", "lightweight-ato", "lightweight-ato-800-171"]:
+                    print("Adding appname '{}' from AppSource '{}' to catalog.".format(appname, created_appsource))
+                    try:
+                        appver = created_appsource.add_app_to_catalog(appname)
+                    except Exception as e:
+                        raise
+
+            # Finally, for authoring, create an AppSource to the stub file
+            qfiles_path = 'guidedmodules/stubs/q-files'
+            if os.path.exists(qfiles_path):
+                # For 0.9.x+.
+                appsource, created = AppSource.objects.get_or_create(
+                    slug="govready-q-files-stubs",
+                    defaults={
+                        "spec": { "type": "local", "path": qfiles_path }
+                    }
+                )
+                if created:
+                    print("Adding AppSource for authoring.")
+                else:
+                    print("Confirmed that AppSource for authoring exists.")
+        else:
+            print("AppSources exist. Skipping install of defaults AppSources.")
 
         # Install default example components if no components in library
         if len(Element.objects.all()) == 0:
@@ -79,21 +102,6 @@ class Command(BaseCommand):
                             oscal_component_json = f.read()
                             result = ComponentImporter().import_components_as_json(import_name, oscal_component_json)
 
-        # Finally, for authoring, create an AppSource to the stub file
-        qfiles_path = 'guidedmodules/stubs/q-files'
-        if os.path.exists(qfiles_path):
-            # For 0.9.x+.
-            appsource, created = AppSource.objects.get_or_create(
-                slug="govready-q-files-stubs",
-                defaults={
-                    "spec": { "type": "local", "path": qfiles_path }
-                }
-            )
-            if created:
-                print("Adding AppSource for authoring.")
-            else:
-                print("Confirmed that AppSource for authoring exists.")
-
         # Create GovReady admin users, if specified in local/environment.json
         if len(settings.GOVREADY_ADMINS):
             for admin_user in settings.GOVREADY_ADMINS:
@@ -107,6 +115,10 @@ class Command(BaseCommand):
                         user.username,
                         user.email
                     ))
+                    # Create the first portfolio
+                    portfolio = Portfolio.objects.create(title=user.username)
+                    portfolio.assign_owner_permissions(user)
+                    print("Created administrator portfolio {}".format(portfolio.title))
                 else:
                     print("\n[INFO] Skipping create admin account '{}' - username already exists.\n".format(
                         username
@@ -135,22 +147,20 @@ class Command(BaseCommand):
             portfolio = Portfolio.objects.create(title=user.username)
             portfolio.assign_owner_permissions(user)
             print("Created administrator portfolio {}".format(portfolio.title))
+
+            # Add the user to the org's help squad and reviewers lists.
+            try:
+                user
+            except NameError:
+                print("[INFO] Admin already added to Help Squad and Reviewers")
+            else:
+                if user not in org.help_squad.all(): org.help_squad.add(user)
+                if user not in org.reviewers.all(): org.reviewers.add(user)
+                print("[INFO] Admin added to Help Squad and Reviewers")
+
         else:
             # One or more superusers already exist
             print("\n[INFO] Superuser(s) already exist, not creating default admin superuser. Did you specify 'govready_admins' in 'local/environment.json'? Are you connecting to a persistent database?\n")
-
-        # Create the default organization.
-        if not Organization.objects.all().exists() and not Organization.objects.filter(name="main").exists():
-            org, result = Organization.objects.get_or_create(name="main", slug="main")
-
-        # Add the user to the org's help squad and reviewers lists.
-        try:
-            user
-        except NameError:
-            print("[INFO] Admin already added to Help Squad and Reviewers")
-        else:
-            if user not in org.help_squad.all(): org.help_squad.add(user)
-            if user not in org.reviewers.all(): org.reviewers.add(user)
 
         # Provide feedback to user
         print("GovReady-Q configuration complete.")

--- a/siteapp/management/commands/first_run.py
+++ b/siteapp/management/commands/first_run.py
@@ -36,7 +36,7 @@ class Command(BaseCommand):
 
         # Create the default organization.
         if not Organization.objects.all().exists() and not Organization.objects.filter(name="main").exists():
-            org, result = Organization.objects.get_or_create(name="main", slug="main")
+            org = Organization.objects.create(name="main", slug="main")
 
         # Install default AppSources and compliance apps if no AppSources installed
         if AppSource.objects.all().exists():

--- a/siteapp/management/commands/first_run.py
+++ b/siteapp/management/commands/first_run.py
@@ -39,7 +39,7 @@ class Command(BaseCommand):
             org, result = Organization.objects.get_or_create(name="main", slug="main")
 
         # Install default AppSources and compliance apps if no AppSources installed
-        if len(AppSource.objects.all()) == 0:
+        if AppSource.objects.all().exists():
             # Create AppSources that we want.
             if os.path.exists("/mnt/q-files-host"):
                 # For our docker image.


### PR DESCRIPTION
Improve first_run management command with better tests
for pre-existing content and to make sure portfolios created for
passed in ADMINS from config file.

* Create portfolios for admins when passing in ADMIN setting for automated admin creation during install first-run.
* Create default org 'main' if none exists earlier in the first-run process.
* Fix adding admin user to Help Squad and Reviewers list.
* Install default AppSources and compliance apps only if no AppSources installed.