### PR TITLE
Include 'Add component statement' btn when component has no smts

### DIFF
--- a/templates/components/element_detail_tabs.html
+++ b/templates/components/element_detail_tabs.html
@@ -269,6 +269,18 @@
               </div>
             </div>
             {% endif %}
+            {% empty %}
+            <div id="panel-{{ forloop.counter }}" class="">
+              <div class="panel-heading" role="tab" id="document-{{ forloop.counter }}-title">
+                <div class="row statement-text">
+                  <div class="col-xs-3 col-sm-3 col-md-3 col-lg-3 col-xl-3">&nbsp;</div>
+                  <div class="col-xs-6 col-sm-6 col-md-6 col-lg-6 col-xl-6">
+                    <button type="submit" id="new_component_statement" class="btn btn-xs btn-success" onclick="add_smt({{ impl_smts|length }})">Add component statement</button>
+                  </div>
+                  <div class="col-xs-3 col-sm-3 col-md-3 col-lg-3 col-xl-3 remark-text-block">&nbsp;</div>
+                </div>
+              </div>
+            </div>
             {% endfor %}
           </div><!--/smt-list-->
       </div>


### PR DESCRIPTION
Previous PR #1681 moved the include template partial for adding a component statement to the `forloop.last` and did not handle case of a component with no controls yet. Simple fix was including the template partial in the `{% empty %}` section of the forloop.