### PR TITLE
enums need to match case of value. adding smt id to logs

### DIFF
--- a/controls/enums/statements.py
+++ b/controls/enums/statements.py
@@ -2,8 +2,8 @@ from siteapp.enums.base import BaseEnum
 
 
 class StatementTypeEnum(BaseEnum):
-    CONTROL_IMPLEMENTATION = "control_implementation"
-    CONTROL_IMPLEMENTATION_PROTOTYPE = "control_implementation_prototype"
-    ASSESSMENT_RESULT = "assessment_result"
+    control_implementation = "control_implementation"
+    control_implementation_prototype = "control_implementation_prototype"
+    assessment_result = "assessment_result"
     POAM = "POAM"
-    FISMA_IMPACT_LEVEL = "fisma_impact_level"
+    fisma_impact_level = "fisma_impact_level"

--- a/controls/enums/statements.py
+++ b/controls/enums/statements.py
@@ -2,8 +2,8 @@ from siteapp.enums.base import BaseEnum
 
 
 class StatementTypeEnum(BaseEnum):
-    control_implementation = "control_implementation"
-    control_implementation_prototype = "control_implementation_prototype"
-    assessment_result = "assessment_result"
+    CONTROL_IMPLEMENTATION = "control_implementation"
+    CONTROL_IMPLEMENTATION_PROTOTYPE = "control_implementation_prototype"
+    ASSESSMENT_RESULT = "assessment_result"
     POAM = "POAM"
-    fisma_impact_level = "fisma_impact_level"
+    FISMA_IMPACT_LEVEL = "fisma_impact_level"

--- a/controls/migrations/0032_auto_20201113_0458.py
+++ b/controls/migrations/0032_auto_20201113_0458.py
@@ -3,6 +3,8 @@
 from django.db import migrations
 
 # Data migration to create prototype statements for all existing control_implementation statements
+from controls.enums.statements import StatementTypeEnum
+
 
 def create_prototype_statements(apps, schema_editor):
     # We can't import the Statement model directly as it may be a newer
@@ -27,7 +29,7 @@ def create_prototype_statements(apps, schema_editor):
         else:
             # Create a prototype statement for the control_implementation_statement
             prototype = deepcopy(statement)
-            prototype.statement_type="control_implementation_prototype"
+            prototype.statement_type=StatementTypeEnum.CONTROL_IMPLEMENTATION_PROTOTYPE.value
             prototype.consumer_element_id = None
             prototype.id = None
             prototype.save()
@@ -40,7 +42,7 @@ def remove_prototype_statements(apps, schema_editor):
     # version than this migration expects. We use the historical version.
     apps.get_model("controls", "Statement")\
         .objects\
-        .filter(statement_type='control_implementation_prototype')\
+        .filter(statement_type=StatementTypeEnum.CONTROL_IMPLEMENTATION_PROTOTYPE.value)\
         .delete()
 
 class Migration(migrations.Migration):

--- a/controls/models.py
+++ b/controls/models.py
@@ -117,7 +117,7 @@ class Statement(auto_prefetch.Model):
             return self.prototype
             # check if prototype content is the same, report error if not, or overwrite if permission approved
         prototype = deepcopy(self)
-        prototype.statement_type="control_implementation_prototype"
+        prototype.statement_type=StatementTypeEnum.CONTROL_IMPLEMENTATION.value
         prototype.consumer_element_id = None
         prototype.id = None
         prototype.save()
@@ -134,7 +134,7 @@ class Statement(auto_prefetch.Model):
         # System already has instance of the control_implementation statement
         # TODO: write check for this logic
         # Get all statements for consumer element so we can identify
-        smts_existing = Statement.objects.filter(consumer_element__id = consumer_element_id, statement_type = "control_implementation").select_related('prototype')
+        smts_existing = Statement.objects.filter(consumer_element__id = consumer_element_id, statement_type=StatementTypeEnum.CONTROL_IMPLEMENTATION.value).select_related('prototype')
 
         # Get prototype ids for all consumer element statements
         smts_existing_prototype_ids = [smt.prototype.id for smt in smts_existing]
