### PR TITLE
Improve reporting of error logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,18 +5,18 @@ v999 (April XX, 2021)
 -------------------------
 
 **Developer changes**
+
 * Add ability for external catalogs and baselines to be used in GovReady-q projects through the two functions `extend_external_baselines` and `extend_external_catalogs`. This includes two new paths GovReady-q looks at which are EXTERNAL_BASELINE_PATH and EXTERNAL_CATALOG_PATH `~/govready-q/local/controls/data/<baselines/catalogs>`
 * Added a `list_catalogs()` method to `Catalog` in order to easily get the `Catalog` objects in a list.
-
+* Provide better error reporting on import component schema validation; report actual validation error to standout.
 
 **Bug fixes**
+
 * Fixed some issues in code resulting in excessive SQL calls slowing down the application
 
 **UI changes**
 
 * Link mini-dashboards on project page to sensible related pages.
-
-
 
 v0.9.3.3 (April 13, 2021)
 -------------------------

--- a/controls/views.py
+++ b/controls/views.py
@@ -651,7 +651,7 @@ class ComponentImporter(object):
             validate(instance=oscal_json, schema=oscal_json_schema)
             return True
         except (SchemaError, SchemaValidationError) as e:
-            logger.info(e)
+            logger.error(e._contents())
             return False
 
     def create_components(self, oscal_json):


### PR DESCRIPTION
Report OSCAL component schema validation error to standout. Provide better error reporting on import component schema validation.
Closes #1466.