### PR TITLE
Catching errors when flattening controls.

### DIFF
--- a/controls/views.py
+++ b/controls/views.py
@@ -160,7 +160,10 @@ def controls_selected(request, system_id):
 
         # sort controls
         controls = list(controls)
-        controls.sort(key=lambda control: control.get_flattened_oscal_control_as_dict()['sort_id'])
+        try:
+            controls.sort(key=lambda control: control.get_flattened_oscal_control_as_dict()['sort_id'])
+        except Exception as e:
+            logger.error(f"Error flattening controls: {e}")
 
         # Determine if a legacy statement exists for the control
         impl_smts_legacy = Statement.objects.filter(consumer_element=system.root_element, statement_type=StatementTypeEnum.CONTROL_IMPLEMENTATION_LEGACY.name)


### PR DESCRIPTION
When going to a Controls page, for example /systems/38/controls/selected, using the ARS Catalog, I get the following error:

```bash
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/dist-packages/django/core/handlers/exception.py", line 47, in inner
    response = get_response(request)
  File "/usr/local/lib/python3.8/dist-packages/django/core/handlers/base.py", line 181, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/usr/lib/python3.8/contextlib.py", line 75, in inner
    return func(*args, **kwds)
  File "/usr/src/app/controls/views.py", line 163, in controls_selected
    controls.sort(key=lambda control: control.get_flattened_oscal_control_as_dict()['sort_id'])

Exception Type: TypeError at /systems/38/controls/selected
Exception Value: '<' not supported between instances of 'NoneType' and 'str' 
```

This doesn't fix the issue, but allows the page to load as expected.