@@ -145,7 +145,7 @@ class Statement(auto_prefetch.Model):
         #     # check if prototype content is the same, report error if not, or overwrite if permission approved
 
         instance = deepcopy(self)
-        instance.statement_type="control_implementation"
+        instance.statement_type=StatementTypeEnum.CONTROL_IMPLEMENTATION.value
         instance.consumer_element_id = consumer_element_id
         instance.id = None
         # Set prototype attribute to newly created instance
@@ -244,7 +244,7 @@ class Element(auto_prefetch.Model, TagModelMixin):
     #    e.statements_consumed.all()
     #
     # Retrieve statements that are control implementations
-    #    e.statements_consumed.filter(statement_type="control_implementation")
+    #    e.statements_consumed.filter(statement_type=StatementTypeEnum.CONTROL_IMPLEMENTATION.value)
 
     def __str__(self):
         return "'%s id=%d'" % (self.name, self.id)
@@ -337,7 +337,7 @@ class Element(auto_prefetch.Model, TagModelMixin):
     def get_control_impl_smts_prototype_count(self):
         """Return count of statements with this element as producer_element"""
 
-        smt_count = Statement.objects.filter(producer_element=self, statement_type="control_implementation_prototype").count()
+        smt_count = Statement.objects.filter(producer_element=self, statement_type=StatementTypeEnum.CONTROL_IMPLEMENTATION.value).count()
 
         return smt_count
 
@@ -470,7 +470,7 @@ class System(auto_prefetch.Model):
     # Notes
     # Retrieve system implementation statements
     #   system = System.objects.get(pk=2)
-    #   system.root_element.statements_consumed.filter(statement_type="control_implementation")
+    #   system.root_element.statements_consumed.filter(statement_type=StatementTypeEnum.CONTROL_IMPLEMENTATION.value)
     #
     # Retrieve system common controls statements
     #   system = System.objects.get(pk=2)
@@ -523,7 +523,7 @@ class System(auto_prefetch.Model):
         control = ElementControl.objects.get(pk=control_id)
 
         # Delete Control Statements
