### PR TITLE
Da/discussion updates

### DIFF
--- a/discussion/models.py
+++ b/discussion/models.py
@@ -176,6 +176,11 @@ class Discussion(models.Model):
     def is_public(self):
         return getattr(self.attached_to_obj, 'is_discussion_public', lambda : False)
 
+    def is_discussion_inactive(self):
+
+        if self.attached_to_obj is not None:
+            return True if self.attached_to_obj.title == "<Deleted Discussion>" else False
+
     def can_comment(self, user):
         return user is not None and self.is_participant(user)
 
@@ -247,14 +252,14 @@ class Discussion(models.Model):
         return self._get_autocompletes
 
     @property
-    def get_task(self, discussion):
+    def get_task(self):
         """
         Retrieves the task for the given discussion's attached object. For example Projects have root_task while TaskAnswer discussion would have a task.
         """
-        if hasattr(self.discussion.attached_to_obj, 'root_task'):
-            return discussion.attached_to_obj.root_task
-        elif hasattr(self.discussion.attached_to_obj, 'task'):
-            return discussion.attached_to_obj.task
+        if hasattr(self.attached_to_obj, 'root_task'):
+            return self.attached_to_obj.root_task
+        elif hasattr(self.attached_to_obj, 'task'):
+            return self.attached_to_obj.task
         else:
             return False
 

--- a/discussion/models.py
+++ b/discussion/models.py
@@ -261,7 +261,7 @@ class Discussion(models.Model):
         elif hasattr(self.attached_to_obj, 'task'):
             return self.attached_to_obj.task
         else:
-            return False
+            return False#TODO: not sure what to do if the model isn't related to a Task
 
 class Comment(models.Model):
     discussion = models.ForeignKey(Discussion, related_name="comments", on_delete=models.CASCADE, help_text="The Discussion that this comment is attached to.")

--- a/discussion/models.py
+++ b/discussion/models.py
@@ -246,6 +246,18 @@ class Discussion(models.Model):
             self._get_autocompletes = self.attached_to_obj.get_discussion_autocompletes(self)
         return self._get_autocompletes
 
+    @property
+    def get_task(self, discussion):
+        """
+        Retrieves the task for the given discussion's attached object. For example Projects have root_task while TaskAnswer discussion would have a task.
+        """
+        if hasattr(self.discussion.attached_to_obj, 'root_task'):
+            return discussion.attached_to_obj.root_task
+        elif hasattr(self.discussion.attached_to_obj, 'task'):
+            return discussion.attached_to_obj.task
+        else:
+            return False
+
 class Comment(models.Model):
     discussion = models.ForeignKey(Discussion, related_name="comments", on_delete=models.CASCADE, help_text="The Discussion that this comment is attached to.")
     replies_to = models.ForeignKey('self', blank=True, null=True, related_name="replies", on_delete=models.CASCADE, help_text="If this is a reply to a Comment, the Comment that this is in reply to.")

--- a/discussion/views.py
+++ b/discussion/views.py
@@ -92,7 +92,8 @@ def edit_discussion_comment(request):
 
     # save
     comment.save()
-
+    # TODO: fully implement this add it as an attribute to Discussion model perhaps? Otherwise to find out if the text of the
+    # Current comment is the same as the previous text you would do something like: comment.extra['history'][-1]['previous-text'] != comment.text
     # Kick the attached object.
     if hasattr(comment.discussion.attached_to, 'on_discussion_comment_edited'):
         comment.discussion.attached_to.on_discussion_comment_edited(comment)

--- a/guidedmodules/models.py
+++ b/guidedmodules/models.py
@@ -2008,12 +2008,12 @@ class TaskAnswer(models.Model):
     # required to attach a Discussion to it
     def get_discussion_autocompletes(self, discussion):
         # Get a list of all users who can be @-mentioned. It includes the discussion
-        # participants (i.e. people working on the same project and disussion guests)
+        # participants (i.e. people working on the same project and discussion guests)
         # plus anyone in the same organization.
-        organization = self.task.project.organization
+        organization = discussion.organization
         mentionable_users = set(discussion.get_all_participants()) \
                             | set(
-            User.objects.filter(projectmembership__project__organization=self.task.project.organization).distinct())
+            User.objects.filter(projectmembership__project__organization=organization).distinct())
         User.preload_profiles(mentionable_users)
         return {
             # @-mention participants in the discussion and other

--- a/guidedmodules/views.py
+++ b/guidedmodules/views.py
@@ -2021,14 +2021,14 @@ def start_a_discussion(request):
 
         # Get the TaskAnswer for this task. It may not exist yet.
         tq, isnew = TaskAnswer.objects.get_or_create(**tq_filter)
-
+    # Filter for discussion and return the first entry (if it doesn't exist it returns None)
     discussion = Discussion.get_for(task.project.organization, tq)
     if not discussion:
         # Validate user can create discussion.
         if not task.has_read_priv(request.user):
             return JsonResponse({ "status": "error", "message": "You do not have permission!" })
 
-        # Get the Discussion.
+        # Create a Discussion.
         discussion = Discussion.get_for(task.project.organization, tq, create=True)
 
     return JsonResponse(discussion.render_context_dict(request.user))


### PR DESCRIPTION
### Unless otherwise discussed below the methods are already ready to be added given the Generic Relationship Discussion can have with any other model (given its GenericForeignKey)
- is_discussion_deleted() is now .is_discussion_inactive() (note there is no deleting of a discussion yet implemented.)
- get_project_context_dict doesn't seem relevant for any other model besides task.
- is_public() doesn't seems to do anything as assigning the attribute is_discussion_public to a model doesn't happen anywhere so it always returns the default which is False.
- Added get_discussion_autocompletes changes to get the organization from the discussion(should be 1 to 1). If another models wants to implement it they can look at the get_discussion_autocompletes in TaskAnswer
- on_discussion_comment assumes a task to get the org which is easy enough to replace (comment.discussion.organization) however it also needs a project for the task which you cannot get from the comment.
- on_discussion_comment_edited is not implemented see TODO line 95 in discussion/views.py
- get_user_role is implemented solely assuming a task in `TaskAnswer`
