### PR TITLE
Batch update cntl impl smts when component_statement changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ v999 (May XX, 2021)
 * Can now edit a system componet's state and type in the detail page for a selected component.
 * Improve project pages appearance: decrease action button width and left align text; widen from 9 to 10 columns main content.
 * Remove "Refresh Documents" button on task finished page because caches are now automatically cleared and document content refreshed.
+* Display system component component_state and component_type when component is listed for a system.
 
 **Developer changes**
 
@@ -25,6 +26,7 @@ v999 (May XX, 2021)
 * Task caches are now automatically cleared and document content refreshed when document downloaded.
 * Add test for system control page.
 * Refactor creating system control statements from component library prototype statements when adding a component from the library to a system and reduce by an order a magnitude the time it takes to add a component to system.
+* Create System method to batch update an element's control implementation statements based on the component's state.
 
 **Bug fix**
 

--- a/controls/models.py
+++ b/controls/models.py
@@ -723,6 +723,12 @@ class System(auto_prefetch.Model):
 
     producer_elements = cached_property(get_producer_elements)
 
+    def set_component_control_status(self, element, status):
+        """Batch update status of system control implementation statements for a specific element."""
+
+        self.root_element.statements_consumed.filter(producer_element=element, statement_type=StatementTypeEnum.CONTROL_IMPLEMENTATION.value).update(status=status)
+        return True
+
 class CommonControlProvider(models.Model):
     name = models.CharField(max_length=150, help_text="Name of the CommonControlProvider", unique=False)
     description = models.CharField(max_length=255, help_text="Brief description of the CommonControlProvider", unique=False)

--- a/siteapp/static/css/govready-q.css
+++ b/siteapp/static/css/govready-q.css
@@ -295,6 +295,8 @@ form #id_json_content { width: 100%; overflow: auto !important; } /* The !import
 
 .component-tag { font-size: 0.7em; color: #999; padding: 0px 6px 0px 6px; border: 1px solid #bbb; border-radius: 24px; }
 .component-tag a { color: #999; }
+.component-state { font-size: 0.8em; color: #444; padding: 0px 6px 0px 6px; border: 1px solid #bbb; border-radius: 24px; }
+.component-type { font-size: 0.8em; color: #444; padding: 0px 6px 0px 6px; border: 1px solid #bbb; border-radius: 24px; }
 
 .component-form {
  float: left;

--- a/templates/controls/editor.html
+++ b/templates/controls/editor.html
@@ -174,7 +174,12 @@
                                     <div class="row statement-text">
                                       <div class="col-xs-3 col-sm-3 col-md-3 col-lg-3 col-xl-3">
                                         <span id="producer_element-{{ forloop.counter }}-control" class="control-id-text">{{ smt.producer_element.name }}</span>
+                                        <div>
+                                            <span class="component-type">{{ smt.producer_element.component_type }}</span>
+                                            <span class="component-state">{{ smt.producer_element.component_state }}</span>
+                                        </div>
                                       </div>
+                                      <div>
                                       <div class="col-xs-6 col-sm-6 col-md-6 col-lg-6 col-xl-6 statement-text-block">{% if smt.pid is not None and smt.pid != "" %}<div class="panel-heading-smt">{{ smt.pid }}.</div>{% endif %}{{ smt.body }}</div>
                                       <div class="col-xs-3 col-sm-3 col-md-3 col-lg-3 col-xl-3 remark-text-block">
                                         {% spaceless %}

--- a/templates/systems/components_selected.html
+++ b/templates/systems/components_selected.html
@@ -45,10 +45,14 @@
             {% for component in system_elements %}
                 {# Each "component" is a Element model object. #}
                     <div id="tab-content" class="row row-control">
-                        <div id="" class="col-xs-4 col-sm-4 col-md-4 col-lg-4 col-xl-4">
+                        <div id="" class="col-xs-3 col-sm-3 col-md-3 col-lg-3 col-xl-3">
                             <a href={% url 'system_element' system_id=system.id element_id=component.id %}>{{ component.name }}</a>
                         </div>
-                        <div id="" class="col-xs-5 col-sm-5 col-md-5 col-lg-5 col-xl-5">
+                        <div id="" class="col-xs-2 col-sm-2 col-md-2 col-lg-2 col-xl-2">
+                            <span class="component-type">{{ component.component_type }}</span>
+                            <span class="component-state">{{ component.component_state }}</span>
+                        </div>
+                        <div id="" class="col-xs-4 col-sm-4 col-md-4 col-lg-4 col-xl-4">
                             {% if component.description %}{{ component.description }}{% else %}<span class="not-provided">No description provided.</span>{% endif %}
                             <div>{% for tag in component.tags.all %}<span class="component-tag">{{ tag.label }}</span> {% endfor %}</div>
                         </div>
@@ -57,13 +61,12 @@
                             <span class="pull-right">{% if ctl_count %}{{ ctl_count }} control{{ ctl_count|pluralize }}</span>{% else %}None{% endif %}
                         </div>
                     {% endwith %}
-
                     {% get_obj_perms request.user for system as "system_perms" %}
                     {% if "change_system" in system_perms %}
                         <div id="" class="col-xs-1 col-sm-1 col-md-1 col-lg-1 col-xl-1 pull-right">
                             <a href="{% url 'system_element_remove' system_id=system.id element_id=component.id %}">
                               <small>
-                              <span class="glyphicon glyphicon-trash" title="remove component"></span>
+                              <span class="glyphicon glyphicon-trash pull-right" title="remove component"></span>
                               </small>
                           </a>
                         </div>


### PR DESCRIPTION
Implemented a faster way to update status of system controls.
When user sets a system component state to "operational" all statements
associated with that component for the system get their status set to
"Implemented". Similarly, setting component’s state to "planned" batch
sets all component statements for that system to "Planned", and
"under-development" sets component statements to "Partially Implemented".

Display system component component_state and component_type when
component is listed for a system.