### PR TITLE
Quick export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ GovReady-Q Release Notes
 v0.9.11-dev (August xx, 2021)
 -----------------------------
 
+**Developer changes**
+
+* Add a set of default headers (through hidden inputs and a html form) for the SSP CSV export, dubbed Quick CSV. 
+
+**UI changes**
+
+* A Quick CSV button on the system security plan page.
+
 **Bug fix**
 
 * Correctly handle exporting library components when component has zero statements to avoid crashing exportcomponentlibrary command.

--- a/guidedmodules/tests.py
+++ b/guidedmodules/tests.py
@@ -2,11 +2,17 @@ from django.contrib.auth.models import Permission
 from django.core.files import File
 from django.db.models import Q
 from django.test import TestCase
+
+from controls.models import Element, System
 from siteapp.enums.assets import AssetTypeEnum
 from siteapp.models import Organization, Project, User, ProjectAsset
 from .app_loading import load_app_into_database
+from .forms import ExportCSVTemplateSSPForm
+from unittest.mock import patch, Mock
+import requests
 from .models import Module, Task, AppVersion
 from .module_logic import *
+from .views import export_ssp_csv
 
 
 class TestCaseWithFixtureData(TestCase):
@@ -799,6 +805,33 @@ class ImportExportTests(TestCaseWithFixtureData):
         # Assert that the model changed on the backend based on the id of the radio button clicked
         # Download the file @ f"/tasks/{task.id}/system-security-plan/download/document/ssp_v1/docx"
         # Assert no errors.  Not sure how to verify the template changes in the docx
+
+    @patch.object(requests, 'post')
+    def test_export_csv(self, mockcsvexport):
+        """
+        Mock post request of SSP CSV export
+        Check if the mock can create valid ExportCSVTemplateSSPForm data.
+        export_ssp_csv
+        """
+
+        mockresponse = Mock()
+        mockcsvexport.return_value = mockresponse
+        mockresponse.POST = dict(info_system="Information System", control_id="Control ID",
+                                              catalog="Control Set Version Number",
+                                              shared_imps="Shared Implementation Details",
+                                              private_imps="Private Implementation Details")
+
+        export_csv_form = ExportCSVTemplateSSPForm(mockresponse.POST)
+        # we need a system and a component
+        root_element = Element(name="My Root Element",
+                               description="Description of my root element")
+        root_element.save()
+        self.system = System()
+        self.system.root_element = root_element
+        if export_csv_form.is_valid():
+            response = export_ssp_csv(export_csv_form.data, self.system)
+            assert response.status_code == 200
+
 
 class ComplianceAppTests(TestCaseWithFixtureData):
     ## COMPLIANCE APP VISIBILITY DATA TESTS ##

--- a/templates/task-finished.html
+++ b/templates/task-finished.html
@@ -168,6 +168,15 @@
                             <!-- <a href="{{task.get_absolute_url}}/download/document/{{document.id | urlencode }}/odt">Open Office (odt)</a>&nbsp;&nbsp; -->
                             <a href="{{task.get_absolute_url}}/download/document/{{document.id | urlencode }}/html">HTML</a>&nbsp;&nbsp;
                             <button id="exportCSVTemplateSSPButton" type="button" class="btn-xs btn-primary glyphicon glyphicon-copy" data-toggle="modal" data-target="#exportCSVTemplateSSP" aria-label="CSV" tooltip="exportCSVTemplateSSP" style="text-align: center; margin-right:10px; margin-left:5px;">CSV</button>&nbsp;&nbsp;
+                              <form role="form" class="pull-left" method="POST">
+                                  {% csrf_token %}
+                              <button class="btn-xs btn-primary glyphicon glyphicon-copy" aria-label="quickCSV" style="text-align: center; margin-right:10px; margin-left:5px;" type="submit">&nbsp;Quick CSV</button>&nbsp;&nbsp;
+                                  <input type="hidden" name="info_system" value="Information System"/>
+                                  <input type="hidden" name="control_id" value="Control ID"/>
+                                  <input type="hidden" name="catalog" value="Control Set Version Number"/>
+                                  <input type="hidden" name="shared_imps" value="Shared Implementation Details"/>
+                                  <input type="hidden" name="private_imps" value="Private Implementation Details"/>
+                              </form>
                             <!-- <a href="{{task.get_absolute_url}}/download/document/{{document.id | urlencode }}/markdown">Markdown</a>&nbsp;&nbsp; -->
                             <!--<a href="{{task.get_absolute_url}}/download/document/{{document.id | urlencode }}/plain">Plain Text</a>&nbsp;&nbsp;-->
                           {% endif %}


### PR DESCRIPTION
**Developer changes**

* Add a set of default headers (through hidden inputs and a html form) for the SSP CSV export, dubbed Quick CSV. 

**UI changes**

* A Quick CSV button on the system security plan page.