### PR TITLE
Fix a few typos

### DIFF
--- a/templates/api-keys.html
+++ b/templates/api-keys.html
@@ -42,11 +42,11 @@ dd p:first-child { margin-bottom: .25em; }
 	<dt>Write-only key</dt>
 	<dd>
 	<p><code>{{api_key_wo}}</code></p>
-	<p>Your write-only key gives external tools the ability to make changes to anything you can make changes to on Q but does not include the abiliy to see any data values stored in Q. The write-only key is useful in situations where the external tool needs to be able to upload data but does not need to read existing data values.</p>
+	<p>Your write-only key gives external tools the ability to make changes to anything you can make changes to on Q but does not include the ability to see any data values stored in Q. The write-only key is useful in situations where the external tool needs to be able to upload data but does not need to read existing data values.</p>
 	</dd>
 	</dl>
 
-	<p>Choose the API key that is most appropriate for the acccess level required by the external application.</p>
+	<p>Choose the API key that is most appropriate for the access level required by the external application.</p>
 
 	<h2>Reset your API keys</h2>
 

--- a/templates/home-user.html
+++ b/templates/home-user.html
@@ -162,7 +162,7 @@ Your Compliance Projects
         </div>
         <div class="col-md-9">
           <h3><a href="https://govready-q.readthedocs.org">Learn more about GovReady-Q</a></h3>
-          <p>Checkout our documentation to learn how to take full advantage of GovReady-Q.
+          <p>Check out our documentation to learn how to take full advantage of GovReady-Q.
           </p>
         </div>
       </div>

--- a/templates/project.html
+++ b/templates/project.html
@@ -318,7 +318,7 @@
 
                     {% if can_start_task %}
 
-                      {# We need one of three forms here. If this is a module-type question and it's been answered already (it has a Task answer), then we simply link to that Task. Otherwise if it's not answered or if it's a module-set type quesion that can be answered multiple times, we show a form. If the question is answered by a particular module, clicking the icon submits a form that creates a new Task and redirects to it. If this question instead has a "protocol" field, then the user is simply redirected to the Apps Catalog and is presented with apps that satisfy the protocol. #}
+                      {# We need one of three forms here. If this is a module-type question and it's been answered already (it has a Task answer), then we simply link to that Task. Otherwise if it's not answered or if it's a module-set type question that can be answered multiple times, we show a form. If the question is answered by a particular module, clicking the icon submits a form that creates a new Task and redirects to it. If this question instead has a "protocol" field, then the user is simply redirected to the Apps Catalog and is presented with apps that satisfy the protocol. #}
 
                       {% if not q.can_start_new_task %}
                         {# This is a module-type question that has been started. Clicking the question doesn't start a new task --- instead, it's just a link to the started Task. #}


### PR DESCRIPTION
Fixes three user-visible typos, and one in a comment.

The important one is changing "Checkout" (not a word) to "Check out" (proper English) on the home page (`home-user.html`).
