### PR TITLE
Display systems using a component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ v999 (May XX, 2021)
 * Remove "Refresh Documents" button on task finished page because caches are now automatically cleared and document content refreshed.
 * Display system component component_state and component_type when component is listed for a system.
 * Add "Create a template" button to template library so admins can create a new template (e.g., compliance app).
+* Add tab to component library component detail page to display list of systems containing the component.
 
 **Developer changes**
 
@@ -28,6 +29,8 @@ v999 (May XX, 2021)
 * Add test for system control page.
 * Refactor creating system control statements from component library prototype statements when adding a component from the library to a system and reduce by an order a magnitude the time it takes to add a component to system.
 * Create System method to batch update an element's control implementation statements based on the component's state.
+* Always display OSCAL tab in component library for component detail (rather than conditional on 'enable_experimental_opencontrol' parameter).
+* Add method controls.element.consuming_systems to produce list of systems consuming (e.g., containing) the element.
 
 **Deployment changes**
 

--- a/controls/models.py
+++ b/controls/models.py
@@ -333,8 +333,8 @@ class Element(auto_prefetch.Model, TagModelMixin):
     def consuming_systems(self):
         """Return list of systems for which Element is producer_element of statement of type control_implementation"""
 
-        root_element_ids = set([ce['consumer_element'] for ce in Statement.objects.filter(producer_element=self).values('consumer_element').distinct()])
-        systems = [Element.objects.get(pk=root_element_id).system.all()[0] for root_element_id in root_element_ids if root_element_id]
+        root_element_ids = set(filter(None, [ce['consumer_element'] for ce in Statement.objects.filter(producer_element=self).values('consumer_element').distinct()]))
+        systems = System.objects.filter(pk__in=Element.objects.filter(pk__in=root_element_ids).values_list('system', flat=True))
         # Remove orphaned systems (e.g., systems whose projects have been deleted). See issue https://github.com/GovReady/govready-q/issues/1617
         systems_with_projects = []
         for s in systems:

--- a/controls/models.py
+++ b/controls/models.py
@@ -338,7 +338,7 @@ class Element(auto_prefetch.Model, TagModelMixin):
         # Remove orphaned systems (e.g., systems whose projects have been deleted). See issue https://github.com/GovReady/govready-q/issues/1617
         systems_with_projects = []
         for s in systems:
-            if len(s.projects.all()) > 0:
+            if s.projects.exists():
                 systems_with_projects.append(s)
         systems_with_projects.sort(key=lambda x: x.root_element.name)
         return systems_with_projects

--- a/controls/views.py
+++ b/controls/views.py
@@ -995,6 +995,9 @@ def component_library_component(request, element_id):
     element = Element.objects.get(id=element_id)
     smt_query = request.GET.get('search')
 
+    # Retrieve systems consuming element
+    consuming_systems = element.consuming_systems()
+
     if smt_query:
         impl_smts = element.statements_produced.filter(sid__icontains=smt_query, statement_type=StatementTypeEnum.CONTROL_IMPLEMENTATION_PROTOTYPE.value)
     else:
