### PR TITLE
Faster retrieval of component control statements, show control titles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ v999 (April XX, 2021)
 **UI changes**
 
 * Add links for "forgot password" and "change password".
+* Add control titles to component control listing pages.
 
 **Bug fixes**
 
@@ -15,6 +16,8 @@ v999 (April XX, 2021)
 * Properly filter system POA&M stat to only count POA&Ms for system.
 
 * Provide better error reporting on import component schema validation; report actual validation error to standout.
+
+* Fix N+1 slow display of component control statements with many statements.
 
 **Developer changes**
 

--- a/controls/models.py
+++ b/controls/models.py
@@ -87,19 +87,27 @@ class Statement(auto_prefetch.Model):
     @property
     def catalog_control(self):
         """Return the control content from the catalog"""
+
         # Get instance of the control catalog
         catalog = Catalog.GetInstance(catalog_key=self.sid_class)
         # Look up control by ID
         return catalog.get_control_by_id(self.sid)
 
-    @property
+    @cached_property
     def catalog_control_as_dict(self):
         """Return the control content from the catalog"""
+
         # Get instance of the control catalog
         catalog = Catalog.GetInstance(catalog_key=self.sid_class)
-        catalog_control_dict = catalog.get_flattened_controls_all_as_dict()
         # Look up control by ID
-        return catalog_control_dict[self.sid]
+        catalog_control_dict = catalog.get_flattened_control_as_dict(self.catalog_control)
+        return catalog_control_dict
+
+    @cached_property
+    def control_title(self):
+        """Return the control title"""
+
+        return self.catalog_control_as_dict['title']
 
     def create_prototype(self):
         """Creates a prototype statement from an existing statement and prototype object"""

--- a/templates/components/element_detail_tabs.html
+++ b/templates/components/element_detail_tabs.html
@@ -1,7 +1,6 @@
 {% extends "base.html" %}
 {% load humanize %}
 {% load guardian_tags %}
-{% load system_tags %}
 {% load static %}
 {% load q %}
 

--- a/templates/components/element_detail_tabs.html
+++ b/templates/components/element_detail_tabs.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% load humanize %}
 {% load guardian_tags %}
+{% load system_tags %}
 {% load static %}
 {% load q %}
 
@@ -200,7 +201,7 @@
         <div class="row statement-column-headings" style="">
           <div class="col-xs-3 col-sm-3 col-md-3 col-lg-3 col-xl-3">Control</div>
           <div class="col-xs-6 col-sm-6 col-md-6 col-lg-6 col-xl-6">Statement</div>
-          <div class="col-xs-3 col-sm-3 col-md-3 col-lg-3 col-xl-3">Action</div>
+            <div class="col-xs-3 col-sm-3 col-md-3 col-lg-3 col-xl-3"><span class="pull-right">Action</span></div>
         </div>
 
           <div id="smt-list" class="" style="width: 100%">
@@ -211,7 +212,7 @@
 
                 <div class="row statement-text">
                   <div class="col-xs-3 col-sm-3 col-md-3 col-lg-3 col-xl-3">
-                    <span id="producer_element-{{ forloop.counter }}-control" class="control-id-text">{{ smt.sid|upper }} {% if smt.pid %}{{ smt.pid }}.{% endif %}</span>
+                    <span id="producer_element-{{ forloop.counter }}-control" class="control-id-text">{{ smt.sid|upper }} {% if smt.pid %}{{ smt.pid }}.{% endif %} - {{ smt.control_title }}</span>
                   </div>
                   <div class="col-xs-6 col-sm-6 col-md-6 col-lg-6 col-xl-6 statement-text-block">{{ smt.body }}</div>
                   <div class="col-xs-3 col-sm-3 col-md-3 col-lg-3 col-xl-3 remark-text-block"><a role="button" class="glyphicon glyphicon-pencil pull-right" style="color: #aaa;" data-toggle="collapse" data-parent="#accordion" href="#document-{{ forloop.counter }}-body" aria-expanded="false" aria-controls="document-{{ forloop.counter }}-body"></a>{% if smt.remarks %}<details><summary>Remarks</summary><div>{{ smt.remarks }}</div></details>{% endif %}</div>

--- a/templates/systems/element_detail_tabs.html
+++ b/templates/systems/element_detail_tabs.html
@@ -149,7 +149,7 @@
                   <div class="row statement-column-headings" style="">
                     <div class="col-xs-3 col-sm-3 col-md-3 col-lg-3 col-xl-3">Control</div>
                     <div class="col-xs-6 col-sm-6 col-md-6 col-lg-6 col-xl-6">Statement</div>
-                    <div class="col-xs-3 col-sm-3 col-md-3 col-lg-3 col-xl-3">Action</div>
+                      <div class="col-xs-3 col-sm-3 col-md-3 col-lg-3 col-xl-3"><span class="pull-right">Action</span></div>
                   </div>
 
                     <div id="smt-list" class="" style="width: 100%">
@@ -160,7 +160,7 @@
 
                                 <div class="row statement-text">
                                   <div class="col-xs-3 col-sm-3 col-md-3 col-lg-3 col-xl-3">
-                                    <span id="producer_element-{{ forloop.counter }}-control" class="control-id-text">{{ smt.sid|upper }} {% if smt.pid %}{{ smt.pid }}.{% endif %}</span>
+                                    <span id="producer_element-{{ forloop.counter }}-control" class="control-id-text">{{ smt.sid|upper }} {% if smt.pid %}{{ smt.pid }}.{% endif %} - {{ smt.control_title }}</span>
                                   </div>
                                   <div class="col-xs-6 col-sm-6 col-md-6 col-lg-6 col-xl-6 statement-text-block">{{ smt.body }}</div><div class="col-xs-3 col-sm-3 col-md-3 col-lg-3 col-xl-3 remark-text-block"><a role="button" class="glyphicon glyphicon-pencil pull-right" style="color: #aaa;"  data-toggle="collapse" data-parent="#accordion" href="#document-{{ forloop.counter }}-body" aria-expanded="false" aria-controls="document-{{ forloop.counter }}-body"></a>{% if smt.remarks %}<details><summary>Remarks</summary><div>{{ smt.remarks }}</div></details>{% endif %}</div></div>
 


### PR DESCRIPTION
Retrieve component control statement much faster by getting
just related catalog_control_as_dict for statement. Also
add statement property to get control title. Display control title
on component control pages.

Important performance improvement!