### PR TITLE
Button, Form for easier adding of an AppSource via uploading zip file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ GovReady-Q Release Notes
 v999 (June XX, 2021)
 --------------------
 
+**UI changes**
+
+* Add "Import AppSource" button for admins in Compliance App store to simplify end-users adding AppSource.
 
 v0.9.4 (June 13, 2021)
 ----------------------

--- a/guidedmodules/urls.py
+++ b/guidedmodules/urls.py
@@ -25,6 +25,7 @@ urlpatterns = [
     url(r'^_authoring_tool/download-app$', guidedmodules.views.authoring_download_app),
     url(r'^_authoring_tool/create-app-project$', guidedmodules.views.authoring_create_q),
     url(r'^_authoring_tool/download-app-project$', guidedmodules.views.authoring_download_app_project),
+    url(r'^_authoring_tool/import-appsource$', guidedmodules.views.authoring_import_appsource),
     url(r'^_upgrade-app$', guidedmodules.views.upgrade_app),
     url(r'^_refresh-output-doc$', guidedmodules.views.refresh_output_doc),
 ]

--- a/siteapp/static/js/authoring_tool.js
+++ b/siteapp/static/js/authoring_tool.js
@@ -297,11 +297,33 @@ function authoring_tool_create_q_form(argument) {
   $('#create_q_authoring_tool').modal();
 }
 
-function  authoring_tool_create_q() {
+function authoring_tool_create_q() {
   var data = $('#create_q_authoring_tool form').serializeArray();
   console.log("data is: "+JSON.stringify(data));
   ajax_with_indicator({
       url: "/tasks/_authoring_tool/create-app-project",
+      method: "POST",
+      data: data,
+      keep_indicator_forever: true, // keep the ajax indicator up forever --- it'll go away when we issue the redirect
+      success: function(res) {
+        // Modal can stay up until the redirect finishes.
+        window.location = res.redirect;
+        if (window.location.hash.length > 1)
+          window.location.reload(); // if there is a # in the URL, the browser won't actually reload
+      }
+  });
+}
+
+function authoring_tool_import_appsource_form(argument) {
+  $('#import_appsource_authoring_tool').modal();
+}
+
+function authoring_tool_import_appsource() {
+  // Use FormData to serialize form object including uploaded file
+  var data = new FormData($('#import_appsource_authoring_tool form')[0]);
+  console.log("data is: "+JSON.stringify(data));
+  ajax_with_indicator({
+      url: "/tasks/_authoring_tool/import-appsource",
       method: "POST",
       data: data,
       keep_indicator_forever: true, // keep the ajax indicator up forever --- it'll go away when we issue the redirect

--- a/templates/app-store.html
+++ b/templates/app-store.html
@@ -114,6 +114,9 @@ Compliance Apps
             <span class="create-new-project">
               <a id="new-project" href="#" class="btn btn-success" onclick="authoring_tool_create_q_form('argument'); return false;">Create a template</a>
             </span>
+            <span class="create-new-project">
+              <a id="import-appsource" href="#" class="btn btn-success" onclick="authoring_tool_import_appsource_form('argument'); return false;">Import AppSource</a>
+            </span>
             {% endif %}
             <label class="sr-only" for="app-search">search apps for</label>
             <div class="input-group">

--- a/templates/authoring-tool-modal.html
+++ b/templates/authoring-tool-modal.html
@@ -373,16 +373,16 @@ label {
             </div>
           </div>
           <div class="form-group">
-            <label for="authoring_tool_q_1_ds" class="col-sm-2 control-label">Category</label>
+            <label for="authoring_tool_q_category" class="col-sm-2 control-label">Category</label>
             <div class="col-sm-9">
-              <input type="text" class="form-control" id="authoring_tool_q_1_ds" name="category" value="Draft">
+              <input type="text" class="form-control" id="authoring_tool_q_category" name="category" value="Draft">
               <span class="help-block small">Ex: Technology, Policy, Drafts, . . .</span>
             </div>
           </div>
           <div class="form-group">
-            <label for="authoring_tool_q_1_ds" class="col-sm-2 control-label">Description</label>
+            <label for="authoring_tool_q_description" class="col-sm-2 control-label">Description</label>
             <div class="col-sm-9">
-              <input type="text" class="form-control" id="authoring_tool_q_1_ds" name="short_description">
+              <input type="text" class="form-control" id="authoring_tool_q_description" name="short_description">
               <span class="help-block small">Less than 100 characters</span>
             </div>
           </div>
@@ -391,6 +391,34 @@ label {
       <div class="modal-footer">
         <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
         <button type="button" class="btn btn-success" onclick="authoring_tool_create_q()">Create</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div id="import_appsource_authoring_tool" class="modal center fade" tabindex="-1" role="dialog" aria-labelledby="import_appsource_authoring_tool" aria-hidden="true" data-keyboard="false" data-backdrop="false">
+  <div class="modal-dialog modal-md">
+    <div class="modal-content modal-content-authoring">
+      <div class="modal-header modal-header-authoring">
+        <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+        <h4 class="modal-title" id="questionnaire_authoring_tool_title">
+          Import AppSource
+        </h4>
+      </div>
+      <div class="modal-body">
+        <form class="form-horizontal" onsubmit="return false;">
+          <div class="form-group">
+            <label for="authoring_tool_q_zipfile" class="col-sm-2 control-label">Zip file</label>
+            <div class="col-sm-9">
+              <input type="file" class="form-control" id="authoring_tool_q_zipfile" name="file" />
+              <span class="help-block small">Upload the zip file of an AppSource</span>
+            </div>
+          </div>
+        </form>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+        <button type="button" class="btn btn-success" onclick="authoring_tool_import_appsource()">Import</button>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Add button, form to add AppSource via upload of zip file

Add button, form to App Store to provide front-end UI for administrators to add an AppSource by uploading a zip file. 

This simplifies setting up an AppSource for first time users. Implementation only validates that uploaded directory is a zip file, does not check if uploaded zip file is valid AppSource directory structure. Implementation assumes apps are in the 'apps' directory.

Uploaded zip file must be a zip file created by downloading an AppSource repo as a zip file.

<img width="1951" alt="Screen Shot 2021-06-14 at 7 31 47 AM" src="https://user-images.githubusercontent.com/24979/121892657-a81bc700-cce2-11eb-9717-2737a0a2950e.png">
