### PR TITLE
Support portfolio selection after app selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ v999 (April XX, 2021)
 -------------------------
 
 
-[Add changes here]
+**UI changes**
+
+* Prompt user for which portfolio to start project in if portfolio value not previously set before visiting project templates. Enables users to start a project from a blank link.
 
 
 v0.9.3.3 (April 13, 2021)

--- a/siteapp/views.py
+++ b/siteapp/views.py
@@ -519,6 +519,9 @@ def apps_catalog(request):
             app["title"], # except if two apps differ only in case, sort case-sensitively
         ))
 
+    # Get the organization - temporarily assume 1 org
+    organization = Organization.objects.first()
+
     # If user is superuser, enable creating new apps
     authoring_tool_enabled = request.user.has_perm('guidedmodules.change_module')
 
@@ -528,6 +531,7 @@ def apps_catalog(request):
         "forward_qsargs": ("?" + urlencode(forward_qsargs)) if forward_qsargs else "",
         "authoring_tool_enabled": authoring_tool_enabled,
         "project_form": AddProjectForm(request.user),
+        "organization": organization
     })
 
 @login_required
@@ -546,8 +550,13 @@ def apps_catalog_item(request, source_slug, app_name):
     # Get portfolio project should be included in.
     if request.GET.get("portfolio"):
       portfolio = Portfolio.objects.get(id=request.GET.get("portfolio"))
+    elif request.POST.get("portfolio"):
+      portfolio = Portfolio.objects.get(id=request.POST.get("portfolio"))
     else:
       portfolio = None
+
+    # Get the organization - temporarily assume 1 org
+    organization = Organization.objects.first()
 
     error = None
 
@@ -589,10 +598,11 @@ def apps_catalog_item(request, source_slug, app_name):
             task, q = get_task_question(request)
             if not app_satifies_interface(app_catalog_info, q):
                 raise ValueError("Invalid protocol.")
-
         # Get portfolio project should be included in.
         if request.GET.get("portfolio"):
           portfolio = Portfolio.objects.get(id=request.GET.get("portfolio"))
+        elif request.POST.get("portfolio"):
+          portfolio = Portfolio.objects.get(id=request.POST.get("portfolio"))
         else:
           portfolio = None
 
@@ -620,7 +630,8 @@ def apps_catalog_item(request, source_slug, app_name):
         "error": error,
         "project_form": AddProjectForm(request.user),
         "source_slug": source_slug,
-        "portfolio": portfolio
+        "portfolio": portfolio,
+        "organization": organization
     })
 
 def start_app(appver, organization, user, folder, task, q, portfolio):

--- a/templates/app-store-item.html
+++ b/templates/app-store-item.html
@@ -124,6 +124,9 @@
                     {% endif %}
                     {% if portfolio %}
                         <button id="start-project" type="submit" class="btn btn-success app-button-width">Add ►</button>
+                      {% else %}
+                        {# Configure start button to ask for portfolio if no portfolio is set #}
+                        <button type="submit" class="btn btn-success btn-sm btn-justified start-app" onclick="show_select_portfolio_modal('/store/{{ app.key|urlencode }}{{ forward_qsargs }}',''); return false;">Add ►</button>
                     {% endif %}
                 </form>
                 <button id="start-project" type="submit" class="btn btn-link btn-start-project">

--- a/templates/app-store.html
+++ b/templates/app-store.html
@@ -181,6 +181,9 @@ Compliance Apps
                       {% endwith %}
                       {% if 'portfolio' in forward_qsargs %}
                         <button type="submit" class="btn btn-success btn-sm btn-justified start-app">Add ►</button>
+                      {% else %}
+                        {# Configure start button to ask for portfolio if no portfolio is set #}
+                        <button type="submit" class="btn btn-success btn-sm btn-justified start-app" onclick="show_select_portfolio_modal('/store/{{ app.key|urlencode }}{{ forward_qsargs }}',''); return false;">Add ►</button>
                       {% endif %}
                   </form>
               {% endif %}

--- a/templates/move-project-modal.html
+++ b/templates/move-project-modal.html
@@ -3,7 +3,7 @@
       <div class="modal-content">
         <div class="modal-header">
           <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-          <h4 class="modal-title" id="invitation_modal_title">Select a Portfolio</h4>
+          <h4 class="modal-title" id="invitation_modal_title">In which portfolio should we put the project?</h4>
         </div>
         <form role="form" method="get">
           <div class="modal-body">
@@ -23,7 +23,7 @@
       </div>
     </div>
   </div>
-  
+
   {% block scripts %}
   <script>
     function show_move_project_modal(callback) {

--- a/templates/portfolios/select-portfolio-modal.html
+++ b/templates/portfolios/select-portfolio-modal.html
@@ -3,27 +3,40 @@
     <div class="modal-content">
       <div class="modal-header">
         <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-        <h4 class="modal-title" id="invitation_modal_title">Select a Portfolio</h4>
+        <h4 class="modal-title" id="invitation_modal_title">In which portfolio should we put the project?</h4>
       </div>
-      <form action="{% url 'store' %}" role="form" method="get">
+      <form id="select_portfolio" action="{% url 'store' %}" role="form" method="get">
+          {% csrf_token %}
+          {% if app.organizations|length > 1 %}
+              <select id="app-org-select" class="" onchange="update_org_choice('{{ app.key }}/organization_{{ forloop.counter }}', event)">
+                  {% for org in app.organizations %}
+                      <option value="{{ org.slug }}">{{ org }}</option>
+                  {% endfor %}
+              </select>
+          {% endif %}
+          <input type="hidden" name="organization" value="{{ organization.slug }}">
         <div class="modal-body">
           <label for="id_portfolio">{{ project_form.portfolio.label }}</label>:&nbsp;
           {{ project_form.portfolio }}
-         </div>
-         <div class="modal-footer">
+        </div>
+        <div class="modal-footer">
            <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
            <button id="select_portfolio_submit" class="btn btn-success btn-submit" type="submit">Start Project</button>
-          </div>
-        </form>
-      </div>
+        </div>
+      </form>
     </div>
   </div>
 </div>
 
 {% block scripts %}
 <script>
-  function show_select_portfolio_modal(callback) {
+  function show_select_portfolio_modal(url, callback) {
     var m = $('#select_portfolio_modal');
+    if (url) {
+      $('#url').text(url);
+      $('#select_portfolio').attr('action', url);
+      $('#select_portfolio').attr('method', 'post');
+    }
     m.modal();
   }
 </script>


### PR DESCRIPTION
Prompt user for which portfolio to start project
in if portfolio value not previously set before visiting project templates.
Enables users to start a project from a blank link.

Update templates/portfolios/select-portfolio-modal.html to
get required information if started afterward and properly
target the the correction action