### PR TITLE
Fix system ctl detail page err; Improve creating smt from prototypes

### DIFF
--- a/controls/models.py
+++ b/controls/models.py
@@ -127,23 +127,16 @@ class Statement(auto_prefetch.Model):
         self.save()
         return self.prototype
 
-    def create_instance_from_prototype(self, consumer_element_id):
+    def create_system_control_smt_from_component_prototype_smt(self, consumer_element_id):
         """Creates a control_implementation statement instance for a system's root_element from an existing control implementation prototype statement"""
 
-        # TODO: Check statement is a prototype
+        # Check statement is a prototype
+        if self.statement_type != StatementTypeEnum.CONTROL_IMPLEMENTATION_PROTOTYPE.value:
+            return None
 
-        # System already has instance of the control_implementation statement
-        # TODO: write check for this logic
-        # Get all statements for consumer element so we can identify
-        smts_existing = Statement.objects.filter(consumer_element__id = consumer_element_id, statement_type=StatementTypeEnum.CONTROL_IMPLEMENTATION.value).select_related('prototype')
-
-        # Get prototype ids for all consumer element statements
-        smts_existing_prototype_ids = [smt.prototype.id for smt in smts_existing]
-        if self.id is smts_existing_prototype_ids:
+        # Return if statement already has instance associated with consumer_element
+        if self.instances.filter(consumer_element__id=consumer_element_id).exists():
             return self.prototype
-
-        #     # TODO:
-        #     # check if prototype content is the same, report error if not, or overwrite if permission approved
 
         instance = deepcopy(self)
         instance.statement_type=StatementTypeEnum.CONTROL_IMPLEMENTATION.value

--- a/controls/tests.py
+++ b/controls/tests.py
@@ -1,4 +1,4 @@
-# This module defines a SeleniumTest class that is used here and in
+
 # the discussion app to run Selenium and Chrome-based functional/integration
 # testing.
 #
@@ -614,7 +614,6 @@ class ElementUnitTests(TestCase):
         self.assertTrue(e2.component_type == "hardware")
         self.assertTrue(e2.component_state == "disposition")
 
-
 class ElementControlUnitTests(TestCase):
 
     def test_assign_baseline(self):
@@ -671,7 +670,6 @@ class ElementControlUnitTests(TestCase):
 
         # Even with two elements there is still only one element with a role
         self.assertEqual(ele.roles.values_list('role', flat=True).count(), 1)
-
 
 class SystemUnitTests(TestCase):
     def test_system_create(self):
@@ -1020,6 +1018,27 @@ class ControlComponentTests(OrganizationSiteFunctionalTests):
         # Add component statement
         submit_comp_statement = wait_for_sleep_after(lambda: self.browser.find_element_by_xpath("//*[@id='relatedcompModal']/div/div[1]/div[4]/button"))
         submit_comp_statement.click()
+
+class ProjectControlTests(OrganizationSiteFunctionalTests):
+
+    def test_project_controls_selected(self):
+
+        # login as the first user and create a new project
+        self._login()
+        self._new_project()
+
+        project = Project.objects.all().last()
+        system = project.system
+        # Assign low baseline
+        result = system.root_element.assign_baseline_controls(self.user, 'NIST_SP-800-53_rev4', 'low')
+        # Add component(s)
+
+        self.navigateToPage(f"/systems/{system.id}/controls/selected")
+        # var_sleep(10)
+
+        wait_for_sleep_after(lambda: self.assertInNodeText("Selected controls", "#tab-content"))
+
+    # def test_project_control_page(self):
 
 class ControlTestHelper(object):
 

--- a/guidedmodules/views.py
+++ b/guidedmodules/views.py
@@ -562,14 +562,11 @@ def save_answer(request, task, answered, context, __):
                                 # Go to next element
                                 continue
 
-                            # If we get here, we are going to add the element to the system
-                            # We add an element to a system by adding copies of the element's statements
-                            # Loop through element's prototype statements and add to control implementation statements
+                            # Add the element to the system by adding copies of the element's statements associated with system's root element
+                            # Loop through all element's prototype statements and add to control implementation statements.
+                            # System's selected controls will filter what controls and control statements to display.
                             for smt in Statement.objects.filter(producer_element_id = producer_element.id, statement_type=StatementTypeEnum.CONTROL_IMPLEMENTATION_PROTOTYPE.value):
-                                # Add all existing control statements for a component to a system even if system does not use controls.
-                                # This guarantees that control statements are associated.
-                                # The selected controls will serve as the primary filter on what content to display.
-                                smt.create_instance_from_prototype(system.root_element.id)
+                                smt.create_system_control_smt_from_component_prototype_smt(system.root_element.id)
 
                             # Get a count of control statements added to the system.
                             smts_added = Statement.objects.filter(producer_element_id = producer_element.id, consumer_element_id = system.root_element.id, statement_type=StatementTypeEnum.CONTROL_IMPLEMENTATION.value)


### PR DESCRIPTION
Refactor creating system control statements from component library
prototype statements when adding a component from the library to a system
and reduce by an order a magnitude the time it takes to add a component to system.

Rename smt.create_instance_from_prototype to smt.create_system_control_smt_from_component_prototype_smt

Fix bug breaking rendering of system's control detail page by
removing an errant login_required decorator on a function.
Add test for system control page. Will add test(s) for system control detail page.