### PR TITLE
Import and display component, smts even if catalog missing

### DIFF
--- a/controls/tests.py
+++ b/controls/tests.py
@@ -355,15 +355,17 @@ class ComponentUITests(OrganizationSiteFunctionalTests):
         wait_for_sleep_after(lambda: self.assertEqual(element_count_before_import + 2, element_count_after_import))
 
         statement_count_after_import = Statement.objects.filter(statement_type=StatementTypeEnum.CONTROL_IMPLEMENTATION_PROTOTYPE.name).count()
-        self.assertEqual(statement_count_before_import + 4, statement_count_after_import)
-        # Test file contains 6 Statements, but only 4 get imported
-        # because one has an improper Catalog
-        # and another has an improper Control
-        # but we can't test individual statements because the UUIDs are randomly generated and not consistent
+        # Test OSCAL file contains 6 Statements, and all 6 get imported even though two Statements have "bad" data.
+        # One Statement has an improper Catalog.
+        # Another Statement has an improper Control.
+        # But we can't test individual statements because the UUIDs are randomly generated and not consistent
         # with the OSCAL JSON file. So we simply do a count.
+        # We allow bad Statements with non-existent catalogs and bad control ids to be imported
+        # because we do not want to create friction of having to have a catalog or having
+        # perfect data prior to importing a component.
+        self.assertEqual(statement_count_before_import + 6, statement_count_after_import)
 
         # Test that duplicate Components are re-imported with a different name and that Statements get reimported
-
         wait_for_sleep_after(lambda: self.click_element('a#component-import-oscal'))
 
         file_input = self.find_selected_option('input#json_content')
@@ -384,7 +386,7 @@ class ComponentUITests(OrganizationSiteFunctionalTests):
 
         statement_count_after_duplicate_import = Statement.objects.filter(
             statement_type=StatementTypeEnum.CONTROL_IMPLEMENTATION_PROTOTYPE.name).count()
-        self.assertEqual(statement_count_after_import + 4, statement_count_after_duplicate_import)
+        self.assertEqual(statement_count_after_import + 6, statement_count_after_duplicate_import)
 
     def test_import_tracker(self):
         """Tests that imports are tracked correctly."""

--- a/controls/views.py
+++ b/controls/views.py
@@ -845,37 +845,33 @@ class ComponentImporter(object):
             for stmnt_id in statements:
                 statement = statements[stmnt_id]
 
-                if self.control_exists_in_catalog(catalog_key, control_id):
-                    if 'description' in statement:
-                        description = statement['description']
-                    elif 'description' in implemented_control:
-                        description = implemented_control['description']
-                    else:
-                        description = ''
-
-                    if 'remarks' in statement:
-                        remarks = statement['remarks']
-                    elif 'remarks' in implemented_control:
-                        remarks = implemented_control['remarks']
-                    else:
-                        remarks = ''
-
-                    new_statement = Statement.objects.create(
-                        sid=control_id,
-                        sid_class=catalog_key,
-                        pid=get_control_statement_part(stmnt_id),
-                        body=description,
-                        statement_type=StatementTypeEnum.CONTROL_IMPLEMENTATION_PROTOTYPE.name,
-                        remarks=remarks,
-                        status=implemented_control['status'] if 'status' in implemented_control else None,
-                        producer_element=parent_component,
-                    )
-
-                    logger.info(f"New statement with UUID {new_statement.uuid} created.")
-                    statements_created.append(new_statement)
-
+                if 'description' in statement:
+                    description = statement['description']
+                elif 'description' in implemented_control:
+                    description = implemented_control['description']
                 else:
-                    logger.info(f"Control {control_id} doesn't exist in catalog {catalog_key}. Skipping Statement...")
+                    description = ''
+
+                if 'remarks' in statement:
+                    remarks = statement['remarks']
+                elif 'remarks' in implemented_control:
+                    remarks = implemented_control['remarks']
+                else:
+                    remarks = ''
+
+                new_statement = Statement.objects.create(
+                    sid=control_id,
+                    sid_class=catalog_key,
+                    pid=get_control_statement_part(stmnt_id),
+                    body=description,
+                    statement_type=StatementTypeEnum.CONTROL_IMPLEMENTATION_PROTOTYPE.name,
+                    remarks=remarks,
+                    status=implemented_control['status'] if 'status' in implemented_control else None,
+                    producer_element=parent_component,
+                )
+
+                logger.info(f"New statement with UUID {new_statement.uuid} created.")
+                statements_created.append(new_statement)
 
         return statements_created
 


### PR DESCRIPTION
Import component control statement even if catalog not found
    
Remove test to see of control exists in control catalog when importing a component because we may import a component that has controls from a catalog that is not yet in GovReady.
    
The test on the control id being in the catalog was originally done to avoid importing a bad control (or bad control id). But it is worse to not be able to import the component because we don't yet have the a control catalog mentioned by the component.

Do not crash on displaying a component and component control implementation statement when a catalog associated with statements is missing from GovReady-Q install.