### PR TITLE
Immediately assign change project perms to user starting project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ v999 (April XX, 2021)
 
 **Bug fixes**
 
-* Replace me
+* Immediately assign change project perms to user starting project and fix issue that non-admin users were not executing modifications to a project the user started such as setting baseline controls.
 
 **Developer changes**
 

--- a/guidedmodules/views.py
+++ b/guidedmodules/views.py
@@ -32,7 +32,7 @@ logger = get_logger()
 
 @login_required
 def new_task(request):
-    # Create a new task by answering a module question of a project rook task.
+    # Create a new task by answering a module question of a project root task.
     project = get_object_or_404(Project, id=request.POST["project"])
 
     # Can the user create a task within this project?
@@ -570,7 +570,7 @@ def save_answer(request, task, answered, context, __):
                                 Statement.objects.filter(producer_element_id = producer_element.id, consumer_element_id = system.root_element.id, statement_type="control_implementation").delete()
                                 messages.add_message(request, messages.INFO,
                                                      f'I\'ve deleted "{producer_element.name}" and its {smts_assigned_count} control implementation statements from the system.')
- 
+
 
     # Form a JSON response to the AJAX request and indicate the
     # URL to redirect to, to load the next question.

--- a/siteapp/views.py
+++ b/siteapp/views.py
@@ -695,7 +695,29 @@ def start_app(appver, organization, user, folder, task, q, portfolio):
             object={"object": "element", "id": element.id, "name": element.name},
             user={"id": user.id, "username": user.username}
         )
-        # Add deault deployments to system
+
+        # Add user as the first admin of project.
+        ProjectMembership.objects.create(
+            project=project,
+            user=user,
+            is_admin=True)
+        # Grant owner permissions on root_element to user
+        element.assign_owner_permissions(user)
+        # Log ownership assignment
+        logger.info(
+            event="new_element new_system assign_owner_permissions",
+            object={"object": "element", "id": element.id, "name": element.name},
+            user={"id": user.id, "username": user.username}
+        )
+        system.assign_owner_permissions(user)
+        # Log ownership assignment
+        logger.info(
+            event="new_system assign_owner_permissions",
+            object={"object": "system", "id": system.root_element.id, "name": system.root_element.name},
+            user={"id": user.id, "username": user.username}
+        )
+
+        # Add default deployments to system
         deployment = Deployment(name="Blueprint", description="Reference system archictecture design", system=system)
         deployment.save()
         deployment = Deployment(name="Dev", description="Development environment deployment", system=system)
@@ -743,27 +765,6 @@ def start_app(appver, organization, user, folder, task, q, portfolio):
             )
 
         # TODO: Assign default org parameters
-
-        # Add user as the first admin.
-        ProjectMembership.objects.create(
-            project=project,
-            user=user,
-            is_admin=True)
-        # Grant owner permissions on root_element to user
-        element.assign_owner_permissions(user)
-        # Log ownership assignment
-        logger.info(
-            event="new_element new_system assign_owner_permissions",
-            object={"object": "element", "id": element.id, "name": element.name},
-            user={"id": user.id, "username": user.username}
-        )
-        system.assign_owner_permissions(user)
-        # Log ownership assignment
-        logger.info(
-            event="new_system assign_owner_permissions",
-            object={"object": "system", "id": system.root_element.id, "name": system.root_element.name},
-            user={"id": user.id, "username": user.username}
-        )
 
         if task and q:
             # It will also answer a task's question.


### PR DESCRIPTION
This fixes a bug where non-admin users were not assigned permissions
to change a project started by the user until after several project
modification steps were performed. The fix assigns non-admin project
change permissions right after project and system is created and
before further actions are made to project, such as setting baseline controls.

This is an import bug fix because non-admin users currently experience incorrect behavior.