### PR TITLE
Content-Security-Policy header permit images (*), videos youtube, vimeo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ v999 (May XX, 2021)
 * Refactor creating system control statements from component library prototype statements when adding a component from the library to a system and reduce by an order a magnitude the time it takes to add a component to system.
 * Create System method to batch update an element's control implementation statements based on the component's state.
 
+**Deployment changes**
+
+* The HTTP Content-Security-Policy header is now set to allow browsers to load third-party videos from YouTube.com, Vimeo.com and images from any source.
+
 **Bug fix**
 
 * Fix OSCAL SSP output template failure where statement didn't exist while exporting to OSCAL.

--- a/siteapp/middleware.py
+++ b/siteapp/middleware.py
@@ -27,7 +27,8 @@ class ContentSecurityPolicyMiddleware:
         # * we're definitely using inline scripts and CSS throughout our templates, but that could be refactored
         response = self.next_middleware(request)
         response['Content-Security-Policy'] = \
-            "default-src 'self' data:; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'"
+            "default-src 'self' data:; script-src 'self' https://apis.google.com 'unsafe-inline'; style-src 'self' 'unsafe-inline'; \
+            child-src https://youtube.com https://www.youtube.com https://player.vimeo.com https://vimeo.com; img-src * data: blob: 'unsafe-inline';"
         return response
 
 def QTemplateContextProcessor(request):


### PR DESCRIPTION
Adjust Content-Security-Policy header permit images from any source and videos from youtube, vimeo. This is to allow videos and pictures to be embedded in the questions.