### PR TITLE
try/except to still do the component search for non-Postgres users.

### DIFF
--- a/controls/views.py
+++ b/controls/views.py
@@ -381,9 +381,13 @@ def component_library(request):
 
     query = request.GET.get('search')
     if query:
-        element_list = Element.objects.filter(Q(name__icontains=query) | Q(tags__label__icontains=query)
-                                              | Q(pk__in=set(Statement.objects.filter(body__search=query).values_list('producer_element', flat=True)))
-                                             ).exclude(element_type='system').distinct()
+        try:
+            element_list = Element.objects.filter(Q(name__icontains=query) | Q(tags__label__icontains=query)
+                                                  | Q(pk__in=set(Statement.objects.filter(body__search=query).values_list('producer_element', flat=True)))
+                                                 ).exclude(element_type='system').distinct()
+        except:
+            logger.info(f"Ah, you are not using Postgres for your Database!")
+            element_list = Element.objects.filter(Q(name__icontains=query) | Q(tags__label__icontains=query)).exclude(element_type='system').distinct()
     else:
         element_list = Element.objects.all().exclude(element_type='system').distinct()
 


### PR DESCRIPTION
If you try to search for a component without using a Postgres server an error occurs.