### PR TITLE
Avoid errors when project has no root_task set

### DIFF
--- a/siteapp/models.py
+++ b/siteapp/models.py
@@ -649,8 +649,7 @@ class Project(TagModelMixin):
 
     @property
     def title(self):
-        if not self.root_task: return "???"
-        return self.root_task.title
+        return self.root_task.title if self.root_task else f"Project {self.id}"
 
     def organization_and_title(self):
         parts = [str(self.organization)]

--- a/siteapp/models.py
+++ b/siteapp/models.py
@@ -869,7 +869,7 @@ class Project(TagModelMixin):
     def get_parent_projects(self):
         parents = []
         project = self
-        while project.root_task.is_answer_to.count():
+        while project.root_task is not None and project.root_task.is_answer_to.count():
             ans = project.root_task.is_answer_to.select_related("taskanswer__task__project__root_task__module").first()
             project = ans.taskanswer.task.project
             parents.append(project)

--- a/siteapp/urls.py
+++ b/siteapp/urls.py
@@ -75,6 +75,7 @@ urlpatterns = [
     *build_tag_urls(r"^projects/(\d+)/", model=Project), # Tag Urls
     url(r'^projects/(\d+)/assets/(\d+)/__update$', views.update_project_asset,
         name="update_project_assets"),
+    url(r'^projects/(\d+)/$', views.project, name="view_project_id"),
     url(r'^projects/(\d+)/(?:[\w\-]+)()$', views.project, name="view_project"), # must be last because regex matches some previous URLs
     url(r'^projects/(\d+)/(?:[\w\-]+)(/settings)$', views.project_settings, name="project_settings"),
     url(r'^projects/(\d+)/(?:[\w\-]+)(/startapps)$', views.project_start_apps), # must be last because regex matches some previous URLs

--- a/siteapp/views.py
+++ b/siteapp/views.py
@@ -779,7 +779,7 @@ def start_app(appver, organization, user, folder, task, q, portfolio):
 
 def project_read_required(f):
     @login_required
-    def g(request, project_id, project_url_suffix):
+    def g(request, project_id, project_url_suffix=None):
         project = get_object_or_404(Project.objects.
                                     prefetch_related('root_task__module__questions',
                                                      'root_task__module__questions__answer_type_module'), id=project_id)
@@ -790,7 +790,7 @@ def project_read_required(f):
 
         # Redirect if slug is not canonical. We do this after checking for
         # read privs so that we don't reveal the task's slug to unpriv'd users.
-        if request.path != project.get_absolute_url() + project_url_suffix:
+        if request.path != project.get_absolute_url() + (project_url_suffix if project_url_suffix else ""):
             return HttpResponseRedirect(project.get_absolute_url())
 
         return f(request, project)
@@ -815,7 +815,10 @@ def project(request, project):
 
     # Pre-load the answers to project root task questions and impute answers so
     # that we know which questions are suppressed by imputed values.
-    root_task_answers = project.root_task.get_answers().with_extended_info()
+    if project.root_task is None:
+        root_task_answers = None
+    else:
+        root_task_answers = project.root_task.get_answers().with_extended_info()
 
     # Check if this user has authorization to start tasks in this Project.
     can_start_task = project.can_start_task(request.user)
@@ -827,7 +830,7 @@ def project(request, project):
     from collections import OrderedDict
     questions = OrderedDict()
     can_start_any_apps = False
-    for (mq, is_answered, answer_obj, answer_value) in root_task_answers.answertuples.values():
+    for (mq, is_answered, answer_obj, answer_value) in (root_task_answers.answertuples.values() if root_task_answers else []):
         # Display module/module-set questions only. Other question types in a project
         # module are not valid.
         if mq.spec.get("type") not in ("module", "module-set"):
@@ -952,9 +955,13 @@ def project(request, project):
 
     # Are there any output documents that we can render?
     has_outputs = False
-    for doc in project.root_task.module.spec.get("output", []):
-        if "id" in doc:
-            has_outputs = True
+    if project.root_task:
+        for doc in project.root_task.module.spec.get("output", []):
+            if "id" in doc:
+                has_outputs = True
+
+    can_upgrade_app = project.root_task.module.app.has_upgrade_priv(request.user) if project.root_task else True
+    authoring_tool_enabled = project.root_task.module.is_authoring_tool_enabled(request.user) if project.root_task else True
 
     # Calculate approximate compliance as degrees to display
     percent_compliant = 0
@@ -999,7 +1006,7 @@ def project(request, project):
         "approx_compliance_degrees": approx_compliance_degrees,
 
         "is_admin": request.user in project.get_admins(),
-        "can_upgrade_app": project.root_task.module.app.has_upgrade_priv(request.user),
+        "can_upgrade_app": can_upgrade_app,
         "can_start_task": can_start_task,
         "can_start_any_apps": can_start_any_apps,
 
@@ -1020,7 +1027,7 @@ def project(request, project):
 
         "class_status": Classification.objects.last(),
 
-        "authoring_tool_enabled": project.root_task.module.is_authoring_tool_enabled(request.user),
+        "authoring_tool_enabled": authoring_tool_enabled,
         "import_project_form": ImportProjectForm()
     })
 

--- a/templates/projects.html
+++ b/templates/projects.html
@@ -128,14 +128,12 @@ Your Compliance Projects
 {% for project in projects %}
 <div class="row projects-row">
   <div class="col-xs-10 col-md-5">
-    {% if project.root_task.get_app_icon_url %}
-      <span class="project-image">
+    <span class="project-image">
+      {% if project.root_task.get_app_icon_url %}
         <img src="{{project.root_task.get_app_icon_url}}" class="img-responsive" alt="App Icon">
-      </span>
-      &nbsp;&nbsp;&nbsp;
-    {% else %}
-    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-    {% endif %}
+      {% endif %}
+    </span>
+    &nbsp;&nbsp;&nbsp;
     <a href="{{project.get_absolute_url}}" class="projects-link">{{project.title}}</a>
   </div>
 


### PR DESCRIPTION
We want to avoid errors and crashes when a project has no root task. Basic support for a project without a root task will allow us to occasionally create and manage empty projects.

<img width="1648" alt="Screen Shot 2021-06-20 at 7 10 26 AM" src="https://user-images.githubusercontent.com/24979/122673586-acd6f400-d196-11eb-8b98-195647598421.png">