-        self.root_element.statements_consumed.filter(statement_type="control_implementation",
+        self.root_element.statements_consumed.filter(statement_type=StatementTypeEnum.CONTROL_IMPLEMENTATION.value,
                                                      sid_class=control.oscal_catalog_key,
                                                      sid=control.oscal_ctl_id
                                                      ).delete()
@@ -536,7 +536,7 @@ class System(auto_prefetch.Model):
         """Assign FISMA impact level to system"""
 
         # Get or create the fisma_impact_level smt for system's root_element; should only have 1 statement
-        smt = Statement.objects.create(statement_type="fisma_impact_level", producer_element=self.root_element,consumer_element=self.root_element, body=fisma_impact_level)
+        smt = Statement.objects.create(statement_type=StatementTypeEnum.FISMA_IMPACT_LEVEL.value, producer_element=self.root_element,consumer_element=self.root_element, body=fisma_impact_level)
         return fisma_impact_level, smt
 
     @property
@@ -544,7 +544,7 @@ class System(auto_prefetch.Model):
         """Assign FISMA impact level to system"""
 
         # Get or create the fisma_impact_level smt for system's root_element; should only have 1 statement
-        smt, created = Statement.objects.get_or_create(statement_type="fisma_impact_level", producer_element=self.root_element,consumer_element=self.root_element)
+        smt, created = Statement.objects.get_or_create(statement_type=StatementTypeEnum.FISMA_IMPACT_LEVEL.value, producer_element=self.root_element,consumer_element=self.root_element)
         fisma_impact_level = smt.body
         return fisma_impact_level
 
@@ -561,7 +561,7 @@ class System(auto_prefetch.Model):
 
     @property
     def smts_control_implementation_as_dict(self):
-        smts = self.root_element.statements_consumed.filter(statement_type="control_implementation").order_by('pid')
+        smts = self.root_element.statements_consumed.filter(statement_type=StatementTypeEnum.CONTROL_IMPLEMENTATION.value).order_by('pid')
         smts_as_dict = {}
         for smt in smts:
             if smt.sid in smts_as_dict:
@@ -578,7 +578,7 @@ class System(auto_prefetch.Model):
         elm = self.root_element
         selected_controls = elm.controls.all().values("oscal_ctl_id", "uuid")
         # Get the smts_control_implementations ordered by part, e.g. pid
-        smts = elm.statements_consumed.filter(statement_type="control_implementation").order_by('pid')
+        smts = elm.statements_consumed.filter(statement_type=StatementTypeEnum.CONTROL_IMPLEMENTATION.value).order_by('pid')
 
         smts_as_dict = {}
 
@@ -665,12 +665,12 @@ class System(auto_prefetch.Model):
         # Fetch all selected controls
         elm = self.root_element
 
-        counts = Statement.objects.filter(statement_type="control_implementation", status__in=status_list).values('status').order_by('status').annotate(count=Count('status'))
+        counts = Statement.objects.filter(statement_type=StatementTypeEnum.CONTROL_IMPLEMENTATION.value, status__in=status_list).values('status').order_by('status').annotate(count=Count('status'))
         status_stats.update({r['status']: r['count'] for r in counts})
 
         # TODO add index on statement status
         # Get overall controls addressed (e.g., covered)
-        status_stats['Addressed'] = elm.statements_consumed.filter(statement_type="control_implementation").values('sid').distinct().count()
+        status_stats['Addressed'] = elm.statements_consumed.filter(statement_type=StatementTypeEnum.CONTROL_IMPLEMENTATION.value).values('sid').distinct().count()
         return status_stats
 
     @cached_property

--- a/controls/models.py
+++ b/controls/models.py
@@ -536,10 +536,8 @@ class System(auto_prefetch.Model):
         """Assign FISMA impact level to system"""
 
         # Get or create the fisma_impact_level smt for system's root_element; should only have 1 statement
-        smt, created = Statement.objects.get_or_create(statement_type="fisma_impact_level", producer_element=self.root_element,consumer_element=self.root_element)
-        smt.body = fisma_impact_level
-        smt.save()
-        return fisma_impact_level
+        smt = Statement.objects.create(statement_type="fisma_impact_level", producer_element=self.root_element,consumer_element=self.root_element, body=fisma_impact_level)
+        return fisma_impact_level, smt
 
     @property
     def get_fisma_impact_level(self):

--- a/controls/tests.py
+++ b/controls/tests.py
@@ -307,7 +307,7 @@ class ComponentUITests(OrganizationSiteFunctionalTests):
 
         element_count_before_import = Element.objects.filter(element_type="system_element").count()
         statement_count_before_import = Statement.objects.filter(
-            statement_type="control_implementation_prototype").count()
+            statement_type=StatementTypeEnum.CONTROL_IMPLEMENTATION.value).count()
 
         # Verify that the contents got copied correctly from the file to the textfield
         try:
@@ -329,7 +329,7 @@ class ComponentUITests(OrganizationSiteFunctionalTests):
         element_count_after_import = Element.objects.filter(element_type="system_element").count()
         self.assertEqual(element_count_before_import, element_count_after_import)
 
-        statement_count_after_import = Statement.objects.filter(statement_type="control_implementation_prototype").count()
+        statement_count_after_import = Statement.objects.filter(statement_type=StatementTypeEnum.CONTROL_IMPLEMENTATION.value).count()
         self.assertEqual(statement_count_before_import, statement_count_after_import)
 
     def test_component_import_oscal_json(self):
@@ -338,7 +338,7 @@ class ComponentUITests(OrganizationSiteFunctionalTests):
         self.browser.get(url)
 
         element_count_before_import = Element.objects.filter(element_type="system_element").count()
