### PR TITLE
Da/bug fix controls

### DIFF
--- a/controls/oscal.py
+++ b/controls/oscal.py
@@ -196,7 +196,7 @@ class Catalog(object):
         # For 800-53, 800-171, we can match by first few characters of control ID
         group_ids = self.get_group_ids()
         for group_id in group_ids:
-            if group_id.lower() in control_id.lower():
+            if group_id.lower() == control_id.lower():
                 return group_id
 
         # Group ID was not matched

--- a/controls/views.py
+++ b/controls/views.py
@@ -355,7 +355,7 @@ class SelectedComponentsList(ListView):
         Return the systems producer elements.
         """
         system = System.objects.get(id=self.kwargs['system_id'])
-        return system.producer_elements
+        return [element for element in system.producer_elements if element.element_type != "system"]
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)


### PR DESCRIPTION
1. Addressing github issue #[1630 ](https://github.com/GovReady/govready-q/issues/1630)in group id matching.
2.  fixed a bug where Elements of type system were shown in the selected components for a project.