### PR TITLE
Adding middleware for health check.

### DIFF
--- a/dev_env/README.md
+++ b/dev_env/README.md
@@ -8,6 +8,9 @@ You need to install the following do deploy a development stack:
     
 This also assumes you can run as root/administrator.  This is due to ports being opened & docker access.
 
+Allocate to Docker as much Memory, Swap, and CPUS as you can. For example, GovReady-Q performs much better on a 2015 Quad-Core MacBook Pro with CPUs: 3, Memory: 9GB, SWAP: 4GB, and Disk image size: 50+GB.
+
+
 ## How To
 1. Configure
 

--- a/siteapp/middleware.py
+++ b/siteapp/middleware.py
@@ -102,3 +102,12 @@ class ProxyHeaderUserAuthenticationBackend(django.contrib.auth.backends.RemoteUs
 
         # Return.
         return user
+
+class HealthCheckMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        if request.path == '/healthcheck':
+            return HttpResponse('ok')
+        return self.get_response(request)

--- a/siteapp/settings.py
+++ b/siteapp/settings.py
@@ -142,6 +142,7 @@ MIDDLEWARE = [
 	'django.middleware.security.SecurityMiddleware',
 	'whitenoise.middleware.WhiteNoiseMiddleware',
 	'django.contrib.sessions.middleware.SessionMiddleware',
+    'siteapp.middleware.HealthCheckMiddleware',
 	'django.middleware.common.CommonMiddleware',
 	'django.middleware.csrf.CsrfViewMiddleware',
 	'django.contrib.auth.middleware.AuthenticationMiddleware',


### PR DESCRIPTION
Adding a middleware health check that will return 200 without checking ALLOWED_HOST for automated deployments.