-        statement_count_before_import = Statement.objects.filter(statement_type="control_implementation_prototype").count()
+        statement_count_before_import = Statement.objects.filter(statement_type=StatementTypeEnum.CONTROL_IMPLEMENTATION.value).count()
 
         # Test initial import of Component(s) and Statement(s)
         self.click_element('a#component-import-oscal')
@@ -353,7 +353,7 @@ class ComponentUITests(OrganizationSiteFunctionalTests):
 
         wait_for_sleep_after(lambda: self.assertEqual(element_count_before_import + 2, element_count_after_import))
 
-        statement_count_after_import = Statement.objects.filter(statement_type="control_implementation_prototype").count()
+        statement_count_after_import = Statement.objects.filter(statement_type=StatementTypeEnum.CONTROL_IMPLEMENTATION.value).count()
         self.assertEqual(statement_count_before_import + 4, statement_count_after_import)
         # Test file contains 6 Statements, but only 4 get imported
         # because one has an improper Catalog
@@ -382,7 +382,7 @@ class ComponentUITests(OrganizationSiteFunctionalTests):
         self.assertEqual(duplicate_import_element_count, 1)
 
         statement_count_after_duplicate_import = Statement.objects.filter(
-            statement_type="control_implementation_prototype").count()
+            statement_type=StatementTypeEnum.CONTROL_IMPLEMENTATION.value).count()
         self.assertEqual(statement_count_after_import + 4, statement_count_after_duplicate_import)
 
     def test_import_tracker(self):
@@ -498,7 +498,7 @@ class StatementUnitTests(TestCase):
             sid = "au.3",
             sid_class = "NIST_SP-800-53_rev4",
             body = "This is a test statement.",
-            statement_type = "control_implementation",
+            statement_type=StatementTypeEnum.CONTROL_IMPLEMENTATION.value,
             status = "Implemented"
         )
         smt.save()
@@ -562,7 +562,7 @@ class ElementUnitTests(TestCase):
             sid = "au-3",
             sid_class = "NIST_SP-800-53_rev4",
             body = "This is the first test statement.",
-            statement_type = "control_implementation_prototype",
+            statement_type=StatementTypeEnum.CONTROL_IMPLEMENTATION_PROTOTYPE.value,
             status = "Implemented",
             producer_element = e
         )
@@ -571,7 +571,7 @@ class ElementUnitTests(TestCase):
             sid = "au-4",
             sid_class = "NIST_SP-800-53_rev4",
             body = "This is the first test statement.",
-            statement_type = "control_implementation_prototype",
+            statement_type=StatementTypeEnum.CONTROL_IMPLEMENTATION_PROTOTYPE.value,
             status = "Implemented",
             producer_element = e
         )
@@ -1031,7 +1031,7 @@ class ControlTestHelper(object):
             sid_class='NIST_SP-800-53_rev4',
             pid='a',
             body='This is a sample statement',
-            statement_type="control_implementation_prototype",
+            statement_type=StatementTypeEnum.CONTROL_IMPLEMENTATION.value,
             producer_element=component,
             import_record=import_record,
         )

--- a/controls/tests.py
+++ b/controls/tests.py
@@ -163,7 +163,7 @@ class ControlUITests(SeleniumTest):
                 'NIST_SP-800-53_rev5_catalog.json',
                 'NIST_SP-800-171_rev1_catalog.json'
             ], "files")
-            # asserts...
+
             self.assertEqual(len(extended_files), 4)
 
             extended_keys = Catalogs.extend_external_catalogs(self, [
@@ -194,7 +194,7 @@ class ControlUITests(SeleniumTest):
             'NIST_SP-800-53_rev4_baselines.json',
             'NIST_SP-800-171_rev1_baselines.json'
         ], "files")
