### PR TITLE
Automatically clear, refresh output document content downloading docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ v999 (May XX, 2021)
 
 * Can now edit a system componet's state and type in the detail page for a selected component.
 * Improve project pages appearance: decrease action button width and left align text; widen from 9 to 10 columns main content.
+* Remove "Refresh Documents" button on task finished page because caches are now automatically cleared and document content refreshed.
 
 **Developer changes**
 
@@ -21,6 +22,7 @@ v999 (May XX, 2021)
 * Add management command `importcomponents` to batch import OSCAL components to library.
 * Add `existing_import_record` to importing and creating components to group multiple imports under the same import record.
 * Improve generation of components in OSCAL model by removing certain keys when values are none as per specification.
+* Task caches are now automatically cleared and document content refreshed when document downloaded.
 
 
 v0.9.3.5.3 (May 16, 2021)

--- a/templates/task-finished.html
+++ b/templates/task-finished.html
@@ -138,9 +138,6 @@
               <a role="button" data-toggle="collapse" data-parent="#accordion" href="#your-answers-body-2" aria-expanded="true" aria-controls="your-answers-body-2">
                 Available documents
               </a>
-              <div class="pull-right">
-                <button type="button" id="force-refresh" class="btn btn-warning btn-xs" onclick="refresh_output_doc({{project.root_task.module.app.id}});return false;"> Refresh documents <span class="glyphicon glyphicon-refresh"></span></button>
-              </div>
             </h4>
           </div>
           <div id="your-answers-body-2" class="panel-collapse collapse in" role="tabpanel" aria-labelledby="your-answers-title-2">
@@ -366,26 +363,5 @@
     });
   }
 
-  function refresh_output_doc(app_id) {
-      if (upgrade_app_option_confirm
-         {% if is_question_page %}
-         && !confirm("All instances of '{{task.project.root_task.title}}' will be updated.\n\nAre you sure you want to upgrade?"))
-         {% else %}
-         && !confirm("Force refresh of output document(s) in '{{project.root_task.title}}'?"))
-         {% endif %}
-        return;
-      ajax_with_indicator({
-          url: "/tasks/_refresh-output-doc",
-          method: "POST",
-          data: {
-            app: app_id,
-            force: upgrade_app_option_force ? "true" : "false"
-          },
-          keep_indicator_forever: true, // keep the ajax indicator up forever --- it'll go away when we issue the redirect or reload
-          success: function(res) {
-            location.reload();
-          }
-      })
-    }
   </script>
 {% endblock %}


### PR DESCRIPTION
Performnce of document generation now sufficiently fast
to not require cache and manual "Refresh documents" button.