### PR TITLE
Add 'Create a template' button to template library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ v999 (May XX, 2021)
 * Improve project pages appearance: decrease action button width and left align text; widen from 9 to 10 columns main content.
 * Remove "Refresh Documents" button on task finished page because caches are now automatically cleared and document content refreshed.
 * Display system component component_state and component_type when component is listed for a system.
+* Add "Create a template" button to template library so admins can create a new template (e.g., compliance app).
 
 **Developer changes**
 

--- a/guidedmodules/stubs/q-files/stub_app/app.yaml
+++ b/guidedmodules/stubs/q-files/stub_app/app.yaml
@@ -22,10 +22,5 @@ questions:
     title: Example Module
     type: module
     module-id: example
-input:
-  - id: my_input_id
-    name: My Component
-    type: oscal
-    path: components/my_component.json
-    group: OSCAL Components
+input: []
 output: []

--- a/guidedmodules/views.py
+++ b/guidedmodules/views.py
@@ -1,5 +1,6 @@
 from django.shortcuts import render, redirect, get_object_or_404
 from django.http import Http404, HttpResponse, HttpResponseRedirect, HttpResponseForbidden, JsonResponse, HttpResponseNotAllowed
+from django.urls import reverse
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required, permission_required
 from django.conf import settings
@@ -1385,10 +1386,9 @@ def authoring_create_q(request):
     except Exception as e:
         raise
 
-    from django.contrib import messages
     messages.add_message(request, messages.INFO, 'New Project "{}" added into the catalog.'.format(new_q["title"]))
 
-    return JsonResponse({ "status": "ok", "redirect": "{% url 'store' %}" })
+    return JsonResponse({ "status": "ok", "redirect": "/store" })
 
 @login_required
 def refresh_output_doc(request):

--- a/templates/app-store.html
+++ b/templates/app-store.html
@@ -111,10 +111,9 @@ Compliance Apps
         <form class="form-inline" onsubmit="return false;">
           <div class="form-group">
             {% if authoring_tool_enabled %}
-{#                commenting out for now until fully implemented#}
-{#            <span class="create-new-project">#}
-{#              <a id="new-project" href="#" class="btn btn-success" onclick="authoring_tool_create_q_form('argument'); return false;">Create App Source</a>#}
-{#            </span>#}
+            <span class="create-new-project">
+              <a id="new-project" href="#" class="btn btn-success" onclick="authoring_tool_create_q_form('argument'); return false;">Create a template</a>
+            </span>
             {% endif %}
             <label class="sr-only" for="app-search">search apps for</label>
             <div class="input-group">
@@ -122,6 +121,7 @@ Compliance Apps
               <input type="text" class="form-control" id="app-search" placeholder="search compliance apps">
             </div>
           </div>
+          &nbsp;&nbsp;
         </form>
       </div>
 

--- a/templates/authoring-tool-modal.html
+++ b/templates/authoring-tool-modal.html
@@ -354,7 +354,7 @@ label {
       <div class="modal-header modal-header-authoring">
         <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
         <h4 class="modal-title" id="questionnaire_authoring_tool_title">
-          Create New Project
+          Create New Template
         </h4>
       </div>
       <div class="modal-body">


### PR DESCRIPTION
Add "Create a template" button to template library so admins can create a new template (e.g., compliance app).