@@ -1048,6 +1051,7 @@ def component_library_component(request, element_id):
     context = {
         "page_obj": page_obj,
         "element": element,
+        "consuming_systems": consuming_systems,
         "impl_smts": impl_smts,
         "catalog_controls": catalog_controls,
         "catalog_key": catalog_key,

--- a/templates/components/element_detail_tabs.html
+++ b/templates/components/element_detail_tabs.html
@@ -63,6 +63,9 @@
 
   .statement-text, .description-text { font-size: 0.8em; }
 
+  .consuming-systems {margin: 1.0em 0 0.5em 0; }
+  .consuming-system {margin: 0 0 0.5em 12px; }
+
   .control-id-text { font-weight: bold; }
 
 </style>
@@ -106,9 +109,8 @@
     <!-- Nav tabs -->
     <ul class="nav nav-tabs" role="tablist">
       <li id="smt-tab" role="presentation" class="active"><a href="#component_controls" aria-controls="component_controls" role="tab" data-toggle="tab"><span class="glyphicon glyphicon-wrench"></span> Control Implementation Statements  &nbsp;<div id="common-tab-count">{{ impl_smts|length }}</div></a></li>
-      {% if enable_experimental_opencontrol %}
+      <li id="systems-tab" role="presentation"><a href="#systems" aria-controls="systems" role="tab" data-toggle="tab"><span class="glyphicon glyphicon-file"></span> Systems </a></li>
       <li id="oscal-tab" role="presentation"><a href="#oscal" aria-controls="oscal" role="tab" data-toggle="tab"><span class="glyphicon glyphicon-file"></span> OSCAL </a></li>
-      {% endif %}
       {% if enable_experimental_opencontrol %}
       <li id="opencontrol-tab" role="presentation"><a href="#opencontrol" aria-controls="opencontrol" role="tab" data-toggle="tab"><span class="glyphicon glyphicon-file"></span> OpenControl </a></li>
       {% endif %}
@@ -264,6 +266,38 @@
         </div>
 
 
+      </div>
+
+      <!-- Tab panel: systems -->
+      <div role="tabpanel" class="tab-pane active" id="systems">
+
+        <div class="row">
+          <div class="col-xs-8 col-sm-8 col-md-8 col-lg-8 col-xl-8">
+            <h3>Systems Using {{ element.name }}</h3>
+
+            <div>{% for tag in element.tags.all %}<span class="component-tag"><a href="{% url 'component_library' %}?search={{ tag.label }}">{{ tag.label }}</a></span> {% endfor %}</div>
+
+            <div class="consuming-systems">
+              {% if consuming_systems|length > 0 %}
+                <div>The component "{{ element.name }}" is currently used by {{ consuming_systems|length }} systems.</div>
+                <div>&nbsp;</div>
+                  {% for cs in consuming_systems %}
+                      <div class="consuming-system">
+                        <a class=""
+                           href={% url 'system_element' system_id=cs.id element_id=element.id %}>
+                           {% for p in cs.projects.all %}
+                            <img id="project-icon" src="{{ p.root_task.get_app_icon_url }}" alt="Project Icon" height="24">
+                           {% endfor %}
+                          {{ cs.root_element.name }}
+                          </a>
+                      </div>
+                  {% endfor %}
+              {% else %}
+                <div>The component "{{ element.name }}"" is not currently used by any system.</div>
+              {% endif %}
+            </div>
+          </div>
+        </div>
       </div>
 
       <!-- Tab panel: combined -->

--- a/templates/components/element_detail_tabs.html
+++ b/templates/components/element_detail_tabs.html
@@ -109,7 +109,7 @@
     <!-- Nav tabs -->
     <ul class="nav nav-tabs" role="tablist">
       <li id="smt-tab" role="presentation" class="active"><a href="#component_controls" aria-controls="component_controls" role="tab" data-toggle="tab"><span class="glyphicon glyphicon-wrench"></span> Control Implementation Statements  &nbsp;<div id="common-tab-count">{{ impl_smts|length }}</div></a></li>
-      <li id="systems-tab" role="presentation"><a href="#systems" aria-controls="systems" role="tab" data-toggle="tab"><span class="glyphicon glyphicon-file"></span> Systems </a></li>
+      <li id="systems-tab" role="presentation"><a href="#systems" aria-controls="systems" role="tab" data-toggle="tab"><span class="glyphicon glyphicon-file"></span> Systems  &nbsp;<div id="common-tab-count">{{ consuming_systems|length }}</div></a></li>
       <li id="oscal-tab" role="presentation"><a href="#oscal" aria-controls="oscal" role="tab" data-toggle="tab"><span class="glyphicon glyphicon-file"></span> OSCAL </a></li>
       {% if enable_experimental_opencontrol %}
       <li id="opencontrol-tab" role="presentation"><a href="#opencontrol" aria-controls="opencontrol" role="tab" data-toggle="tab"><span class="glyphicon glyphicon-file"></span> OpenControl </a></li>
@@ -273,14 +273,10 @@
 
         <div class="row">
           <div class="col-xs-8 col-sm-8 col-md-8 col-lg-8 col-xl-8">
-            <h3>Systems Using {{ element.name }}</h3>
-
-            <div>{% for tag in element.tags.all %}<span class="component-tag"><a href="{% url 'component_library' %}?search={{ tag.label }}">{{ tag.label }}</a></span> {% endfor %}</div>
+            <h3>Systems</h3>
 
             <div class="consuming-systems">
               {% if consuming_systems|length > 0 %}
-                <div>The component "{{ element.name }}" is currently used by {{ consuming_systems|length }} systems.</div>
-                <div>&nbsp;</div>
                   {% for cs in consuming_systems %}
                       <div class="consuming-system">
                         <a class=""
@@ -293,7 +289,7 @@
                       </div>
                   {% endfor %}
               {% else %}
-                <div>The component "{{ element.name }}"" is not currently used by any system.</div>
+                <div>There aren't any systems using the component.</div>
               {% endif %}
             </div>
           </div>


### PR DESCRIPTION
Add method controls.element.consuming_systems to produce list of systems
consuming (e.g., containing) the element.

Add tab to component library component detail page to display list of systems
containing the component.

Also, always display OSCAL tab in component library for component detail
(rather than conditional on 'enable_experimental_opencontrol' parameter).

<img width="1027" alt="Screen Shot 2021-06-15 at 4 41 31 AM" src="https://user-images.githubusercontent.com/24979/122031137-09e83980-cd94-11eb-80f2-159448abc45c.png">

