### PR TITLE
Link to library version of component from a system's selected control component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ GovReady-Q Release Notes
 v999 (June XX, 2021)
 --------------------
 
+**UI changes**
+
+* Link to library version of component from a system's selected control component listing and selected components.
 
 v0.9.4 (June 13, 2021)
 ----------------------

--- a/templates/controls/editor.html
+++ b/templates/controls/editor.html
@@ -173,7 +173,7 @@
                                 <div class="panel-heading" role="tab" id="document-{{ forloop.counter }}-title">
                                     <div class="row statement-text">
                                       <div class="col-xs-3 col-sm-3 col-md-3 col-lg-3 col-xl-3">
-                                        <span id="producer_element-{{ forloop.counter }}-control" class="control-id-text">{{ smt.producer_element.name }}</span>
+                                        <span id="producer_element-{{ forloop.counter }}-control" class="control-id-text">{{ smt.producer_element.name }}&nbsp; &nbsp;<a href="{% url 'component_library_component' smt.producer_element.id %}" target="_blank"><span class="glyphicon glyphicon-new-window" style="color: #aaa;"></span></a></span>
                                         <div>
                                             <span class="component-type">{{ smt.producer_element.component_type }}</span>
                                             <span class="component-state">{{ smt.producer_element.component_state }}</span>

--- a/templates/systems/element_detail_tabs.html
+++ b/templates/systems/element_detail_tabs.html
@@ -83,7 +83,7 @@
       <div id="above-tab-content" class="row">
         <div class="col-sm-10 ">
             <h2 class="">
-                System Component: {{ element.name }}
+                System Component: {{ element.name }}&nbsp;&nbsp;<a href="{% url 'component_library_component' element.id %}" target="_blank"><span class="glyphicon glyphicon-new-window" style="color: #aaa;"></span></a>
             </h2>
             <h3 class="" style="">
                  {{ catalog.catalog_key_display }}


### PR DESCRIPTION
Make it easy to navigate from a component listed as part of a control to the component in the library.