-            # asserts...
+
             self.assertEqual(len(extended_files), 3)
 
             extended_keys = Baselines.extend_external_baselines(self, [

--- a/controls/views.py
+++ b/controls/views.py
@@ -738,7 +738,7 @@ class ComponentImporter(object):
                         sid_class=catalog_key,
                         pid=get_control_statement_part(stmnt_id),
                         body=description,
-                        statement_type="control_implementation_prototype",
+                        statement_type=StatementTypeEnum.CONTROL_IMPLEMENTATION.value,
                         remarks=remarks,
                         status=implemented_control['status'] if 'status' in implemented_control else None,
                         producer_element=parent_component,
@@ -778,7 +778,7 @@ def add_selected_components(system, import_record):
         for imported_component in imported_components:
             # Loop through element's prototype statements and add to control implementation statements
             for smt in Statement.objects.filter(producer_element_id=imported_component.id,
-                                                statement_type="control_implementation_prototype"):
+                                                statement_type=StatementTypeEnum.CONTROL_IMPLEMENTATION.value):
                 # Add all existing control statements for a component to a system even if system does not use controls.
                 # This guarantees that control statements are associated.
                 # The selected controls will serve as the primary filter on what content to display.
@@ -898,11 +898,11 @@ def component_library_component(request, element_id):
     smt_query = request.GET.get('search')
 
     if smt_query:
-        impl_smts = element.statements_produced.filter(sid__icontains=smt_query, statement_type="control_implementation_prototype")
+        impl_smts = element.statements_produced.filter(sid__icontains=smt_query, statement_type=StatementTypeEnum.CONTROL_IMPLEMENTATION.value)
     else:
         # Retrieve impl_smts produced by element and consumed by system
         # Get the impl_smts contributed by this component to system
-        impl_smts = element.statements_produced.filter(statement_type="control_implementation_prototype")
+        impl_smts = element.statements_produced.filter(statement_type=StatementTypeEnum.CONTROL_IMPLEMENTATION.value)
 
     if len(impl_smts) < 1:
         context = {
@@ -1962,7 +1962,7 @@ def add_system_component(request, system_id):
         # Redirect to selected element page
         return HttpResponseRedirect("/systems/{}/components/selected".format(system_id))
 
-    smts = Statement.objects.filter(producer_element_id = producer_element.id, statement_type="control_implementation_prototype")
+    smts = Statement.objects.filter(producer_element_id = producer_element.id, statement_type=StatementTypeEnum.CONTROL_IMPLEMENTATION.value)
 
     # Component does not have any statements of type control_implementation_prototype to
     # add to system. So we cannot add the component (element) to the system.
@@ -1974,14 +1974,14 @@ def add_system_component(request, system_id):
         return HttpResponseRedirect("/systems/{}/components/selected".format(system_id))
 
     # Loop through element's prototype statements and add to control implementation statements
-    for smt in Statement.objects.filter(producer_element_id = producer_element.id, statement_type="control_implementation_prototype"):
+    for smt in Statement.objects.filter(producer_element_id = producer_element.id, statement_type=StatementTypeEnum.CONTROL_IMPLEMENTATION.value):
         # Add all existing control statements for a component to a system even if system does not use controls.
         # This guarantees that control statements are associated.
         # The selected controls will serve as the primary filter on what content to display.
         smt.create_instance_from_prototype(system.root_element.id)
 
     # Make sure some controls were added to the system. Report error otherwise.
-    smts_added = Statement.objects.filter(producer_element_id = producer_element.id, consumer_element_id = system.root_element.id, statement_type="control_implementation")
+    smts_added = Statement.objects.filter(producer_element_id = producer_element.id, consumer_element_id = system.root_element.id, statement_type=StatementTypeEnum.CONTROL_IMPLEMENTATION.value)
 
     smts_added_count = len(smts_added)
     if smts_added_count > 0:
@@ -2211,7 +2211,7 @@ class EditorAutocomplete(View):
                 for related_element in form_values['relatedcomps']:
 
                     # Look up the element
-                    for smt in Statement.objects.filter(id=related_element, statement_type="control_implementation"):
+                    for smt in Statement.objects.filter(id=related_element, statement_type=StatementTypeEnum.CONTROL_IMPLEMENTATION.value):
                         logger.info(
                             f"Adding an element with the id {smt.id} and sid class {smt.sid} to system_id {system_id}")
                         # Only add statements for controls selected for system

--- a/guidedmodules/module_logic.py
+++ b/guidedmodules/module_logic.py
@@ -324,7 +324,7 @@ def oscal_context(answers):
 
     # collect all the control implementation statements
     statements = system.root_element.statements_consumed \
-                                    .filter(statement_type="control_implementation") \
+                                    .filter(statement_type=StatementTypeEnum.CONTROL_IMPLEMENTATION.value) \
                                     .order_by('sid')
 
     # and all the project's organizational parameters

--- a/guidedmodules/views.py
+++ b/guidedmodules/views.py
@@ -482,14 +482,14 @@ def save_answer(request, task, answered, context, __):
                         )
                         # Set fisma_impact_level statement
                         if baseline.lower() in ["low", "moderate", "high"]:
-                            fisma_impact_level = system.set_fisma_impact_level(baseline)
+                            fisma_impact_level, smt = system.set_fisma_impact_level(baseline)
                             if fisma_impact_level == baseline.lower():
                                 messages.add_message(request, messages.INFO,
                                                               f'I\'ve set the system FISMA impact level to "{fisma_impact_level}.')
                                 # Log setting fisma_impact_level
                                 logger.info(
                                     event=f"system assign_fisma_impact_level {fisma_impact_level}",
-                                    object={"object": "system", "id": system.id, "name": system.root_element.name},
+                                    object={"object": "system", "id": system.id, "name": system.root_element.name, "statementid": smt.id},
                                     user={"id": request.user.id, "username": request.user.username}
                                 )
                             else:

--- a/guidedmodules/views.py
+++ b/guidedmodules/views.py
@@ -8,6 +8,7 @@ from django.db import transaction
 
 import re
 
+from controls.enums.statements import StatementTypeEnum
 from discussion.validators import validate_file_extension
 from .models import Module, ModuleQuestion, Task, TaskAnswer, TaskAnswerHistory, InstrumentationEvent
 
@@ -550,7 +551,7 @@ def save_answer(request, task, answered, context, __):
                                 # Go to next element
                                 continue
 
-                            smts = Statement.objects.filter(producer_element_id = producer_element.id, statement_type="control_implementation_prototype")
+                            smts = Statement.objects.filter(producer_element_id = producer_element.id, statement_type=StatementTypeEnum.CONTROL_IMPLEMENTATION.value)
 
                             # Component does not have any statements of type control_implementation_prototype to
                             # add to system. So we cannot add the component (element) to the system.
@@ -564,14 +565,14 @@ def save_answer(request, task, answered, context, __):
                             # If we get here, we are going to add the element to the system
                             # We add an element to a system by adding copies of the element's statements
                             # Loop through element's prototype statements and add to control implementation statements
-                            for smt in Statement.objects.filter(producer_element_id = producer_element.id, statement_type="control_implementation_prototype"):
+                            for smt in Statement.objects.filter(producer_element_id = producer_element.id, statement_type=StatementTypeEnum.CONTROL_IMPLEMENTATION.value):
                                 # Add all existing control statements for a component to a system even if system does not use controls.
                                 # This guarantees that control statements are associated.
                                 # The selected controls will serve as the primary filter on what content to display.
                                 smt.create_instance_from_prototype(system.root_element.id)
 
                             # Get a count of control statements added to the system.
-                            smts_added = Statement.objects.filter(producer_element_id = producer_element.id, consumer_element_id = system.root_element.id, statement_type="control_implementation")
+                            smts_added = Statement.objects.filter(producer_element_id = producer_element.id, consumer_element_id = system.root_element.id, statement_type=StatementTypeEnum.CONTROL_IMPLEMENTATION.value)
                             smts_added_count = len(smts_added)
                             # Prepare message
                             if smts_added_count > 0:
@@ -585,9 +586,9 @@ def save_answer(request, task, answered, context, __):
                     if a_verb == "del_role":
                         for producer_element in elements_with_role:
                             # Delete component from system
-                            smts_assigned_count = len(Statement.objects.filter(producer_element_id = producer_element.id, consumer_element_id = system.root_element.id, statement_type="control_implementation"))
+                            smts_assigned_count = len(Statement.objects.filter(producer_element_id = producer_element.id, consumer_element_id = system.root_element.id, statement_type=StatementTypeEnum.CONTROL_IMPLEMENTATION.value))
                             if smts_assigned_count > 0:
-                                Statement.objects.filter(producer_element_id = producer_element.id, consumer_element_id = system.root_element.id, statement_type="control_implementation").delete()
+                                Statement.objects.filter(producer_element_id = producer_element.id, consumer_element_id = system.root_element.id, statement_type=StatementTypeEnum.CONTROL_IMPLEMENTATION.value).delete()
                                 messages.add_message(request, messages.INFO,
                                                      f'I\'ve deleted "{producer_element.name}" and its {smts_assigned_count} control implementation statements from the system.')
 

--- a/siteapp/tests.py
+++ b/siteapp/tests.py
@@ -29,6 +29,7 @@ from django.contrib.staticfiles.testing import StaticLiveServerTestCase
 # StaticLiveServerTestCase can server static files but you have to make sure settings have DEBUG set to True
 from django.utils.crypto import get_random_string
 
+from controls.enums.statements import StatementTypeEnum
 from guidedmodules.tests import TestCaseWithFixtureData
 from siteapp.models import (Organization, Portfolio, Project,
                             ProjectMembership, User)
@@ -1475,6 +1476,6 @@ class ProjectPageTests(OrganizationSiteFunctionalTests):
         self.click_element('#btn-project-home')
         # See if project page has changed
         wait_for_sleep_after( lambda: self.assertInNodeText("low", "#systems-fisma-impact-level") )
-        impact_level_smts = project.system.root_element.statements_consumed.filter(statement_type="fisma_impact_level")
+        impact_level_smts = project.system.root_element.statements_consumed.filter(statement_type=StatementTypeEnum.FISMA_IMPACT_LEVEL.value)
         self.assertEqual(impact_level_smts.count(), 1)
 

--- a/siteapp/tests.py
+++ b/siteapp/tests.py
@@ -1475,4 +1475,6 @@ class ProjectPageTests(OrganizationSiteFunctionalTests):
         self.click_element('#btn-project-home')
         # See if project page has changed
         wait_for_sleep_after( lambda: self.assertInNodeText("low", "#systems-fisma-impact-level") )
+        impact_level_smts = project.system.root_element.statements_consumed.filter(statement_type="fisma_impact_level")
+        self.assertEqual(impact_level_smts.count(), 1)
 

--- a/siteapp/views.py
+++ b/siteapp/views.py
@@ -22,6 +22,7 @@ from django.views.generic import ListView
 from guardian.decorators import permission_required_or_403
 from guardian.shortcuts import get_perms_for_model, get_perms, assign_perm
 
+from controls.enums.statements import StatementTypeEnum
 from controls.forms import ImportProjectForm
 from controls.views import add_selected_components
 from discussion.models import Discussion
@@ -972,7 +973,7 @@ def project(request, project):
         approx_compliance_degrees = 358
 
     # Fetch statement defining FISMA impact level if set
-    impact_level_smts = project.system.root_element.statements_consumed.filter(statement_type="fisma_impact_level")
+    impact_level_smts = project.system.root_element.statements_consumed.filter(statement_type=StatementTypeEnum.FISMA_IMPACT_LEVEL.value)
     if len(impact_level_smts) > 0:
         impact_level = impact_level_smts[0].body
     else:


### PR DESCRIPTION
Backwards compatibility issue with enum keys upper case when filtering by statement type throughout the rest of the code base.