### PR TITLE
Fix for Dockerfile smell DL3009

### DIFF
--- a/dev_env/docker/images/backend/Dockerfile
+++ b/dev_env/docker/images/backend/Dockerfile
@@ -46,7 +46,9 @@ ENV DISPLAY=:99
 # Put the Python source code here.
 WORKDIR /usr/src/app
 
-RUN apt-get update && apt-get install -y wkhtmltopdf;
+RUN apt-get update && apt-get install -y wkhtmltopdf \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 # Upgrade pip to version 20.1+ - IMPORTANT
 RUN python3 -m pip install --upgrade pip


### PR DESCRIPTION
Hi!
The Dockerfile placed at "dev_env/docker/images/backend/Dockerfile" contains the best practice violation [DL3009](https://github.com/hadolint/hadolint/wiki/DL3009) detected by the [hadolint](https://github.com/hadolint/hadolint) tool.

The smell DL3009 occurs when the apt tool is used to install packages without wiping the cache and source lists.
This pull request proposes a fix for that smell generated by my fixing tool. The generated patch has been manually verified before opening the pull request.
To fix this smell, specifically, the instructions to clean up the apt cache and remove the /var/lib/apt/lists have been added. This helps keep the image size down.

This change is only aimed at fixing that specific smell. If the fix is not valid or useful, please briefly indicate the reason and suggestions for possible improvements.

Thanks in advance